### PR TITLE
BREAKING CHANGE: rename -ignore flag to -ignore-modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ tf-version-bump -pattern <glob-pattern> -module <module-source> -to <version>
 - `-to`: Desired version number
 - `-from`: (Optional) Version to update from (can be specified multiple times, e.g., `-from 3.0.0 -from '~> 3.0'`)
 - `-ignore-version`: (Optional) Version(s) to skip (can be specified multiple times, e.g., `-ignore-version 3.0.0 -ignore-version '~> 3.0'`)
-- `-ignore`: (Optional) Comma-separated list of module names or patterns to ignore (e.g., `vpc,legacy-*,*-test`)
+- `-ignore-modules`: (Optional) Comma-separated list of module names or patterns to ignore (e.g., `vpc,legacy-*,*-test`)
 - `-force-add`: (Optional) Add version attribute to modules that don't have one (default: false, skip with warning)
 - `-dry-run`: (Optional) Show what changes would be made without actually modifying files
 - `-verbose`: (Optional) Show verbose output including skipped modules
@@ -177,7 +177,7 @@ This will update all S3 bucket modules to version `4.0.0` EXCEPT those currently
 Update all VPC modules except specific ones using ignore patterns:
 
 ```bash
-tf-version-bump -pattern "*.tf" -module "terraform-aws-modules/vpc/aws" -to "5.0.0" -ignore "legacy-vpc,test-*"
+tf-version-bump -pattern "*.tf" -module "terraform-aws-modules/vpc/aws" -to "5.0.0" -ignore-modules "legacy-vpc,test-*"
 ```
 
 This will update all VPC modules to version 5.0.0 except:
@@ -246,7 +246,7 @@ modules:
     ignore_versions:     # Optional: versions to skip
       - "3.0.0"
       - "~> 3.0"
-    ignore:              # Optional: module names or patterns to ignore
+    ignore_modules:      # Optional: module names or patterns to ignore
       - "legacy-vpc"
       - "test-*"
   - source: "terraform-aws-modules/s3-bucket/aws"
@@ -259,7 +259,7 @@ modules:
   - source: "terraform-aws-modules/security-group/aws"
     version: "5.1.0"
     from: "4.0.0"        # Optional: only update from version 4.0.0
-    ignore:
+    ignore_modules:
       - "*-deprecated"
 ```
 
@@ -275,7 +275,7 @@ Each module entry supports the following fields:
   - Can be a list of versions: `ignore_versions: ["3.0.0", "~> 3.0"]`
   - Modules will be skipped if their current version matches any version in the list
   - Takes precedence over `from` filter (if a version matches both, it will be skipped)
-- `ignore` (optional): List of module names or wildcard patterns to skip
+- `ignore_modules` (optional): List of module names or wildcard patterns to skip
   - Supports exact matches: `"vpc"` matches only a module named "vpc"
   - Supports wildcards with `*`:
     - Prefix: `"legacy-*"` matches `legacy-vpc`, `legacy-network`, etc.
@@ -447,7 +447,7 @@ See the `examples/` directory for sample configuration files:
 - `config-basic.yml` - Simple configuration with a few modules
 - `config-advanced.yml` - Advanced configuration showing various module types (subpaths, Git sources)
 - `config-production.yml` - Production-ready configuration with common AWS modules
-- `config-with-ignore.yml` - Examples of using the ignore feature with various patterns
+- `config-with-ignore.yml` - Examples of using the ignore_modules feature with various patterns
 
 ## How it Works
 
@@ -583,7 +583,7 @@ For verification instructions and detailed release information, see [docs/RELEAS
 The tool fully supports Unicode characters in:
 - Module names (e.g., `module "vpc-主要"`)
 - Module sources (e.g., `source = "registry.example.com/組織/module"`)
-- Ignore patterns (e.g., `ignore: ["vpc-主要", "test-🚀-*"]`)
+- Ignore patterns (e.g., `ignore_modules: ["vpc-主要", "test-🚀-*"]`)
 
 ### Permissions
 

--- a/chaos_advanced_test.go
+++ b/chaos_advanced_test.go
@@ -421,7 +421,7 @@ func TestConfigWithDuplicateSources(t *testing.T) {
 	// This is the expected contract: not finding a module is not considered an error, just a no-op.
 	var successCount, failCount, notFoundCount int
 	for _, update := range updates {
-		updated, err := updateModuleVersion(testFile, update.Source, update.Version, update.From, update.IgnoreVersions, update.Ignore, false, false, false, "text")
+		updated, err := updateModuleVersion(testFile, update.Source, update.Version, update.From, update.IgnoreVersions, update.IgnoreModules, false, false, false, "text")
 		if err != nil {
 			t.Logf("Update for %s to %s failed: %v", update.Source, update.Version, err)
 			failCount++
@@ -563,7 +563,7 @@ func TestIgnorePatternWhitespaceTrimming(t *testing.T) {
 	content := `modules:
   - source: "terraform-aws-modules/vpc/aws"
     version: "5.0.0"
