### PR TITLE
Skip CI when only Markdown files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: [ main, master ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [ main, master ]
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   test:


### PR DESCRIPTION
Add paths-ignore for **/*.md to both push and pull_request triggers to avoid running lint, build, and test jobs for documentation-only changes.