### PR TITLE
[codex] Fix golangci-lint failures

### DIFF
--- a/chaos_advanced_test.go
+++ b/chaos_advanced_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -35,7 +36,7 @@ func TestRecursiveGlobPatterns(t *testing.T) {
 	}
 
 	for _, dir := range dirs {
-		err := os.MkdirAll(filepath.Join(tmpDir, dir), 0755)
+		err := os.MkdirAll(filepath.Join(tmpDir, dir), 0o755)
 		if err != nil {
 			t.Fatalf("Failed to create directory %s: %v", dir, err)
 		}
@@ -56,7 +57,7 @@ func TestRecursiveGlobPatterns(t *testing.T) {
 
 	for _, file := range files {
 		fullPath := filepath.Join(tmpDir, file)
-		err := os.WriteFile(fullPath, []byte(content), 0644)
+		err := os.WriteFile(fullPath, []byte(content), 0o644)
 		if err != nil {
 			t.Fatalf("Failed to create file %s: %v", file, err)
 		}
@@ -65,7 +66,7 @@ func TestRecursiveGlobPatterns(t *testing.T) {
 	// Demonstrate that ** is NOT supported as recursive wildcard by filepath.Glob
 	// The ** pattern acts like a single-level wildcard (similar to *), not recursive.
 	// So "**/*.tf" matches one directory level down, not all nested levels.
-	pattern := filepath.Join(tmpDir, "**/*.tf")
+	pattern := filepath.Join(tmpDir, "**", "*.tf")
 	matchedFiles, err := filepath.Glob(pattern)
 	if err != nil {
 		t.Fatalf("Unexpected error from filepath.Glob: %v", err)
@@ -122,7 +123,7 @@ module "vpc-prod-legacy" {
   version = "3.0.0"
 }`
 
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -160,7 +161,7 @@ func TestHugeVersionString(t *testing.T) {
   source  = "terraform-aws-modules/vpc/aws"
   version = "1.0.0"
 }`
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -200,7 +201,7 @@ func TestInterpolationInSource(t *testing.T) {
   source  = "terraform-aws-modules/${var.module_name}/aws"
   version = "3.0.0"
 }`
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -242,7 +243,7 @@ func TestMultilineAttributes(t *testing.T) {
     description for the VPC module
   EOT
 }`
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -274,15 +275,15 @@ func TestIgnorePatternPerformanceWithManyModules(t *testing.T) {
 	// Create file with many modules
 	var contentBuilder strings.Builder
 	for i := 0; i < 100; i++ {
-		contentBuilder.WriteString(fmt.Sprintf(`module "vpc-%d" {
+		fmt.Fprintf(&contentBuilder, `module "vpc-%d" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.0.0"
 }
 
-`, i))
+`, i)
 	}
 
-	err := os.WriteFile(testFile, []byte(contentBuilder.String()), 0644)
+	err := os.WriteFile(testFile, []byte(contentBuilder.String()), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -351,7 +352,7 @@ module       "vpc"        {
 
 
 `
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -385,7 +386,7 @@ func TestConfigWithDuplicateSources(t *testing.T) {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.0.0"
 }`
-	err := os.WriteFile(testFile, []byte(tfContent), 0644)
+	err := os.WriteFile(testFile, []byte(tfContent), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -399,7 +400,7 @@ func TestConfigWithDuplicateSources(t *testing.T) {
   - source: "terraform-aws-modules/s3-bucket/aws"
     version: "4.0.0"`
 
-	err = os.WriteFile(configFile, []byte(configContent), 0644)
+	err = os.WriteFile(configFile, []byte(configContent), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create config: %v", err)
 	}
@@ -473,7 +474,7 @@ func TestSourceWithEscapedCharacters(t *testing.T) {
   source  = "` + source + `"
   version = "3.0.0"
 }`
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -505,7 +506,7 @@ func TestVeryLongModuleSource(t *testing.T) {
   source  = "` + longSource + `"
   version = "3.0.0"
 }`
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -529,7 +530,7 @@ func TestFromVersionNotMatching(t *testing.T) {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.0.0"
 }`
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -568,7 +569,7 @@ func TestIgnorePatternWhitespaceTrimming(t *testing.T) {
       - "  staging-*  "
       - "	dev-*	"`
 
-	err := os.WriteFile(configFile, []byte(content), 0644)
+	err := os.WriteFile(configFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create config: %v", err)
 	}
@@ -604,7 +605,7 @@ func TestDryRunModificationTime(t *testing.T) {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.0.0"
 }`
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -639,7 +640,7 @@ func TestDryRunModificationTime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to read file after dry-run: %v", err)
 	}
-	if string(newBytes) != string(originalBytes) {
+	if !bytes.Equal(newBytes, originalBytes) {
 		t.Error("Dry-run should not change file content")
 	}
 

--- a/chaos_test.go
+++ b/chaos_test.go
@@ -30,7 +30,7 @@ func TestNullBytesInFile(t *testing.T) {
 
 	// Create file with null byte in the middle
 	content := "module \"vpc\" {\n  source  = \"terraform-aws-modules/vpc/aws\"\x00\n  version = \"3.0.0\"\n}"
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestBinaryFileContent(t *testing.T) {
 
 	// Create file with binary content that looks like it might have HCL
 	binaryContent := []byte{0xFF, 0xFE, 0x00, 0x00, 'm', 'o', 'd', 'u', 'l', 'e'}
-	err := os.WriteFile(testFile, binaryContent, 0644)
+	err := os.WriteFile(testFile, binaryContent, 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestUTF8BOM(t *testing.T) {
 	// Prepend UTF-8 BOM to content
 	fullContent := []byte{0xEF, 0xBB, 0xBF}
 	fullContent = append(fullContent, []byte(content)...)
-	err := os.WriteFile(testFile, fullContent, 0644)
+	err := os.WriteFile(testFile, fullContent, 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestMixedLineEndings(t *testing.T) {
 
 	// Mix of CRLF and LF
 	content := "module \"vpc\" {\r\n  source  = \"terraform-aws-modules/vpc/aws\"\n  version = \"3.0.0\"\r\n}"
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestSymbolicLinks(t *testing.T) {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.0.0"
 }`
-	err := os.WriteFile(realFile, []byte(content), 0644)
+	err := os.WriteFile(realFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create real file: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestReadOnlyFile(t *testing.T) {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.0.0"
 }`
-	err := os.WriteFile(testFile, []byte(content), 0444) // Read-only
+	err := os.WriteFile(testFile, []byte(content), 0o444) // Read-only
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -225,7 +225,7 @@ func TestExtremelyNestedModuleSource(t *testing.T) {
   source  = "` + deepSource + `"
   version = "3.0.0"
 }`
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -260,7 +260,7 @@ func TestModuleSourceWithQueryParams(t *testing.T) {
   source  = "` + tt.source + `"
   version = "3.0.0"
 }`
-			err := os.WriteFile(testFile, []byte(content), 0644)
+			err := os.WriteFile(testFile, []byte(content), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create test file: %v", err)
 			}
@@ -302,7 +302,7 @@ func TestInvalidVersionFormats(t *testing.T) {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.0.0"
 }`
-			err := os.WriteFile(testFile, []byte(content), 0644)
+			err := os.WriteFile(testFile, []byte(content), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create test file: %v", err)
 			}
@@ -360,7 +360,7 @@ func TestExtremeWhitespace(t *testing.T) {
 			tmpDir := t.TempDir()
 			testFile := filepath.Join(tmpDir, "test.tf")
 
-			err := os.WriteFile(testFile, []byte(tt.content), 0644)
+			err := os.WriteFile(testFile, []byte(tt.content), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create test file: %v", err)
 			}
@@ -393,7 +393,7 @@ module "vpc" {
   version = "4.0.0"
 }`
 
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -428,7 +428,7 @@ func TestVeryLargeIgnoreList(t *testing.T) {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.0.0"
 }`
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -498,7 +498,7 @@ func TestConfigWithEmptyModulesList(t *testing.T) {
 
 	// Config with empty modules list
 	content := `modules: []`
-	err := os.WriteFile(configFile, []byte(content), 0644)
+	err := os.WriteFile(configFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create config: %v", err)
 	}
@@ -522,7 +522,7 @@ func TestConfigWithNullValues(t *testing.T) {
 	content := `modules:
   - source: null
     version: "1.0.0"`
-	err := os.WriteFile(configFile, []byte(content), 0644)
+	err := os.WriteFile(configFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create config: %v", err)
 	}
@@ -550,7 +550,7 @@ func TestFileWithOnlyComments(t *testing.T) {
 // Yet another comment
 /* Multi-line
    comment */`
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -578,7 +578,7 @@ func TestNestedQuotesInAttributes(t *testing.T) {
     Name = "VPC with \"quotes\""
   }
 }`
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -618,7 +618,7 @@ func TestTrailingWhitespace(t *testing.T) {
 
 	// File with trailing spaces and tabs
 	content := "module \"vpc\" {  \t  \n  source  = \"terraform-aws-modules/vpc/aws\"  \n  version = \"3.0.0\"  \t\n}  \t  "
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -643,7 +643,7 @@ func TestFromVersionWithSpecialChars(t *testing.T) {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.0.0-rc.1+build.123"
 }`
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}

--- a/cli_functions_test.go
+++ b/cli_functions_test.go
@@ -67,7 +67,7 @@ func TestFindMatchingFiles(t *testing.T) {
 	file3 := filepath.Join(tmpDir, "outputs.tf")
 
 	for _, f := range []string{file1, file2, file3} {
-		if err := os.WriteFile(f, []byte("# test"), 0644); err != nil {
+		if err := os.WriteFile(f, []byte("# test"), 0o644); err != nil {
 			t.Fatalf("Failed to create test file: %v", err)
 		}
 	}
@@ -127,7 +127,7 @@ module "vpc" {
   version = "3.0.0"
 }`
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("Failed to create terraform file: %v", err)
 	}
 
@@ -140,7 +140,7 @@ modules:
   - source: "terraform-aws-modules/vpc/aws"
     version: "5.0.0"`
 	configFile := filepath.Join(tmpDir, "config.yml")
-	if err := os.WriteFile(configFile, []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(configFile, []byte(configContent), 0o644); err != nil {
 		t.Fatalf("Failed to create config file: %v", err)
 	}
 
@@ -180,13 +180,13 @@ func TestRunConfigFileModeDryRun(t *testing.T) {
   required_version = ">= 1.0"
 }`
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("Failed to create terraform file: %v", err)
 	}
 
 	configContent := `terraform_version: ">= 1.6"`
 	configFile := filepath.Join(tmpDir, "config.yml")
-	if err := os.WriteFile(configFile, []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(configFile, []byte(configContent), 0o644); err != nil {
 		t.Fatalf("Failed to create config file: %v", err)
 	}
 
@@ -218,7 +218,7 @@ func TestRunCLIModeWithTerraformVersion(t *testing.T) {
   required_version = ">= 1.0"
 }`
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("Failed to create terraform file: %v", err)
 	}
 
@@ -255,7 +255,7 @@ func TestRunCLIModeWithProvider(t *testing.T) {
   }
 }`
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("Failed to create terraform file: %v", err)
 	}
 
@@ -289,7 +289,7 @@ func TestRunCLIModeWithModule(t *testing.T) {
   version = "3.0.0"
 }`
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("Failed to create terraform file: %v", err)
 	}
 

--- a/config.go
+++ b/config.go
@@ -125,59 +125,57 @@ func loadConfig(filename string) (*Config, error) {
 	// Trim and validate terraform_version
 	config.TerraformVersion = strings.TrimSpace(config.TerraformVersion)
 
-	// Validate and sanitize provider updates
-	for i, provider := range config.Providers {
-		config.Providers[i].Name = strings.TrimSpace(provider.Name)
-		config.Providers[i].Version = strings.TrimSpace(provider.Version)
-
-		if config.Providers[i].Name == "" {
-			return nil, fmt.Errorf("provider at index %d is missing 'name' field", i)
-		}
-		if config.Providers[i].Version == "" {
-			return nil, fmt.Errorf("provider at index %d is missing 'version' field", i)
-		}
+	if err := sanitizeProviderUpdates(config.Providers); err != nil {
+		return nil, err
 	}
-
-	// Validate and sanitize module updates
-	for i, module := range config.Modules {
-		// Trim whitespace from source and version fields
-		config.Modules[i].Source = strings.TrimSpace(module.Source)
-		config.Modules[i].Version = strings.TrimSpace(module.Version)
-
-		// Trim whitespace from from versions and filter out empty ones
-		filteredFrom := make([]string, 0, len(module.From))
-		for _, fromVer := range module.From {
-			if trimmed := strings.TrimSpace(fromVer); trimmed != "" {
-				filteredFrom = append(filteredFrom, trimmed)
-			}
-		}
-		config.Modules[i].From = filteredFrom
-
-		// Trim whitespace from ignore versions and filter out empty ones
-		filteredIgnoreVersions := make([]string, 0, len(module.IgnoreVersions))
-		for _, ignoreVer := range module.IgnoreVersions {
-			if trimmed := strings.TrimSpace(ignoreVer); trimmed != "" {
-				filteredIgnoreVersions = append(filteredIgnoreVersions, trimmed)
-			}
-		}
-		config.Modules[i].IgnoreVersions = filteredIgnoreVersions
-
-		// Trim whitespace from ignore patterns and filter out empty ones
-		filteredIgnore := make([]string, 0, len(module.IgnoreModules))
-		for _, pattern := range module.IgnoreModules {
-			if trimmed := strings.TrimSpace(pattern); trimmed != "" {
-				filteredIgnore = append(filteredIgnore, trimmed)
-			}
-		}
-		config.Modules[i].IgnoreModules = filteredIgnore
-
-		if config.Modules[i].Source == "" {
-			return nil, fmt.Errorf("module at index %d is missing 'source' field", i)
-		}
-		if config.Modules[i].Version == "" {
-			return nil, fmt.Errorf("module at index %d is missing 'version' field", i)
-		}
+	if err := sanitizeModuleUpdates(config.Modules); err != nil {
+		return nil, err
 	}
 
 	return &config, nil
+}
+
+func sanitizeProviderUpdates(providers []ProviderUpdate) error {
+	for i := range providers {
+		providers[i].Name = strings.TrimSpace(providers[i].Name)
+		providers[i].Version = strings.TrimSpace(providers[i].Version)
+
+		if providers[i].Name == "" {
+			return fmt.Errorf("provider at index %d is missing 'name' field", i)
+		}
+		if providers[i].Version == "" {
+			return fmt.Errorf("provider at index %d is missing 'version' field", i)
+		}
+	}
+
+	return nil
+}
+
+func sanitizeModuleUpdates(modules []ModuleUpdate) error {
+	for i := range modules {
+		modules[i].Source = strings.TrimSpace(modules[i].Source)
+		modules[i].Version = strings.TrimSpace(modules[i].Version)
+		modules[i].From = FromVersions(trimNonEmptyStrings(modules[i].From))
+		modules[i].IgnoreVersions = FromVersions(trimNonEmptyStrings(modules[i].IgnoreVersions))
+		modules[i].IgnoreModules = trimNonEmptyStrings(modules[i].IgnoreModules)
+
+		if modules[i].Source == "" {
+			return fmt.Errorf("module at index %d is missing 'source' field", i)
+		}
+		if modules[i].Version == "" {
+			return fmt.Errorf("module at index %d is missing 'version' field", i)
+		}
+	}
+
+	return nil
+}
+
+func trimNonEmptyStrings(values []string) []string {
+	filtered := make([]string, 0, len(values))
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			filtered = append(filtered, trimmed)
+		}
+	}
+	return filtered
 }

--- a/config_test.go
+++ b/config_test.go
@@ -106,7 +106,7 @@ func TestLoadConfig(t *testing.T) {
 			tmpDir := t.TempDir()
 			configFile := filepath.Join(tmpDir, "config.yml")
 
-			err := os.WriteFile(configFile, []byte(tt.configYAML), 0644)
+			err := os.WriteFile(configFile, []byte(tt.configYAML), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create temp config file: %v", err)
 			}
@@ -177,10 +177,10 @@ module "s3" {
 	tf1File := filepath.Join(tmpDir, "test1.tf")
 	tf2File := filepath.Join(tmpDir, "test2.tf")
 
-	if err := os.WriteFile(tf1File, []byte(tf1Content), 0644); err != nil {
+	if err := os.WriteFile(tf1File, []byte(tf1Content), 0o644); err != nil {
 		t.Fatalf("Failed to create test1.tf: %v", err)
 	}
-	if err := os.WriteFile(tf2File, []byte(tf2Content), 0644); err != nil {
+	if err := os.WriteFile(tf2File, []byte(tf2Content), 0o644); err != nil {
 		t.Fatalf("Failed to create test2.tf: %v", err)
 	}
 
@@ -192,7 +192,7 @@ module "s3" {
     version: "4.0.0"
 `
 	configFile := filepath.Join(tmpDir, "config.yml")
-	if err := os.WriteFile(configFile, []byte(configYAML), 0644); err != nil {
+	if err := os.WriteFile(configFile, []byte(configYAML), 0o644); err != nil {
 		t.Fatalf("Failed to create config file: %v", err)
 	}
 
@@ -252,7 +252,7 @@ modules:
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -278,7 +278,7 @@ func TestLoadConfigWithGitSources(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -315,7 +315,7 @@ func TestLoadConfigWithLocalModules(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -381,7 +381,7 @@ func TestLoadConfigMultipleMissingFields(t *testing.T) {
 			tmpDir := t.TempDir()
 			configFile := filepath.Join(tmpDir, "config.yml")
 
-			err := os.WriteFile(configFile, []byte(tt.configYAML), 0644)
+			err := os.WriteFile(configFile, []byte(tt.configYAML), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create temp config file: %v", err)
 			}
@@ -406,15 +406,15 @@ func TestLoadConfigLargeFile(t *testing.T) {
 
 	// Generate 50 module entries
 	for i := 0; i < 50; i++ {
-		sb.WriteString(fmt.Sprintf(`  - source: "terraform-aws-modules/module-%d/aws"
+		fmt.Fprintf(&sb, `  - source: "terraform-aws-modules/module-%d/aws"
     version: "1.0.%d"
-`, i, i))
+`, i, i)
 	}
 
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(sb.String()), 0644)
+	err := os.WriteFile(configFile, []byte(sb.String()), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -437,6 +437,58 @@ func TestLoadConfigLargeFile(t *testing.T) {
 	}
 }
 
+func validateConfigWithFromField(t *testing.T, updates []ModuleUpdate) {
+	assertModuleUpdate(t, &updates[0], "terraform-aws-modules/vpc/aws", "5.0.0")
+	assertFromVersions(t, updates[0].From, "3.14.0")
+}
+
+func validateMixedFromFields(t *testing.T, updates []ModuleUpdate) {
+	assertFromVersions(t, updates[0].From, "3.14.0")
+	assertFromVersions(t, updates[1].From)
+}
+
+func validateAllModulesWithFromFields(t *testing.T, updates []ModuleUpdate) {
+	assertFromVersions(t, updates[0].From, "3.14.0")
+	assertFromVersions(t, updates[1].From, "3.0.0")
+	assertFromVersions(t, updates[2].From, "5.1.0")
+}
+
+func validateEmptyFromField(t *testing.T, updates []ModuleUpdate) {
+	assertFromVersions(t, updates[0].From)
+}
+
+func validateArrayFromVersions(t *testing.T, updates []ModuleUpdate) {
+	assertModuleUpdate(t, &updates[0], "terraform-aws-modules/s3-bucket/aws", "4.0.0")
+	assertFromVersions(t, updates[0].From, "3.0.0", "~> 3.0")
+}
+
+func validateMixedSingleAndArrayFromVersions(t *testing.T, updates []ModuleUpdate) {
+	assertFromVersions(t, updates[0].From, "4.0.0")
+	assertFromVersions(t, updates[1].From, "3.0.0", "~> 3.0")
+}
+
+func assertModuleUpdate(t *testing.T, update *ModuleUpdate, source, version string) {
+	t.Helper()
+	if update.Source != source {
+		t.Errorf("Module source = %q, want %q", update.Source, source)
+	}
+	if update.Version != version {
+		t.Errorf("Module version = %q, want %q", update.Version, version)
+	}
+}
+
+func assertFromVersions(t *testing.T, got FromVersions, want ...string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("Module from length = %d, want %d", len(got), len(want))
+	}
+	for i, wantVersion := range want {
+		if got[i] != wantVersion {
+			t.Errorf("Module from[%d] = %q, want %q", i, got[i], wantVersion)
+		}
+	}
+}
+
 // TestLoadConfigWithFromField tests config parsing with optional 'from' field
 func TestLoadConfigWithFromField(t *testing.T) {
 	tests := []struct {
@@ -455,17 +507,7 @@ func TestLoadConfigWithFromField(t *testing.T) {
 `,
 			expectError: false,
 			expectCount: 1,
-			validate: func(t *testing.T, updates []ModuleUpdate) {
-				if updates[0].Source != "terraform-aws-modules/vpc/aws" {
-					t.Errorf("Module source = %q, want %q", updates[0].Source, "terraform-aws-modules/vpc/aws")
-				}
-				if updates[0].Version != "5.0.0" {
-					t.Errorf("Module version = %q, want %q", updates[0].Version, "5.0.0")
-				}
-				if len(updates[0].From) != 1 || updates[0].From[0] != "3.14.0" {
-					t.Errorf("Module from = %v, want [\"3.14.0\"]", updates[0].From)
-				}
-			},
+			validate:    validateConfigWithFromField,
 		},
 		{
 			name: "config with mixed from fields",
@@ -478,14 +520,7 @@ func TestLoadConfigWithFromField(t *testing.T) {
 `,
 			expectError: false,
 			expectCount: 2,
-			validate: func(t *testing.T, updates []ModuleUpdate) {
-				if len(updates[0].From) != 1 || updates[0].From[0] != "3.14.0" {
-					t.Errorf("First module from = %v, want [\"3.14.0\"]", updates[0].From)
-				}
-				if len(updates[1].From) != 0 {
-					t.Errorf("Second module from = %v, want empty slice", updates[1].From)
-				}
-			},
+			validate:    validateMixedFromFields,
 		},
 		{
 			name: "config with all modules having from field",
@@ -502,17 +537,7 @@ func TestLoadConfigWithFromField(t *testing.T) {
 `,
 			expectError: false,
 			expectCount: 3,
-			validate: func(t *testing.T, updates []ModuleUpdate) {
-				if len(updates[0].From) != 1 || updates[0].From[0] != "3.14.0" {
-					t.Errorf("First module from = %v, want [\"3.14.0\"]", updates[0].From)
-				}
-				if len(updates[1].From) != 1 || updates[1].From[0] != "3.0.0" {
-					t.Errorf("Second module from = %v, want [\"3.0.0\"]", updates[1].From)
-				}
-				if len(updates[2].From) != 1 || updates[2].From[0] != "5.1.0" {
-					t.Errorf("Third module from = %v, want [\"5.1.0\"]", updates[2].From)
-				}
-			},
+			validate:    validateAllModulesWithFromFields,
 		},
 		{
 			name: "config with empty from string",
@@ -523,11 +548,7 @@ func TestLoadConfigWithFromField(t *testing.T) {
 `,
 			expectError: false,
 			expectCount: 1,
-			validate: func(t *testing.T, updates []ModuleUpdate) {
-				if len(updates[0].From) != 0 {
-					t.Errorf("Expected empty from slice for empty string, got %v", updates[0].From)
-				}
-			},
+			validate:    validateEmptyFromField,
 		},
 	}
 
@@ -536,7 +557,7 @@ func TestLoadConfigWithFromField(t *testing.T) {
 			tmpDir := t.TempDir()
 			configFile := filepath.Join(tmpDir, "config.yml")
 
-			err := os.WriteFile(configFile, []byte(tt.configYAML), 0644)
+			err := os.WriteFile(configFile, []byte(tt.configYAML), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create temp config file: %v", err)
 			}
@@ -585,23 +606,7 @@ func TestLoadConfigWithMultipleFromVersions(t *testing.T) {
 `,
 			expectError: false,
 			expectCount: 1,
-			validate: func(t *testing.T, updates []ModuleUpdate) {
-				if updates[0].Source != "terraform-aws-modules/s3-bucket/aws" {
-					t.Errorf("Module source = %q, want %q", updates[0].Source, "terraform-aws-modules/s3-bucket/aws")
-				}
-				if updates[0].Version != "4.0.0" {
-					t.Errorf("Module version = %q, want %q", updates[0].Version, "4.0.0")
-				}
-				if len(updates[0].From) != 2 {
-					t.Fatalf("Module from length = %d, want 2", len(updates[0].From))
-				}
-				if updates[0].From[0] != "3.0.0" {
-					t.Errorf("Module from[0] = %q, want %q", updates[0].From[0], "3.0.0")
-				}
-				if updates[0].From[1] != "~> 3.0" {
-					t.Errorf("Module from[1] = %q, want %q", updates[0].From[1], "~> 3.0")
-				}
-			},
+			validate:    validateArrayFromVersions,
 		},
 		{
 			name: "config with mixed single and array from versions",
@@ -617,22 +622,7 @@ func TestLoadConfigWithMultipleFromVersions(t *testing.T) {
 `,
 			expectError: false,
 			expectCount: 2,
-			validate: func(t *testing.T, updates []ModuleUpdate) {
-				// First module with single from version
-				if len(updates[0].From) != 1 || updates[0].From[0] != "4.0.0" {
-					t.Errorf("First module from = %v, want [\"4.0.0\"]", updates[0].From)
-				}
-				// Second module with multiple from versions
-				if len(updates[1].From) != 2 {
-					t.Fatalf("Second module from length = %d, want 2", len(updates[1].From))
-				}
-				if updates[1].From[0] != "3.0.0" {
-					t.Errorf("Second module from[0] = %q, want %q", updates[1].From[0], "3.0.0")
-				}
-				if updates[1].From[1] != "~> 3.0" {
-					t.Errorf("Second module from[1] = %q, want %q", updates[1].From[1], "~> 3.0")
-				}
-			},
+			validate:    validateMixedSingleAndArrayFromVersions,
 		},
 		{
 			name: "config with empty from array",
@@ -643,11 +633,7 @@ func TestLoadConfigWithMultipleFromVersions(t *testing.T) {
 `,
 			expectError: false,
 			expectCount: 1,
-			validate: func(t *testing.T, updates []ModuleUpdate) {
-				if len(updates[0].From) != 0 {
-					t.Errorf("Module from = %v, want empty slice", updates[0].From)
-				}
-			},
+			validate:    validateEmptyFromField,
 		},
 		{
 			name: "config with invalid from type - number",
@@ -695,7 +681,7 @@ func TestLoadConfigWithMultipleFromVersions(t *testing.T) {
 			tmpDir := t.TempDir()
 			configFile := filepath.Join(tmpDir, "config.yml")
 
-			err := os.WriteFile(configFile, []byte(tt.configYAML), 0644)
+			err := os.WriteFile(configFile, []byte(tt.configYAML), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create temp config file: %v", err)
 			}
@@ -746,7 +732,7 @@ module "iam" {
 `
 
 	tfFile := filepath.Join(tmpDir, "test.tf")
-	err := os.WriteFile(tfFile, []byte(tfContent), 0644)
+	err := os.WriteFile(tfFile, []byte(tfContent), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp Terraform file: %v", err)
 	}
@@ -764,7 +750,7 @@ module "iam" {
 `
 
 	configFile := filepath.Join(tmpDir, "config.yml")
-	err = os.WriteFile(configFile, []byte(configYAML), 0644)
+	err = os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -829,7 +815,7 @@ module "s3_other" {
 `
 
 	tfFile := filepath.Join(tmpDir, "test.tf")
-	err := os.WriteFile(tfFile, []byte(tfContent), 0644)
+	err := os.WriteFile(tfFile, []byte(tfContent), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp Terraform file: %v", err)
 	}
@@ -844,7 +830,7 @@ module "s3_other" {
 `
 
 	configFile := filepath.Join(tmpDir, "config.yml")
-	err = os.WriteFile(configFile, []byte(configContent), 0644)
+	err = os.WriteFile(configFile, []byte(configContent), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -891,7 +877,7 @@ func TestLoadConfigEmptyFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "empty.yml")
 
-	err := os.WriteFile(configFile, []byte(""), 0644)
+	err := os.WriteFile(configFile, []byte(""), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -915,7 +901,7 @@ func TestLoadConfigOnlyComments(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "comments.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -941,7 +927,7 @@ func TestLoadConfigSpecialCharacters(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -975,7 +961,7 @@ func TestLoadConfigDuplicateModules(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -1012,7 +998,7 @@ func TestLoadConfigMixedQuotes(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -1051,7 +1037,7 @@ func TestLoadConfigVeryLongVersionString(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -1080,7 +1066,7 @@ func TestLoadConfigWhitespaceInValues(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -1163,7 +1149,7 @@ func TestLoadConfigVersionConstraintsWithWhitespace(t *testing.T) {
 			tmpDir := t.TempDir()
 			configFile := filepath.Join(tmpDir, "config.yml")
 
-			err := os.WriteFile(configFile, []byte(configYAML), 0644)
+			err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create temp config file: %v", err)
 			}
@@ -1206,7 +1192,7 @@ func TestLoadConfigWithIgnoreModulesField(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -1267,7 +1253,7 @@ func TestLoadConfigWithIgnoreModulesFieldWhitespace(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -1308,7 +1294,7 @@ func TestLoadConfigWithWhitespaceOnlyIgnoreModulesPatterns(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -1344,7 +1330,7 @@ func TestLoadConfigWithEmptyIgnoreModulesField(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -1373,7 +1359,7 @@ func TestLoadConfigWithoutIgnoreModulesField(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -1404,7 +1390,7 @@ func TestLoadConfigWithLegacyIgnoreField(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -1479,7 +1465,7 @@ unknown_root: "value"
 			tmpDir := t.TempDir()
 			configFile := filepath.Join(tmpDir, "config.yml")
 
-			err := os.WriteFile(configFile, []byte(tt.configYAML), 0644)
+			err := os.WriteFile(configFile, []byte(tt.configYAML), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create temp config file: %v", err)
 			}
@@ -1509,7 +1495,7 @@ func TestLoadConfigWithMultipleLegacyFields(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -1537,7 +1523,7 @@ func TestLoadConfigProviderMissingName(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -1560,7 +1546,7 @@ func TestLoadConfigProviderMissingVersion(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -1584,7 +1570,7 @@ func TestLoadConfigProviderWhitespaceTrimming(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
@@ -1614,7 +1600,7 @@ func TestLoadConfigEmptyProvidersArray(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yml")
 
-	err := os.WriteFile(configFile, []byte(configYAML), 0644)
+	err := os.WriteFile(configFile, []byte(configYAML), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}

--- a/coverage_test.go
+++ b/coverage_test.go
@@ -432,7 +432,7 @@ func TestLoadModuleUpdatesConfigFile(t *testing.T) {
     version: "4.0.0"
 `
 	configFile := filepath.Join(tmpDir, "config.yml")
-	if err := os.WriteFile(configFile, []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(configFile, []byte(configContent), 0o644); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
 	}
 
@@ -479,7 +479,7 @@ module "s3" {
 }
 `
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("failed to write tf file: %v", err)
 	}
 
@@ -524,7 +524,7 @@ module "s3" {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Reset the file for each test
-			if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+			if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 				t.Fatalf("failed to reset tf file: %v", err)
 			}
 
@@ -573,7 +573,7 @@ func TestProcessFilesWithFromVersionFilter(t *testing.T) {
 }
 `
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("failed to write tf file: %v", err)
 	}
 
@@ -602,7 +602,7 @@ func TestProcessFilesWithFromVersionFilter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Reset the file
-			if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+			if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 				t.Fatalf("failed to reset tf file: %v", err)
 			}
 
@@ -666,10 +666,10 @@ func TestProcessFilesMultipleFiles(t *testing.T) {
 	tfFile1 := filepath.Join(tmpDir, "main1.tf")
 	tfFile2 := filepath.Join(tmpDir, "main2.tf")
 
-	if err := os.WriteFile(tfFile1, []byte(tfContent1), 0644); err != nil {
+	if err := os.WriteFile(tfFile1, []byte(tfContent1), 0o644); err != nil {
 		t.Fatalf("failed to write tf file 1: %v", err)
 	}
-	if err := os.WriteFile(tfFile2, []byte(tfContent2), 0644); err != nil {
+	if err := os.WriteFile(tfFile2, []byte(tfContent2), 0o644); err != nil {
 		t.Fatalf("failed to write tf file 2: %v", err)
 	}
 
@@ -805,7 +805,7 @@ func TestProcessFilesWithVerbose(t *testing.T) {
 }
 `
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("failed to write tf file: %v", err)
 	}
 
@@ -867,7 +867,7 @@ func TestProcessFilesMarkdownOutput(t *testing.T) {
 }
 `
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("failed to write tf file: %v", err)
 	}
 
@@ -951,7 +951,7 @@ func TestProcessFilesOutputMessages(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Reset the file
-			if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+			if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 				t.Fatalf("failed to reset tf file: %v", err)
 			}
 
@@ -1077,7 +1077,7 @@ func TestLoadConfigYAMLEdgeCases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			configFile := filepath.Join(tmpDir, "config.yml")
-			if err := os.WriteFile(configFile, []byte(tt.yamlContent), 0644); err != nil {
+			if err := os.WriteFile(configFile, []byte(tt.yamlContent), 0o644); err != nil {
 				t.Fatalf("failed to write config file: %v", err)
 			}
 
@@ -1130,7 +1130,7 @@ module "legacy-vpc" {
 }
 `
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("failed to write tf file: %v", err)
 	}
 
@@ -1169,7 +1169,7 @@ module "legacy-vpc" {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Reset the file
-			if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+			if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 				t.Fatalf("failed to reset tf file: %v", err)
 			}
 

--- a/edge_cases_test.go
+++ b/edge_cases_test.go
@@ -54,7 +54,7 @@ func TestUnicodeModuleNames(t *testing.T) {
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, "test.tf")
 
-			err := os.WriteFile(tmpFile, []byte(tt.inputContent), 0644)
+			err := os.WriteFile(tmpFile, []byte(tt.inputContent), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create temp file: %v", err)
 			}
@@ -148,7 +148,7 @@ module "vpc-prod" {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(inputContent), 0644)
+	err := os.WriteFile(tmpFile, []byte(inputContent), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -171,10 +171,10 @@ module "vpc-prod" {
 
 	// Count version occurrences - should be 1 old, 1 new
 	old := strings.Count(string(content), `version = "3.0.0"`)
-	new := strings.Count(string(content), `version = "5.0.0"`)
+	newCount := strings.Count(string(content), `version = "5.0.0"`)
 
-	if old != 1 || new != 1 {
-		t.Errorf("Expected 1 old version and 1 new version, got %d old and %d new", old, new)
+	if old != 1 || newCount != 1 {
+		t.Errorf("Expected 1 old version and 1 new version, got %d old and %d new", old, newCount)
 	}
 }
 
@@ -189,7 +189,7 @@ func TestVeryLongModuleName(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(inputContent), 0644)
+	err := os.WriteFile(tmpFile, []byte(inputContent), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -251,7 +251,7 @@ func TestSpecialCharactersInModuleName(t *testing.T) {
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, "test.tf")
 
-			err := os.WriteFile(tmpFile, []byte(inputContent), 0644)
+			err := os.WriteFile(tmpFile, []byte(inputContent), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create temp file: %v", err)
 			}
@@ -279,7 +279,7 @@ func TestFilePermissionPreservation(t *testing.T) {
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
 	// Create file with specific permissions (read-only for owner, others have no access)
-	err := os.WriteFile(tmpFile, []byte(inputContent), 0600)
+	err := os.WriteFile(tmpFile, []byte(inputContent), 0o600)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -422,7 +422,7 @@ func TestConfigLoadingEdgeCases(t *testing.T) {
 			tmpDir := t.TempDir()
 			configFile := filepath.Join(tmpDir, "config.yml")
 
-			err := os.WriteFile(configFile, []byte(tt.configYAML), 0644)
+			err := os.WriteFile(configFile, []byte(tt.configYAML), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create config file: %v", err)
 			}
@@ -495,7 +495,7 @@ func TestMultipleFilesSimultaneously(t *testing.T) {
   version = "3.0.0"
 }`
 		filename := filepath.Join(tmpDir, fmt.Sprintf("test%d.tf", i))
-		err := os.WriteFile(filename, []byte(content), 0644)
+		err := os.WriteFile(filename, []byte(content), 0o644)
 		if err != nil {
 			t.Fatalf("Failed to create file %s: %v", filename, err)
 		}

--- a/integration_config_test.go
+++ b/integration_config_test.go
@@ -16,14 +16,14 @@ func TestConfigFileWithTerraformVersion(t *testing.T) {
   required_version = ">= 1.0"
 }`
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("Failed to create terraform file: %v", err)
 	}
 
 	// Create config file with terraform_version
 	configContent := `terraform_version: ">= 1.6"`
 	configFile := filepath.Join(tmpDir, "config.yml")
-	if err := os.WriteFile(configFile, []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(configFile, []byte(configContent), 0o644); err != nil {
 		t.Fatalf("Failed to create config file: %v", err)
 	}
 
@@ -75,7 +75,7 @@ func TestConfigFileWithMultipleProviders(t *testing.T) {
   }
 }`
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("Failed to create terraform file: %v", err)
 	}
 
@@ -86,7 +86,7 @@ func TestConfigFileWithMultipleProviders(t *testing.T) {
   - name: "azurerm"
     version: "~> 3.5"`
 	configFile := filepath.Join(tmpDir, "config.yml")
-	if err := os.WriteFile(configFile, []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(configFile, []byte(configContent), 0o644); err != nil {
 		t.Fatalf("Failed to create config file: %v", err)
 	}
 
@@ -150,7 +150,7 @@ module "vpc" {
   version = "3.0.0"
 }`
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("Failed to create terraform file: %v", err)
 	}
 
@@ -163,7 +163,7 @@ modules:
   - source: "terraform-aws-modules/vpc/aws"
     version: "5.0.0"`
 	configFile := filepath.Join(tmpDir, "config.yml")
-	if err := os.WriteFile(configFile, []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(configFile, []byte(configContent), 0o644); err != nil {
 		t.Fatalf("Failed to create config file: %v", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -179,7 +179,7 @@ func processFiles(files []string, updates []ModuleUpdate, flags *cliFlags) int {
 }
 
 // printSummary prints the final summary of updates
-func printSummary(totalUpdates int, updatesCount int, dryRun bool) {
+func printSummary(totalUpdates, updatesCount int, dryRun bool) {
 	if dryRun {
 		if updatesCount > 1 {
 			fmt.Printf("\nDry run: would apply %d update(s) across all files\n", totalUpdates)
@@ -432,7 +432,7 @@ func processTerraformVersion(files []string, version string, dryRun bool, output
 //
 // Returns:
 //   - int: Number of files that were updated (or would be updated in dry-run mode)
-func processProviderVersion(files []string, providerName string, version string, dryRun bool, outputFormat string) int {
+func processProviderVersion(files []string, providerName, version string, dryRun bool, outputFormat string) int {
 	totalUpdates := 0
 	for _, file := range files {
 		updated, err := updateProviderVersion(file, providerName, version, dryRun)
@@ -555,33 +555,8 @@ func updateProviderVersion(filename, providerName, version string, dryRun bool) 
 
 	// Iterate through all blocks in the file
 	for _, block := range file.Body().Blocks() {
-		// Look for terraform blocks
-		if block.Type() == "terraform" {
-			// Look for required_providers block (it's a nested block type)
-			for _, nestedBlock := range block.Body().Blocks() {
-				if nestedBlock.Type() == "required_providers" {
-					// First, try block-based syntax: required_providers { aws { source = "..." version = "..." } }
-					for _, providerBlock := range nestedBlock.Body().Blocks() {
-						if providerBlock.Type() == providerName {
-							// Update the version attribute within the provider block
-							providerBlock.Body().SetAttributeValue("version", cty.StringVal(version))
-							updated = true
-						}
-					}
-
-					// Second, try attribute-based syntax: required_providers { aws = { source = "..." version = "..." } }
-					if !updated {
-						// Check if provider exists as an attribute
-						attrs := nestedBlock.Body().Attributes()
-						if _, exists := attrs[providerName]; exists {
-							// Update the attribute by modifying the object expression
-							if updateProviderAttributeVersion(nestedBlock, providerName, version) {
-								updated = true
-							}
-						}
-					}
-				}
-			}
+		if updateProviderTerraformBlock(block, providerName, version) {
+			updated = true
 		}
 	}
 
@@ -597,132 +572,167 @@ func updateProviderVersion(filename, providerName, version string, dryRun bool) 
 	return updated, nil
 }
 
-// updateProviderAttributeVersion updates the version value within a provider attribute's object expression
-// This handles the attribute-based syntax: aws = { source = "..." version = "..." }
-func updateProviderAttributeVersion(nestedBlock *hclwrite.Block, providerName, newVersion string) bool {
-	// Get the raw attribute expression as a string
-	attrs := nestedBlock.Body().Attributes()
-	if attr, exists := attrs[providerName]; exists {
-		// Get the expression as bytes
-		tokens := attr.Expr().BuildTokens(nil)
-		exprStr := string(tokens.Bytes())
+func updateProviderTerraformBlock(block *hclwrite.Block, providerName, version string) bool {
+	if block.Type() != "terraform" {
+		return false
+	}
 
-		// Parse the expression using hclsyntax to understand its structure
-		expr, diags := parseExpression([]byte(exprStr), "inline", hcl.Pos{Line: 1, Column: 1})
-		if diags.HasErrors() {
-			return false
+	updated := false
+	for _, nestedBlock := range block.Body().Blocks() {
+		if nestedBlock.Type() != "required_providers" {
+			continue
 		}
-
-		// Check if it's an object construction expression
-		objExpr, ok := expr.(*hclsyntax.ObjectConsExpr)
-		if !ok {
-			return false
+		if updateProviderBlockSyntax(nestedBlock, providerName, version) {
+			updated = true
+			continue
 		}
-
-		// Build a new object with the updated version
-		// We'll reconstruct the object manually
-		newObj := make(map[string]string)
-		hasVersion := false
-
-		for _, item := range objExpr.Items {
-			// Extract the key name
-			keyExpr, ok := item.KeyExpr.(*hclsyntax.ObjectConsKeyExpr)
-			if !ok {
-				continue
-			}
-
-			traversal, ok := keyExpr.Wrapped.(*hclsyntax.ScopeTraversalExpr)
-			if !ok {
-				continue
-			}
-
-			if len(traversal.Traversal) == 0 {
-				continue
-			}
-
-			rootName, ok := traversal.Traversal[0].(hcl.TraverseRoot)
-			if !ok {
-				continue
-			}
-
-			keyName := rootName.Name
-
-			// Extract the value - handle multiple expression types
-			var value string
-			valueExtracted := false
-
-			switch expr := item.ValueExpr.(type) {
-			case *hclsyntax.TemplateExpr:
-				// Handle template expressions (quoted strings)
-				if len(expr.Parts) > 0 {
-					if lit, ok := expr.Parts[0].(*hclsyntax.LiteralValueExpr); ok {
-						value = lit.Val.AsString()
-						valueExtracted = true
-					}
-				}
-			case *hclsyntax.LiteralValueExpr:
-				// Handle direct literal values
-				if expr.Val.Type().Equals(cty.String) {
-					value = expr.Val.AsString()
-					valueExtracted = true
-				}
-			default:
-				// Skip non-string attributes (variables, functions, complex expressions, etc.)
-				// These will not be included in the reconstructed object to avoid errors
-				continue
-			}
-
-			if valueExtracted {
-				if keyName == "version" {
-					newObj[keyName] = newVersion
-					hasVersion = true
-				} else {
-					newObj[keyName] = value
-				}
-			}
-		}
-
-		if !hasVersion {
-			return false
-		}
-
-		// Determine indentation from the original HCL (default to 6 spaces if unable to detect)
-		// In HCL files, required_providers block is typically indented 2 spaces,
-		// and the provider attributes inside the object are indented an additional 4 spaces (total 6)
-		indent := "      " // 6 spaces as default
-
-		// Reconstruct the object expression with proper formatting
-		newExprStr := "{\n"
-		// Preserve the order: source first, then version, then others
-		if source, ok := newObj["source"]; ok {
-			newExprStr += fmt.Sprintf("%ssource  = %q\n", indent, source)
-		}
-		if _, ok := newObj["version"]; ok {
-			newExprStr += fmt.Sprintf("%sversion = %q\n", indent, newVersion)
-		}
-		for key, value := range newObj {
-			if key != "source" && key != "version" {
-				newExprStr += fmt.Sprintf("%s%s = %q\n", indent, key, value)
-			}
-		}
-		newExprStr += "    }"
-
-		// Set the new expression
-		newExpr, diags := hclwrite.ParseConfig([]byte(providerName+" = "+newExprStr), "inline", hcl.Pos{Line: 1, Column: 1})
-		if diags.HasErrors() {
-			return false
-		}
-
-		// Get the attribute from the parsed expression
-		if len(newExpr.Body().Attributes()) > 0 {
-			for _, newAttr := range newExpr.Body().Attributes() {
-				nestedBlock.Body().SetAttributeRaw(providerName, newAttr.Expr().BuildTokens(nil))
-				return true
-			}
+		if updateProviderAttributeVersion(nestedBlock, providerName, version) {
+			updated = true
 		}
 	}
 
+	return updated
+}
+
+func updateProviderBlockSyntax(nestedBlock *hclwrite.Block, providerName, version string) bool {
+	updated := false
+	for _, providerBlock := range nestedBlock.Body().Blocks() {
+		if providerBlock.Type() != providerName {
+			continue
+		}
+		providerBlock.Body().SetAttributeValue("version", cty.StringVal(version))
+		updated = true
+	}
+
+	return updated
+}
+
+// updateProviderAttributeVersion updates the version value within a provider attribute's object expression
+// This handles the attribute-based syntax: aws = { source = "..." version = "..." }
+func updateProviderAttributeVersion(nestedBlock *hclwrite.Block, providerName, newVersion string) bool {
+	objExpr, ok := providerAttributeObject(nestedBlock, providerName)
+	if !ok {
+		return false
+	}
+
+	newObj, hasVersion := providerObjectValues(objExpr, newVersion)
+	if !hasVersion {
+		return false
+	}
+
+	newExprStr := buildProviderObjectExpr(newObj, newVersion)
+	newExpr, diags := hclwrite.ParseConfig([]byte(providerName+" = "+newExprStr), "inline", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return false
+	}
+
+	for _, newAttr := range newExpr.Body().Attributes() {
+		nestedBlock.Body().SetAttributeRaw(providerName, newAttr.Expr().BuildTokens(nil))
+		return true
+	}
+
 	return false
+}
+
+func providerAttributeObject(nestedBlock *hclwrite.Block, providerName string) (*hclsyntax.ObjectConsExpr, bool) {
+	attr, exists := nestedBlock.Body().Attributes()[providerName]
+	if !exists {
+		return nil, false
+	}
+
+	tokens := attr.Expr().BuildTokens(nil)
+	expr, diags := parseExpression(tokens.Bytes(), "inline", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, false
+	}
+
+	objExpr, ok := expr.(*hclsyntax.ObjectConsExpr)
+	return objExpr, ok
+}
+
+func providerObjectValues(objExpr *hclsyntax.ObjectConsExpr, newVersion string) (map[string]string, bool) {
+	newObj := make(map[string]string)
+	hasVersion := false
+
+	for _, item := range objExpr.Items {
+		keyName, ok := providerObjectItemKey(item)
+		if !ok {
+			continue
+		}
+
+		value, ok := providerObjectItemStringValue(item)
+		if !ok {
+			continue
+		}
+
+		if keyName == "version" {
+			newObj[keyName] = newVersion
+			hasVersion = true
+			continue
+		}
+		newObj[keyName] = value
+	}
+
+	return newObj, hasVersion
+}
+
+func providerObjectItemKey(item hclsyntax.ObjectConsItem) (string, bool) {
+	keyExpr, ok := item.KeyExpr.(*hclsyntax.ObjectConsKeyExpr)
+	if !ok {
+		return "", false
+	}
+
+	traversal, ok := keyExpr.Wrapped.(*hclsyntax.ScopeTraversalExpr)
+	if !ok || len(traversal.Traversal) == 0 {
+		return "", false
+	}
+
+	rootName, ok := traversal.Traversal[0].(hcl.TraverseRoot)
+	if !ok {
+		return "", false
+	}
+
+	return rootName.Name, true
+}
+
+func providerObjectItemStringValue(item hclsyntax.ObjectConsItem) (string, bool) {
+	switch expr := item.ValueExpr.(type) {
+	case *hclsyntax.TemplateExpr:
+		if len(expr.Parts) == 0 {
+			return "", false
+		}
+		lit, ok := expr.Parts[0].(*hclsyntax.LiteralValueExpr)
+		if !ok {
+			return "", false
+		}
+		return lit.Val.AsString(), true
+	case *hclsyntax.LiteralValueExpr:
+		if !expr.Val.Type().Equals(cty.String) {
+			return "", false
+		}
+		return expr.Val.AsString(), true
+	default:
+		return "", false
+	}
+}
+
+func buildProviderObjectExpr(newObj map[string]string, newVersion string) string {
+	indent := "      "
+	newExprStr := "{\n"
+
+	if source, ok := newObj["source"]; ok {
+		newExprStr += fmt.Sprintf("%ssource  = %q\n", indent, source)
+	}
+	if _, ok := newObj["version"]; ok {
+		newExprStr += fmt.Sprintf("%sversion = %q\n", indent, newVersion)
+	}
+	for key, value := range newObj {
+		if key != "source" && key != "version" {
+			newExprStr += fmt.Sprintf("%s%s = %q\n", indent, key, value)
+		}
+	}
+
+	return newExprStr + "    }"
 }
 
 // updateModuleVersion parses a Terraform file, finds modules with the specified source,
@@ -753,7 +763,7 @@ func updateProviderAttributeVersion(nestedBlock *hclwrite.Block, providerName, n
 // Returns:
 //   - bool: true if at least one module was updated (or would be updated in dry-run mode), false otherwise
 //   - error: Any error encountered during file reading, parsing, or writing
-func updateModuleVersion(filename, moduleSource, version string, fromVersions []string, ignoreVersions []string, ignorePatterns []string, forceAdd bool, dryRun bool, verbose bool, outputFormat string) (bool, error) {
+func updateModuleVersion(filename, moduleSource, version string, fromVersions, ignoreVersions, ignorePatterns []string, forceAdd, dryRun, verbose bool, outputFormat string) (bool, error) {
 	// Get original file permissions to preserve them when writing
 	fileInfo, err := os.Stat(filename)
 	if err != nil {
@@ -775,84 +785,22 @@ func updateModuleVersion(filename, moduleSource, version string, fromVersions []
 
 	// Track if we made any changes
 	updated := false
+	opts := moduleUpdateOptions{
+		filename:       filename,
+		moduleSource:   moduleSource,
+		version:        version,
+		fromVersions:   fromVersions,
+		ignoreVersions: ignoreVersions,
+		ignorePatterns: ignorePatterns,
+		forceAdd:       forceAdd,
+		verbose:        verbose,
+		outputFormat:   outputFormat,
+	}
 
 	// Iterate through all blocks in the file
 	for _, block := range file.Body().Blocks() {
-		// Look for module blocks with matching source
-		if block.Type() == "module" {
-			// Get the module name from block labels
-			moduleName := ""
-			if len(block.Labels()) > 0 {
-				moduleName = block.Labels()[0]
-			}
-
-			// Get the source attribute
-			sourceAttr := block.Body().GetAttribute("source")
-			if sourceAttr != nil {
-				// Extract the source value
-				sourceTokens := sourceAttr.Expr().BuildTokens(nil)
-				sourceValue := string(sourceTokens.Bytes())
-
-				// Remove whitespace and quotes from the source value
-				sourceValue = trimQuotes(strings.TrimSpace(sourceValue))
-
-				// Skip local modules - they don't have versions
-				if isLocalModule(sourceValue) && sourceValue == moduleSource {
-					fmt.Fprintf(os.Stderr, "Warning: Module %s in %s (source: %s) is a local module and cannot be version-bumped, skipping\n",
-						quote(moduleName, outputFormat), filename, quote(moduleSource, outputFormat))
-					continue
-				}
-
-				// Check if this module's source matches
-				if sourceValue == moduleSource {
-					// Check if module name matches any ignore pattern
-					if shouldIgnoreModule(moduleName, ignorePatterns) {
-						if verbose {
-							fmt.Printf("  ⊗ Skipped module %s in %s (matches ignore pattern)\n", quote(moduleName, outputFormat), filename)
-						}
-						continue
-					}
-
-					// Check if the module has a version attribute
-					versionAttr := block.Body().GetAttribute("version")
-					if versionAttr == nil {
-						if !forceAdd {
-							// Module doesn't have a version attribute - print warning and skip
-							fmt.Fprintf(os.Stderr, "Warning: Module %s in %s (source: %s) has no version attribute, skipping\n",
-								quote(moduleName, outputFormat), filename, quote(moduleSource, outputFormat))
-							continue
-						}
-						// forceAdd is true, so we'll add the version attribute below
-					} else {
-						// Get the current version for filtering
-						versionTokens := versionAttr.Expr().BuildTokens(nil)
-						currentVersion := string(versionTokens.Bytes())
-						currentVersion = trimQuotes(strings.TrimSpace(currentVersion))
-
-						// Check if current version matches any ignore-version filter
-						if len(ignoreVersions) > 0 && containsVersion(ignoreVersions, currentVersion) {
-							// Current version matches an ignore-version filter, skip this module
-							if verbose {
-								fmt.Printf("  ⊗ Skipped module %s in %s (current version %s matches 'ignore-version' filter %v)\n", quote(moduleName, outputFormat), filename, quote(currentVersion, outputFormat), ignoreVersions)
-							}
-							continue
-						}
-
-						// If fromVersions is specified, check if current version matches any in the list
-						if len(fromVersions) > 0 && !containsVersion(fromVersions, currentVersion) {
-							// Current version doesn't match any fromVersion, skip this module
-							if verbose {
-								fmt.Printf("  ⊗ Skipped module %s in %s (current version %s does not match any 'from' filter %v)\n", quote(moduleName, outputFormat), filename, quote(currentVersion, outputFormat), fromVersions)
-							}
-							continue
-						}
-					}
-
-					// Update or add the version attribute
-					block.Body().SetAttributeValue("version", cty.StringVal(version))
-					updated = true
-				}
-			}
+		if updateModuleBlock(block, &opts) {
+			updated = true
 		}
 	}
 
@@ -866,6 +814,95 @@ func updateModuleVersion(filename, moduleSource, version string, fromVersions []
 	}
 
 	return updated, nil
+}
+
+type moduleUpdateOptions struct {
+	filename       string
+	moduleSource   string
+	version        string
+	fromVersions   []string
+	ignoreVersions []string
+	ignorePatterns []string
+	forceAdd       bool
+	verbose        bool
+	outputFormat   string
+}
+
+func updateModuleBlock(block *hclwrite.Block, opts *moduleUpdateOptions) bool {
+	if block.Type() != "module" {
+		return false
+	}
+
+	moduleName := moduleBlockName(block)
+	sourceValue, ok := moduleSourceValue(block)
+	if !ok || sourceValue != opts.moduleSource {
+		return false
+	}
+
+	if isLocalModule(sourceValue) {
+		fmt.Fprintf(os.Stderr, "Warning: Module %s in %s (source: %s) is a local module and cannot be version-bumped, skipping\n",
+			quote(moduleName, opts.outputFormat), opts.filename, quote(opts.moduleSource, opts.outputFormat))
+		return false
+	}
+
+	if shouldIgnoreModule(moduleName, opts.ignorePatterns) {
+		if opts.verbose {
+			fmt.Printf("  ⊗ Skipped module %s in %s (matches ignore pattern)\n", quote(moduleName, opts.outputFormat), opts.filename)
+		}
+		return false
+	}
+
+	versionAttr := block.Body().GetAttribute("version")
+	if versionAttr == nil {
+		if !opts.forceAdd {
+			fmt.Fprintf(os.Stderr, "Warning: Module %s in %s (source: %s) has no version attribute, skipping\n",
+				quote(moduleName, opts.outputFormat), opts.filename, quote(opts.moduleSource, opts.outputFormat))
+			return false
+		}
+	} else if shouldSkipModuleVersion(moduleName, attributeStringValue(versionAttr), opts) {
+		return false
+	}
+
+	block.Body().SetAttributeValue("version", cty.StringVal(opts.version))
+	return true
+}
+
+func moduleBlockName(block *hclwrite.Block) string {
+	if len(block.Labels()) == 0 {
+		return ""
+	}
+	return block.Labels()[0]
+}
+
+func moduleSourceValue(block *hclwrite.Block) (string, bool) {
+	sourceAttr := block.Body().GetAttribute("source")
+	if sourceAttr == nil {
+		return "", false
+	}
+	return attributeStringValue(sourceAttr), true
+}
+
+func attributeStringValue(attr *hclwrite.Attribute) string {
+	tokens := attr.Expr().BuildTokens(nil)
+	return trimQuotes(strings.TrimSpace(string(tokens.Bytes())))
+}
+
+func shouldSkipModuleVersion(moduleName, currentVersion string, opts *moduleUpdateOptions) bool {
+	if len(opts.ignoreVersions) > 0 && containsVersion(opts.ignoreVersions, currentVersion) {
+		if opts.verbose {
+			fmt.Printf("  ⊗ Skipped module %s in %s (current version %s matches 'ignore-version' filter %v)\n", quote(moduleName, opts.outputFormat), opts.filename, quote(currentVersion, opts.outputFormat), opts.ignoreVersions)
+		}
+		return true
+	}
+
+	if len(opts.fromVersions) > 0 && !containsVersion(opts.fromVersions, currentVersion) {
+		if opts.verbose {
+			fmt.Printf("  ⊗ Skipped module %s in %s (current version %s does not match any 'from' filter %v)\n", quote(moduleName, opts.outputFormat), opts.filename, quote(currentVersion, opts.outputFormat), opts.fromVersions)
+		}
+		return true
+	}
+
+	return false
 }
 
 // isLocalModule checks if a module source is a local path.
@@ -958,57 +995,59 @@ func matchPattern(name, pattern string) bool {
 	// Split pattern by '*' to get the literal parts
 	parts := strings.Split(pattern, "*")
 
-	// Check if name starts with first part (if not empty)
-	if parts[0] != "" && !strings.HasPrefix(name, parts[0]) {
+	if !patternBoundsMatch(name, parts) {
 		return false
 	}
 
-	// Check if name ends with last part (if not empty)
-	if parts[len(parts)-1] != "" && !strings.HasSuffix(name, parts[len(parts)-1]) {
+	pos, ok := orderedMiddlePartsEnd(name, parts)
+	return ok && suffixDoesNotOverlap(name, parts, pos)
+}
+
+func patternBoundsMatch(name string, parts []string) bool {
+	first := parts[0]
+	last := parts[len(parts)-1]
+
+	if first != "" && !strings.HasPrefix(name, first) {
+		return false
+	}
+	if last != "" && !strings.HasSuffix(name, last) {
 		return false
 	}
 
-	// Ensure there's enough length for both prefix and suffix when both are present
-	if parts[0] != "" && parts[len(parts)-1] != "" {
-		minLength := len(parts[0]) + len(parts[len(parts)-1])
-		if len(name) < minLength {
-			return false
-		}
-	}
+	return first == "" || last == "" || len(name) >= len(first)+len(last)
+}
 
-	// For middle parts, check they appear in order
+func orderedMiddlePartsEnd(name string, parts []string) (int, bool) {
 	pos := 0
 	for i, part := range parts {
 		if part == "" {
 			continue
 		}
-		// Skip the first part check (already done above)
 		if i == 0 {
 			pos = len(part)
 			continue
 		}
-		// Skip the last part check (already done above)
 		if i == len(parts)-1 {
 			break
 		}
-		// Find the part in the remaining string
+
 		idx := strings.Index(name[pos:], part)
 		if idx == -1 {
-			return false
+			return 0, false
 		}
 		pos += idx + len(part)
 	}
 
-	// Ensure middle parts don't overlap with the suffix
-	// The suffix must start at or after the current position
-	if parts[len(parts)-1] != "" {
-		suffixStart := len(name) - len(parts[len(parts)-1])
-		if pos > suffixStart {
-			return false
-		}
+	return pos, true
+}
+
+func suffixDoesNotOverlap(name string, parts []string, pos int) bool {
+	last := parts[len(parts)-1]
+	if last == "" {
+		return true
 	}
 
-	return true
+	return pos <= len(name)-len(last)
 }
 
 // trimQuotes removes surrounding single or double quotes from a string.

--- a/main_coverage_test.go
+++ b/main_coverage_test.go
@@ -20,19 +20,19 @@ type exitCall struct {
 	code int
 }
 
-func stubExit(t *testing.T) (func(), *int) {
+func stubExit(t *testing.T) (restore func(), code *int) {
 	t.Helper()
 	hookMu.Lock()
 	original := exitFunc
-	code := -1
+	exitCode := -1
 	exitFunc = func(c int) {
-		code = c
+		exitCode = c
 		panic(exitCall{code: c})
 	}
 	return func() {
 		exitFunc = original
 		hookMu.Unlock()
-	}, &code
+	}, &exitCode
 }
 
 func withFlagArgs(t *testing.T, args []string, fn func()) {
@@ -130,7 +130,7 @@ func TestMainExecutionPath(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(`module "example" { source = "example/module" version = "1.0.0" }`), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(`module "example" { source = "example/module" version = "1.0.0" }`), 0o644); err != nil {
 		t.Fatalf("failed to write terraform file: %v", err)
 	}
 
@@ -164,12 +164,12 @@ func TestMainConfigFilePath(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(`terraform { required_version = ">= 0.13" }`), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(`terraform { required_version = ">= 0.13" }`), 0o644); err != nil {
 		t.Fatalf("failed to create terraform file: %v", err)
 	}
 
 	configFile := filepath.Join(tmpDir, "config.yml")
-	if err := os.WriteFile(configFile, []byte(`terraform_version: ">= 1.2"`), 0644); err != nil {
+	if err := os.WriteFile(configFile, []byte(`terraform_version: ">= 1.2"`), 0o644); err != nil {
 		t.Fatalf("failed to write config: %v", err)
 	}
 
@@ -289,7 +289,7 @@ func TestFindMatchingFilesFailures(t *testing.T) {
 func TestFindMatchingFilesDryRunMessage(t *testing.T) {
 	tmpDir := t.TempDir()
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte("# test"), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte("# test"), 0o644); err != nil {
 		t.Fatalf("failed to write file: %v", err)
 	}
 
@@ -335,7 +335,7 @@ func TestUpdateTerraformVersionReadError(t *testing.T) {
 	}
 	tmpDir := t.TempDir()
 	file := filepath.Join(tmpDir, "unreadable.tf")
-	if err := os.WriteFile(file, []byte("content"), 0222); err != nil {
+	if err := os.WriteFile(file, []byte("content"), 0o222); err != nil {
 		t.Fatalf("failed to create file: %v", err)
 	}
 
@@ -352,7 +352,7 @@ func TestUpdateTerraformVersionWriteError(t *testing.T) {
 	tmpDir := t.TempDir()
 	file := filepath.Join(tmpDir, "main.tf")
 	content := `terraform { required_version = ">= 0.13" }`
-	if err := os.WriteFile(file, []byte(content), 0444); err != nil {
+	if err := os.WriteFile(file, []byte(content), 0o444); err != nil {
 		t.Fatalf("failed to create file: %v", err)
 	}
 
@@ -368,7 +368,7 @@ func TestUpdateProviderVersionReadError(t *testing.T) {
 	}
 	tmpDir := t.TempDir()
 	file := filepath.Join(tmpDir, "provider.tf")
-	if err := os.WriteFile(file, []byte("content"), 0222); err != nil {
+	if err := os.WriteFile(file, []byte("content"), 0o222); err != nil {
 		t.Fatalf("failed to create file: %v", err)
 	}
 
@@ -392,7 +392,7 @@ func TestUpdateProviderVersionWriteError(t *testing.T) {
     }
   }
 }`
-	if err := os.WriteFile(file, []byte(content), 0444); err != nil {
+	if err := os.WriteFile(file, []byte(content), 0o444); err != nil {
 		t.Fatalf("failed to create file: %v", err)
 	}
 
@@ -681,7 +681,7 @@ func TestUpdateModuleVersionVerboseIgnore(t *testing.T) {
   source  = "example/module"
   version = "1.0.0"
 }`
-	if err := os.WriteFile(tfFile, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(content), 0o644); err != nil {
 		t.Fatalf("failed to create file: %v", err)
 	}
 

--- a/main_integration_test.go
+++ b/main_integration_test.go
@@ -112,7 +112,7 @@ func TestProcessTerraformVersionWithErrors(t *testing.T) {
 
 	// Create a file with invalid HCL
 	invalidFile := filepath.Join(tmpDir, "invalid.tf")
-	if err := os.WriteFile(invalidFile, []byte("this is not valid HCL {{{"), 0644); err != nil {
+	if err := os.WriteFile(invalidFile, []byte("this is not valid HCL {{{"), 0o644); err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
 
@@ -132,7 +132,7 @@ func TestProcessTerraformVersionDryRun(t *testing.T) {
   required_version = ">= 1.0"
 }`
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
 
@@ -160,7 +160,7 @@ func TestProcessProviderVersionWithErrors(t *testing.T) {
 
 	// Create a file with invalid HCL
 	invalidFile := filepath.Join(tmpDir, "invalid.tf")
-	if err := os.WriteFile(invalidFile, []byte("this is not valid HCL {{{"), 0644); err != nil {
+	if err := os.WriteFile(invalidFile, []byte("this is not valid HCL {{{"), 0o644); err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
 
@@ -185,7 +185,7 @@ func TestProcessProviderVersionDryRun(t *testing.T) {
   }
 }`
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
 
@@ -220,7 +220,7 @@ func TestProcessProviderVersionMarkdownOutput(t *testing.T) {
   }
 }`
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
 
@@ -251,7 +251,7 @@ func TestUpdateTerraformVersionNoTerraformBlock(t *testing.T) {
   instance_type = "t2.micro"
 }`
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
 
@@ -270,7 +270,7 @@ func TestUpdateTerraformVersionInvalidFile(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	invalidFile := filepath.Join(tmpDir, "invalid.tf")
-	if err := os.WriteFile(invalidFile, []byte("this is not valid HCL {{{"), 0644); err != nil {
+	if err := os.WriteFile(invalidFile, []byte("this is not valid HCL {{{"), 0o644); err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
 
@@ -304,7 +304,7 @@ func TestUpdateProviderVersionNoProviderBlock(t *testing.T) {
   required_version = ">= 1.0"
 }`
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
 
@@ -323,7 +323,7 @@ func TestUpdateProviderVersionInvalidFile(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	invalidFile := filepath.Join(tmpDir, "invalid.tf")
-	if err := os.WriteFile(invalidFile, []byte("this is not valid HCL {{{"), 0644); err != nil {
+	if err := os.WriteFile(invalidFile, []byte("this is not valid HCL {{{"), 0o644); err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
 
@@ -362,7 +362,7 @@ func TestUpdateProviderVersionDifferentProvider(t *testing.T) {
   }
 }`
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(tfContent), 0644); err != nil {
+	if err := os.WriteFile(tfFile, []byte(tfContent), 0o644); err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -375,7 +375,7 @@ module "s3" {
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, "test.tf")
 
-			err := os.WriteFile(tmpFile, []byte(tt.inputContent), 0644)
+			err := os.WriteFile(tmpFile, []byte(tt.inputContent), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create temp file: %v", err)
 			}
@@ -434,7 +434,7 @@ resource "aws_instance" "example" {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	err := os.WriteFile(tmpFile, []byte(input), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -496,7 +496,7 @@ func TestUpdateModuleVersionEmptyFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "empty.tf")
 
-	err := os.WriteFile(tmpFile, []byte(""), 0644)
+	err := os.WriteFile(tmpFile, []byte(""), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -536,7 +536,7 @@ func TestUpdateModuleVersionMultipleVersionFormats(t *testing.T) {
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, "test.tf")
 
-			err := os.WriteFile(tmpFile, []byte(input), 0644)
+			err := os.WriteFile(tmpFile, []byte(input), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create temp file: %v", err)
 			}
@@ -555,7 +555,7 @@ func TestUpdateModuleVersionMultipleVersionFormats(t *testing.T) {
 				t.Fatalf("Failed to read updated file: %v", err)
 			}
 
-			expectedVersion := fmt.Sprintf(`version = "%s"`, tt.version)
+			expectedVersion := fmt.Sprintf("version = %q", tt.version)
 			if !strings.Contains(string(content), expectedVersion) {
 				t.Errorf("Expected version %q not found in content:\n%s", expectedVersion, string(content))
 			}
@@ -573,7 +573,7 @@ func TestUpdateModuleVersionGitSource(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	err := os.WriteFile(tmpFile, []byte(input), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -612,7 +612,7 @@ variable "region" {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	err := os.WriteFile(tmpFile, []byte(input), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -643,7 +643,7 @@ module "registry_module" {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	err := os.WriteFile(tmpFile, []byte(input), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -696,7 +696,7 @@ module "vpc3" {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	err := os.WriteFile(tmpFile, []byte(input), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -758,7 +758,7 @@ module "registry_module" {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	err := os.WriteFile(tmpFile, []byte(input), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -798,7 +798,7 @@ module "registry_module" {
 }`
 
 	tmpFile2 := filepath.Join(tmpDir, "test2.tf")
-	err = os.WriteFile(tmpFile2, []byte(input2), 0644)
+	err = os.WriteFile(tmpFile2, []byte(input2), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -868,7 +868,7 @@ func TestUpdateModuleVersionLocalModulesSkipped(t *testing.T) {
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, "test.tf")
 
-			err := os.WriteFile(tmpFile, []byte(tt.inputContent), 0644)
+			err := os.WriteFile(tmpFile, []byte(tt.inputContent), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create temp file: %v", err)
 			}
@@ -931,7 +931,7 @@ output "vpc_id" {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	err := os.WriteFile(tmpFile, []byte(input), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -1114,7 +1114,7 @@ module "s3" {
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, "test.tf")
 
-			err := os.WriteFile(tmpFile, []byte(tt.inputContent), 0644)
+			err := os.WriteFile(tmpFile, []byte(tt.inputContent), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create temp file: %v", err)
 			}
@@ -1164,7 +1164,7 @@ module "vpc" {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(inputContent), 0644)
+	err := os.WriteFile(tmpFile, []byte(inputContent), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -1270,7 +1270,7 @@ module "valid" {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	err := os.WriteFile(tmpFile, []byte(input), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -1335,7 +1335,7 @@ func TestUpdateModuleVersionSpecialCharactersInSource(t *testing.T) {
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, "test.tf")
 
-			err := os.WriteFile(tmpFile, []byte(input), 0644)
+			err := os.WriteFile(tmpFile, []byte(input), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create temp file: %v", err)
 			}
@@ -1354,7 +1354,7 @@ func TestUpdateModuleVersionSpecialCharactersInSource(t *testing.T) {
 				t.Fatalf("Failed to read file: %v", err)
 			}
 
-			expectedVersion := fmt.Sprintf(`version = "%s"`, tt.version)
+			expectedVersion := fmt.Sprintf("version = %q", tt.version)
 			if !strings.Contains(string(content), expectedVersion) {
 				t.Errorf("Expected version %q not found in content", expectedVersion)
 			}
@@ -1372,7 +1372,7 @@ func TestUpdateModuleVersionLongVersionString(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	err := os.WriteFile(tmpFile, []byte(input), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -1394,7 +1394,7 @@ func TestUpdateModuleVersionLongVersionString(t *testing.T) {
 		t.Fatalf("Failed to read file: %v", err)
 	}
 
-	expectedVersion := fmt.Sprintf(`version = "%s"`, longVersion)
+	expectedVersion := fmt.Sprintf("version = %q", longVersion)
 	if !strings.Contains(string(content), expectedVersion) {
 		t.Error("Long version string was not set correctly")
 	}
@@ -1410,7 +1410,7 @@ func TestUpdateModuleVersionAbsolutePathLocalModule(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	err := os.WriteFile(tmpFile, []byte(input), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -1447,7 +1447,7 @@ func TestUpdateModuleVersionModuleWithNoLabels(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	err := os.WriteFile(tmpFile, []byte(input), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -1502,7 +1502,7 @@ func TestUpdateModuleVersionWhitespaceVariations(t *testing.T) {
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, "test.tf")
 
-			err := os.WriteFile(tmpFile, []byte(tt.inputContent), 0644)
+			err := os.WriteFile(tmpFile, []byte(tt.inputContent), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create temp file: %v", err)
 			}
@@ -1540,7 +1540,7 @@ func TestUpdateModuleVersionRegistryModuleWithoutVersionNoForceAdd(t *testing.T)
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	err := os.WriteFile(tmpFile, []byte(input), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -2559,7 +2559,7 @@ func TestOutputFormatText(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(inputContent), 0644)
+	err := os.WriteFile(tmpFile, []byte(inputContent), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -2615,7 +2615,7 @@ func TestOutputFormatMarkdown(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(inputContent), 0644)
+	err := os.WriteFile(tmpFile, []byte(inputContent), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}

--- a/terraform_provider_test.go
+++ b/terraform_provider_test.go
@@ -96,7 +96,7 @@ terraform {
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, "test.tf")
 
-			err := os.WriteFile(tmpFile, []byte(tt.inputContent), 0644)
+			err := os.WriteFile(tmpFile, []byte(tt.inputContent), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create temp file: %v", err)
 			}
@@ -145,7 +145,7 @@ func TestUpdateTerraformVersionDryRun(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(inputContent), 0644)
+	err := os.WriteFile(tmpFile, []byte(inputContent), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -283,7 +283,7 @@ func TestUpdateProviderVersion(t *testing.T) {
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, "test.tf")
 
-			err := os.WriteFile(tmpFile, []byte(tt.inputContent), 0644)
+			err := os.WriteFile(tmpFile, []byte(tt.inputContent), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create temp file: %v", err)
 			}
@@ -337,7 +337,7 @@ func TestUpdateProviderVersionDryRun(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test.tf")
 
-	err := os.WriteFile(tmpFile, []byte(inputContent), 0644)
+	err := os.WriteFile(tmpFile, []byte(inputContent), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -392,13 +392,13 @@ module "vpc" {
 	file2 := filepath.Join(tmpDir, "vpc.tf")
 	file3 := filepath.Join(tmpDir, "s3.tf")
 
-	if err := os.WriteFile(file1, []byte(file1Content), 0644); err != nil {
+	if err := os.WriteFile(file1, []byte(file1Content), 0o644); err != nil {
 		t.Fatalf("Failed to create file1: %v", err)
 	}
-	if err := os.WriteFile(file2, []byte(file2Content), 0644); err != nil {
+	if err := os.WriteFile(file2, []byte(file2Content), 0o644); err != nil {
 		t.Fatalf("Failed to create file2: %v", err)
 	}
-	if err := os.WriteFile(file3, []byte(file3Content), 0644); err != nil {
+	if err := os.WriteFile(file3, []byte(file3Content), 0o644); err != nil {
 		t.Fatalf("Failed to create file3: %v", err)
 	}
 
@@ -467,13 +467,13 @@ func TestProcessProviderVersion(t *testing.T) {
 	file2 := filepath.Join(tmpDir, "vpc.tf")
 	file3 := filepath.Join(tmpDir, "s3.tf")
 
-	if err := os.WriteFile(file1, []byte(file1Content), 0644); err != nil {
+	if err := os.WriteFile(file1, []byte(file1Content), 0o644); err != nil {
 		t.Fatalf("Failed to create file1: %v", err)
 	}
-	if err := os.WriteFile(file2, []byte(file2Content), 0644); err != nil {
+	if err := os.WriteFile(file2, []byte(file2Content), 0o644); err != nil {
 		t.Fatalf("Failed to create file2: %v", err)
 	}
-	if err := os.WriteFile(file3, []byte(file3Content), 0644); err != nil {
+	if err := os.WriteFile(file3, []byte(file3Content), 0o644); err != nil {
 		t.Fatalf("Failed to create file3: %v", err)
 	}
 
@@ -597,7 +597,7 @@ func TestUpdateProviderVersionAttributeSyntax(t *testing.T) {
 			defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 			// Write input content
-			if err := os.WriteFile(tmpFile.Name(), []byte(tt.inputContent), 0644); err != nil {
+			if err := os.WriteFile(tmpFile.Name(), []byte(tt.inputContent), 0o644); err != nil {
 				t.Fatalf("Failed to write temp file: %v", err)
 			}
 
@@ -652,7 +652,7 @@ terraform {
 	}
 	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
-	if err := os.WriteFile(tmpFile.Name(), []byte(inputContent), 0644); err != nil {
+	if err := os.WriteFile(tmpFile.Name(), []byte(inputContent), 0o644); err != nil {
 		t.Fatalf("Failed to write temp file: %v", err)
 	}
 
@@ -718,10 +718,10 @@ func TestProcessProviderVersionAttributeSyntax(t *testing.T) {
 	file1 := filepath.Join(tmpDir, "test1.tf")
 	file2 := filepath.Join(tmpDir, "test2.tf")
 
-	if err := os.WriteFile(file1, []byte(file1Content), 0644); err != nil {
+	if err := os.WriteFile(file1, []byte(file1Content), 0o644); err != nil {
 		t.Fatalf("Failed to write file1: %v", err)
 	}
-	if err := os.WriteFile(file2, []byte(file2Content), 0644); err != nil {
+	if err := os.WriteFile(file2, []byte(file2Content), 0o644); err != nil {
 		t.Fatalf("Failed to write file2: %v", err)
 	}
 

--- a/validation_test.go
+++ b/validation_test.go
@@ -67,7 +67,7 @@ func TestInvalidGlobPatternsInProduction(t *testing.T) {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.0.0"
 }`
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestValidationOfModuleUpdates(t *testing.T) {
 			tmpDir := t.TempDir()
 			configFile := filepath.Join(tmpDir, "config.yml")
 
-			err := os.WriteFile(configFile, []byte(tt.configYAML), 0644)
+			err := os.WriteFile(configFile, []byte(tt.configYAML), 0o644)
 			if err != nil {
 				t.Fatalf("Failed to create config file: %v", err)
 			}
@@ -185,7 +185,7 @@ func TestFileSystemEdgeCases(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			deepPath = filepath.Join(deepPath, "dir")
 		}
-		err := os.MkdirAll(deepPath, 0755)
+		err := os.MkdirAll(deepPath, 0o755)
 		if err != nil {
 			t.Fatalf("Failed to create deep directory: %v", err)
 		}
@@ -196,7 +196,7 @@ func TestFileSystemEdgeCases(t *testing.T) {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.0.0"
 }`
-		err = os.WriteFile(testFile, []byte(content), 0644)
+		err = os.WriteFile(testFile, []byte(content), 0o644)
 		if err != nil {
 			t.Fatalf("Failed to create test file: %v", err)
 		}
@@ -227,7 +227,7 @@ func TestConcurrentSafetyConsiderations(t *testing.T) {
   source  = "terraform-aws-modules/vpc/aws"
   version = "1.0.0"
 }`
-		err := os.WriteFile(testFile, []byte(content), 0644)
+		err := os.WriteFile(testFile, []byte(content), 0o644)
 		if err != nil {
 			t.Fatalf("Failed to create test file: %v", err)
 		}
@@ -260,7 +260,7 @@ func TestLargeFileHandling(t *testing.T) {
 		content += "}\n\n"
 	}
 
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create large test file: %v", err)
 	}
@@ -317,7 +317,7 @@ func TestErrorMessageQuality(t *testing.T) {
 
 		// Create file with invalid HCL
 		invalidContent := `module "test" {`
-		err := os.WriteFile(testFile, []byte(invalidContent), 0644)
+		err := os.WriteFile(testFile, []byte(invalidContent), 0o644)
 		if err != nil {
 			t.Fatalf("Failed to create test file: %v", err)
 		}


### PR DESCRIPTION
## Summary

Fixes the current `golangci-lint run --timeout=5m` failures.

## Changes

- Refactored high-complexity config, provider, module update, and wildcard matching code into focused helpers.
- Updated test helpers and assertions to satisfy `gocritic` while preserving behavior.
- Normalized Go permission literals to `0o...` syntax and applied related mechanical lint cleanups.

## Root Cause

The linter was failing on newly enforced/expanded `gocritic` and `gocyclo` findings, plus `staticcheck` simplifications in tests. The initial local lint attempt also failed inside the sandbox because Go package loading needed access to the external module/cache directories.

## Validation

- `golangci-lint run --timeout=5m` -> `0 issues`
- `go test -v -race -coverprofile=coverage.out -covermode=atomic ./...` -> pass, 98.9% coverage
- `git diff --check` -> clean
