### PR TITLE
fix: handle empty subjects in SLSA provenance workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,12 +112,12 @@ jobs:
           all_subjects=""
 
           if [ -n "$ARTIFACT_SUBJECTS" ]; then
-            artifact_subjects=$(echo "$ARTIFACT_SUBJECTS" | base64 -d | sed '/^$/d')
+            artifact_subjects=$(echo "$ARTIFACT_SUBJECTS" | base64 -d || true | sed '/^$/d')
             all_subjects="$artifact_subjects"
           fi
 
           if [ -n "$PACKAGE_SUBJECTS" ]; then
-            package_subjects=$(echo "$PACKAGE_SUBJECTS" | base64 -d | sed '/^$/d')
+            package_subjects=$(echo "$PACKAGE_SUBJECTS" | base64 -d || true | sed '/^$/d')
             if [ -n "$all_subjects" ]; then
               all_subjects=$(printf '%s\n%s' "$all_subjects" "$package_subjects")
             else


### PR DESCRIPTION
The combine-subjects job was failing when artifact-subjects or package-subjects were empty. Added proper checks to handle empty inputs and provide a clear error message when no subjects are found.