-    ignore:
+    ignore_modules:
       - "  vpc-prod  "
       - "  staging-*  "
       - "	dev-*	"`
@@ -578,18 +578,18 @@ func TestIgnorePatternWhitespaceTrimming(t *testing.T) {
 		t.Fatalf("Failed to load config: %v", err)
 	}
 
-	// Ignore patterns should have whitespace trimmed
-	if len(updates[0].Ignore) != 3 {
-		t.Errorf("Expected 3 ignore patterns, got %d", len(updates[0].Ignore))
+	// IgnoreModules patterns should have whitespace trimmed
+	if len(updates[0].IgnoreModules) != 3 {
+		t.Errorf("Expected 3 ignore patterns, got %d", len(updates[0].IgnoreModules))
 	}
-	if updates[0].Ignore[0] != "vpc-prod" {
-		t.Errorf("First ignore pattern whitespace not trimmed: %q", updates[0].Ignore[0])
+	if updates[0].IgnoreModules[0] != "vpc-prod" {
+		t.Errorf("First ignore pattern whitespace not trimmed: %q", updates[0].IgnoreModules[0])
 	}
-	if updates[0].Ignore[1] != "staging-*" {
-		t.Errorf("Second ignore pattern whitespace not trimmed: %q", updates[0].Ignore[1])
+	if updates[0].IgnoreModules[1] != "staging-*" {
+		t.Errorf("Second ignore pattern whitespace not trimmed: %q", updates[0].IgnoreModules[1])
 	}
-	if updates[0].Ignore[2] != "dev-*" {
-		t.Errorf("Third ignore pattern (with tabs) whitespace not trimmed: %q", updates[0].Ignore[2])
+	if updates[0].IgnoreModules[2] != "dev-*" {
+		t.Errorf("Third ignore pattern (with tabs) whitespace not trimmed: %q", updates[0].IgnoreModules[2])
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -54,7 +54,7 @@ type ModuleUpdate struct {
 	Version        string       `yaml:"version"`         // Target version (e.g., "5.0.0")
 	From           FromVersions `yaml:"from"`            // Optional: only update if current version matches any in this list (e.g., ["4.0.0", "~> 3.0"])
 	IgnoreVersions FromVersions `yaml:"ignore_versions"` // Optional: skip update if current version matches any in this list (e.g., ["4.0.0", "~> 3.0"])
-	Ignore         []string     `yaml:"ignore"`          // Optional: list of module names or patterns to ignore (e.g., ["vpc", "legacy-*"])
+	IgnoreModules  []string     `yaml:"ignore_modules"`  // Optional: list of module names or patterns to ignore (e.g., ["vpc", "legacy-*"])
 }
 
 // Config represents the structure of a YAML configuration file for batch updates.
@@ -69,7 +69,7 @@ type ModuleUpdate struct {
 //	    ignore_versions:       # Optional: versions to skip
 //	      - "3.0.0"
 //	      - "~> 3.0"
-//	    ignore:                # Optional: module names or patterns to ignore
+//	    ignore_modules:        # Optional: module names or patterns to ignore
 //	      - "legacy-vpc"
 //	      - "test-*"
 //	  - source: "terraform-aws-modules/s3-bucket/aws"
@@ -123,13 +123,13 @@ func loadConfig(filename string) ([]ModuleUpdate, error) {
 		config.Modules[i].IgnoreVersions = filteredIgnoreVersions
 
 		// Trim whitespace from ignore patterns and filter out empty ones
-		filteredIgnore := make([]string, 0, len(module.Ignore))
-		for _, pattern := range module.Ignore {
+		filteredIgnore := make([]string, 0, len(module.IgnoreModules))
+		for _, pattern := range module.IgnoreModules {
 			if trimmed := strings.TrimSpace(pattern); trimmed != "" {
 				filteredIgnore = append(filteredIgnore, trimmed)
 			}
 		}
-		config.Modules[i].Ignore = filteredIgnore
+		config.Modules[i].IgnoreModules = filteredIgnore
 
 		if config.Modules[i].Source == "" {
 			return nil, fmt.Errorf("module at index %d is missing 'source' field", i)

--- a/edge_cases_test.go
+++ b/edge_cases_test.go
@@ -400,17 +400,17 @@ func TestConfigLoadingEdgeCases(t *testing.T) {
 			configYAML: `modules:
   - source: "terraform-aws-modules/vpc/aws"
     version: "5.0.0"
-    ignore:
+    ignore_modules:
       - "vpc-主要"
       - "test-🚀-*"
       - "vpc[prod]"
 `,
 			expectError: false,
 			validate: func(t *testing.T, updates []ModuleUpdate) {
-				if len(updates[0].Ignore) != 3 {
-					t.Errorf("Expected 3 ignore patterns, got %d", len(updates[0].Ignore))
+				if len(updates[0].IgnoreModules) != 3 {
+					t.Errorf("Expected 3 ignore patterns, got %d", len(updates[0].IgnoreModules))
 				}
-				if updates[0].Ignore[0] != "vpc-主要" {
+				if updates[0].IgnoreModules[0] != "vpc-主要" {
 					t.Errorf("Unicode ignore pattern not preserved")
 				}
 			},

--- a/examples/config-with-ignore.yml
+++ b/examples/config-with-ignore.yml
@@ -1,11 +1,11 @@
-# Example configuration file demonstrating the ignore feature
+# Example configuration file demonstrating the ignore_modules feature
 # This shows how to selectively ignore specific modules by name or pattern
 
 modules:
   # Update all VPC modules to 5.0.0, except legacy and test modules
   - source: "terraform-aws-modules/vpc/aws"
     version: "5.0.0"
-    ignore:
+    ignore_modules:
       - "legacy-vpc"           # Ignore exact module name
       - "test-*"               # Ignore all modules starting with "test-"
       - "*-deprecated"         # Ignore all modules ending with "-deprecated"
@@ -14,27 +14,27 @@ modules:
   - source: "terraform-aws-modules/s3-bucket/aws"
     version: "4.0.0"
     from: "3.0.0"
-    ignore:
+    ignore_modules:
       - "dev-*"                # Skip all dev environment buckets
       - "*-staging"            # Skip staging buckets
 
   # Update security groups but preserve old ones for compatibility
   - source: "terraform-aws-modules/security-group/aws"
     version: "5.1.0"
-    ignore:
+    ignore_modules:
       - "*-old"                # Keep old security groups
       - "legacy-*"             # Keep legacy security groups
 
   # Update RDS modules everywhere except production
   - source: "terraform-aws-modules/rds/aws"
     version: "6.0.0"
-    ignore:
+    ignore_modules:
       - "prod-*"               # Don't touch production databases
       - "*-production"         # Alternative production naming
 
   # Complex pattern examples
   - source: "terraform-aws-modules/eks/aws"
     version: "19.0.0"
-    ignore:
+    ignore_modules:
       - "*-temp-*"             # Ignore temporary clusters
       - "experimental-*"       # Ignore experimental setups

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -68,7 +68,7 @@
             ],
             "description": "Optional: Only update the module if its current version matches this value or any value in the list. Supports version constraints like ~> 3.0"
           },
-          "ignore": {
+          "ignore_modules": {
             "type": "array",
             "description": "Optional: List of module names or patterns to ignore. Supports wildcard matching using '*' for zero or more characters",
             "items": {
@@ -113,13 +113,13 @@
         {
           "source": "terraform-aws-modules/vpc/aws",
           "version": "5.0.0",
-          "ignore": ["legacy-vpc", "test-*"]
+          "ignore_modules": ["legacy-vpc", "test-*"]
         },
         {
           "source": "terraform-aws-modules/s3-bucket/aws",
           "version": "4.0.0",
           "from": ["3.0.0", "~> 3.0"],
-          "ignore": ["*-deprecated"]
+          "ignore_modules": ["*-deprecated"]
         }
       ]
     }


### PR DESCRIPTION
Rename the `ignore` option to `ignore-modules` to reduce confusion with the existing `ignore-version` option. This is a breaking change that affects both CLI flag usage and YAML configuration.

Changes:
- CLI: `-ignore` → `-ignore-modules`
- YAML: `ignore:` → `ignore_modules:`
- Struct field: `Ignore` → `IgnoreModules`

Updated all documentation, tests, and example configs.