### PR TITLE
feat: prepare GitHub Actions state-branch automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ coverage.html
 # Go workspace file
 go.work
 
+# Local feature worktrees
+.worktrees/
+
 # Binary output
 tf-version-bump
 tf-version-bump-*

--- a/cli_functions_test.go
+++ b/cli_functions_test.go
@@ -440,7 +440,9 @@ modules:
 	}
 
 	// Run the function
-	runConfigFileMode(files, flags)
+	if err := runConfigFileMode(files, flags); err != nil {
+		t.Fatalf("runConfigFileMode failed: %v", err)
+	}
 
 	// Verify the file was updated
 	content, err := os.ReadFile(tfFile)
@@ -485,7 +487,9 @@ func TestRunConfigFileModeDryRun(t *testing.T) {
 		output:     "text",
 	}
 
-	runConfigFileMode(files, flags)
+	if err := runConfigFileMode(files, flags); err != nil {
+		t.Fatalf("runConfigFileMode failed: %v", err)
+	}
 
 	// Verify file was NOT modified
 	content, err := os.ReadFile(tfFile)
@@ -517,7 +521,9 @@ func TestRunCLIModeWithTerraformVersion(t *testing.T) {
 		output:           "text",
 	}
 
-	runCLIMode(files, flags)
+	if err := runCLIMode(files, flags); err != nil {
+		t.Fatalf("runCLIMode failed: %v", err)
+	}
 
 	// Verify the file was updated
 	content, err := os.ReadFile(tfFile)
@@ -555,7 +561,9 @@ func TestRunCLIModeWithProvider(t *testing.T) {
 		output:       "text",
 	}
 
-	runCLIMode(files, flags)
+	if err := runCLIMode(files, flags); err != nil {
+		t.Fatalf("runCLIMode failed: %v", err)
+	}
 
 	// Verify the file was updated
 	content, err := os.ReadFile(tfFile)
@@ -590,7 +598,9 @@ func TestRunCLIModeWithModule(t *testing.T) {
 		output:       "text",
 	}
 
-	runCLIMode(files, flags)
+	if err := runCLIMode(files, flags); err != nil {
+		t.Fatalf("runCLIMode failed: %v", err)
+	}
 
 	// Verify the file was updated
 	content, err := os.ReadFile(tfFile)

--- a/cli_functions_test.go
+++ b/cli_functions_test.go
@@ -576,6 +576,44 @@ func TestRunCLIModeWithProvider(t *testing.T) {
 	}
 }
 
+func TestRunCLIModeTerraformAllFilesSucceed(t *testing.T) {
+	tmpDir := t.TempDir()
+	files := []string{
+		filepath.Join(tmpDir, "01.tf"),
+		filepath.Join(tmpDir, "02.tf"),
+	}
+	for _, file := range files {
+		if err := os.WriteFile(file, []byte(`terraform {
+  required_version = ">= 1.0"
+}
+`), 0o644); err != nil {
+			t.Fatalf("failed to write Terraform file: %v", err)
+		}
+	}
+
+	stdout, diagnostic, runnerErr := captureRunnerOutput(t, func() error {
+		return runCLIMode(files, &cliFlags{terraformVersion: ">= 1.5", output: "text"})
+	})
+	if runnerErr != nil {
+		t.Fatalf("expected all valid files to succeed: %v", runnerErr)
+	}
+	if diagnostic != "" {
+		t.Errorf("expected no diagnostics, got %q", diagnostic)
+	}
+	if !strings.Contains(stdout, "Successfully updated Terraform version in 2 file(s)") {
+		t.Errorf("expected existing summary in stdout, got %q", stdout)
+	}
+	for _, file := range files {
+		content, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("failed to read updated Terraform file: %v", err)
+		}
+		if !strings.Contains(string(content), `required_version = ">= 1.5"`) {
+			t.Errorf("expected %s to be updated, got: %s", file, content)
+		}
+	}
+}
+
 // TestRunCLIModeWithModule tests CLI mode with module
 func TestRunCLIModeWithModule(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/cli_functions_test.go
+++ b/cli_functions_test.go
@@ -614,7 +614,6 @@ func TestRunCLIModeTerraformAllFilesSucceed(t *testing.T) {
 	}
 }
 
-// TestRunCLIModeWithModule tests CLI mode with module
 func TestRunCLIModeProviderAllFilesSucceed(t *testing.T) {
 	tmpDir := t.TempDir()
 	files := []string{filepath.Join(tmpDir, "01.tf"), filepath.Join(tmpDir, "02.tf")}

--- a/cli_functions_test.go
+++ b/cli_functions_test.go
@@ -615,6 +615,47 @@ func TestRunCLIModeTerraformAllFilesSucceed(t *testing.T) {
 }
 
 // TestRunCLIModeWithModule tests CLI mode with module
+func TestRunCLIModeProviderAllFilesSucceed(t *testing.T) {
+	tmpDir := t.TempDir()
+	files := []string{filepath.Join(tmpDir, "01.tf"), filepath.Join(tmpDir, "02.tf")}
+	for _, file := range files {
+		if err := os.WriteFile(file, []byte(`terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+`), 0o644); err != nil {
+			t.Fatalf("failed to write Terraform file: %v", err)
+		}
+	}
+
+	stdout, diagnostic, runnerErr := captureRunnerOutput(t, func() error {
+		return runCLIMode(files, &cliFlags{providerName: "aws", toVersion: "~> 5.0", output: "text"})
+	})
+	if runnerErr != nil {
+		t.Fatalf("expected all valid files to succeed: %v", runnerErr)
+	}
+	if diagnostic != "" {
+		t.Errorf("expected no diagnostics, got %q", diagnostic)
+	}
+	if !strings.Contains(stdout, "Successfully updated 'aws' provider version in 2 file(s)") {
+		t.Errorf("expected existing summary in stdout, got %q", stdout)
+	}
+	for _, file := range files {
+		content, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("failed to read updated Terraform file: %v", err)
+		}
+		if !strings.Contains(string(content), `version = "~> 5.0"`) {
+			t.Errorf("expected %s to be updated, got: %s", file, content)
+		}
+	}
+}
+
+// TestRunCLIModeWithModule tests CLI mode with module
 func TestRunCLIModeWithModule(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/coverage_test.go
+++ b/coverage_test.go
@@ -547,7 +547,7 @@ module "s3" {
 			os.Stdout = w
 			defer func() { os.Stdout = oldStdout }()
 
-			totalUpdates := processFiles([]string{tfFile}, tt.updates, flags)
+			totalUpdates, _ := processFiles([]string{tfFile}, tt.updates, flags)
 
 			if err := w.Close(); err != nil {
 				t.Fatalf("failed to close pipe writer: %v", err)
@@ -632,7 +632,7 @@ func TestProcessFilesWithFromVersionFilter(t *testing.T) {
 			os.Stdout = w
 			defer func() { os.Stdout = oldStdout }()
 
-			totalUpdates := processFiles([]string{tfFile}, updates, flags)
+			totalUpdates, _ := processFiles([]string{tfFile}, updates, flags)
 
 			if err := w.Close(); err != nil {
 				t.Fatalf("failed to close pipe writer: %v", err)
@@ -695,7 +695,7 @@ func TestProcessFilesMultipleFiles(t *testing.T) {
 	os.Stdout = w
 	defer func() { os.Stdout = oldStdout }()
 
-	totalUpdates := processFiles([]string{tfFile1, tfFile2}, updates, flags)
+	totalUpdates, _ := processFiles([]string{tfFile1, tfFile2}, updates, flags)
 
 	if err := w.Close(); err != nil {
 		t.Fatalf("failed to close pipe writer: %v", err)
@@ -837,7 +837,7 @@ func TestProcessFilesWithVerbose(t *testing.T) {
 	os.Stdout = w
 	defer func() { os.Stdout = oldStdout }()
 
-	totalUpdates := processFiles([]string{tfFile}, updates, flags)
+	totalUpdates, _ := processFiles([]string{tfFile}, updates, flags)
 
 	if err := w.Close(); err != nil {
 		t.Fatalf("failed to close pipe writer: %v", err)
@@ -893,7 +893,7 @@ func TestProcessFilesMarkdownOutput(t *testing.T) {
 	os.Stdout = w
 	defer func() { os.Stdout = oldStdout }()
 
-	totalUpdates := processFiles([]string{tfFile}, updates, flags)
+	totalUpdates, _ := processFiles([]string{tfFile}, updates, flags)
 
 	if err := w.Close(); err != nil {
 		t.Fatalf("failed to close pipe writer: %v", err)
@@ -981,7 +981,7 @@ func TestProcessFilesOutputMessages(t *testing.T) {
 			os.Stdout = w
 			defer func() { os.Stdout = oldStdout }()
 
-			processFiles([]string{tfFile}, updates, flags)
+			_, _ = processFiles([]string{tfFile}, updates, flags)
 
 			if err := w.Close(); err != nil {
 				t.Fatalf("failed to close pipe writer: %v", err)
@@ -1010,7 +1010,7 @@ func TestProcessFilesError(t *testing.T) {
 		{Source: "test/module", Version: "1.0.0"},
 	}
 
-	totalUpdates := processFiles([]string{"/nonexistent/path/file.tf"}, updates, flags)
+	totalUpdates, _ := processFiles([]string{"/nonexistent/path/file.tf"}, updates, flags)
 
 	// Should return 0 updates but handle the error gracefully
 	// Note: The actual error is logged via log.Printf which uses the default logger
@@ -1199,7 +1199,7 @@ module "legacy-vpc" {
 			os.Stdout = w
 			defer func() { os.Stdout = oldStdout }()
 
-			totalUpdates := processFiles([]string{tfFile}, updates, flags)
+			totalUpdates, _ := processFiles([]string{tfFile}, updates, flags)
 
 			if err := w.Close(); err != nil {
 				t.Fatalf("failed to close pipe writer: %v", err)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -253,9 +253,9 @@ An invalid pattern or a pattern with no matching files is a fatal command error.
 - Parse, stat, read, and write errors for an individual file are logged and processing continues
   with later files or updates.
 
-Because individual processing errors are logged rather than returned as a final failure, read
-the complete output in automation; a zero exit status does not by itself prove that every file
-was updated successfully.
+File-level errors do not stop processing: the command writes every diagnostic and continues with
+later files or configured updates. After printing the final summary, it exits non-zero if any
+selected operation encountered a file-level error.
 
 ## File-writing behaviour
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -254,8 +254,8 @@ An invalid pattern or a pattern with no matching files is a fatal command error.
   with later files or updates.
 
 File-level errors do not stop processing: the command writes every diagnostic and continues with
-later files or configured updates. After printing the final summary, it exits non-zero if any
-selected operation encountered a file-level error.
+later files or configured updates. After processing, and after any summary, it exits non-zero if
+any selected operation encountered a file-level error.
 
 ## File-writing behaviour
 

--- a/docs/superpowers/plans/2026-08-18-github-actions-branch-automation.md
+++ b/docs/superpowers/plans/2026-08-18-github-actions-branch-automation.md
@@ -1,0 +1,1086 @@
+# GitHub Actions State-Branch Automation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a copyable GitHub Actions example that safely updates, initialises, validates, and
+opens one managed pull request or failure issue for each selected Terraform state branch.
+
+**Architecture:** Two Bash helpers provide branch discovery and per-branch preparation,
+validation, and reconciliation. A four-stage reusable workflow runs target-controlled Terraform
+only in credential-free jobs, uploads the publishable candidate before provider execution, and
+publishes from a fresh protected reconciliation runner. Production and non-production caller
+workflows supply separate prefix policy, schedules, and configurations.
+
+**Tech Stack:** Go 1.25, Bash, Git, `jq`, Terraform 1.15.5, GitHub CLI, GitHub Actions,
+actionlint 1.7.12
+
+**Spec:** `docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md`
+
+## Global Constraints
+
+- Work on a feature branch or isolated worktree created with `superpowers:using-git-worktrees`;
+  never implement directly on `main`.
+- Use `/Users/dan/.codex/bin/codex-git` for every Git operation. Every created or rewritten commit
+  must be signed; signing failure is a hard stop.
+- Follow TDD for every behaviour change: write one failing test, run it and inspect the expected
+  failure, implement the smallest fix, then rerun the focused and affected suites.
+- Run `test-cleanup` as a separate subagent after implementation and before final verification.
+- Keep the example under `examples/github-actions/`; consumers copy its `.github` directory into
+  their default branch.
+- Match branch names by literal prefixes only. A manual prefix may narrow but never widen the
+  caller allow-list.
+- Treat workflow contexts, inputs, refs, manifests, target files, and artefacts as untrusted data.
+  Pass them into shell through `env:`, double-quote expansions, use full refspecs and `--`, create
+  JSON with `jq --arg`, and create Markdown bodies through files.
+- Every checkout uses `persist-credentials: false`. Discovery, preparation, and validation receive
+  `contents: read` only and never receive publication or signing secrets.
+- Run `terraform init -upgrade -backend=false -input=false -no-color` in preparation. Upload the
+  immutable candidate before running `terraform validate` or any provider RPC.
+- Validate provider-using candidates with
+  `terraform init -backend=false -input=false -no-color -lockfile=readonly`; provider-free roots
+  may omit `.terraform.lock.hcl`.
+- Reconciliation executes neither Terraform nor target-supplied executables. It independently
+  reproduces the `.tf` diff and accepts lock bytes only from the pre-provider candidate.
+- Dry run performs real disposable updates, initialisation, and validation but never enters the
+  publication environment or mutates refs, repository content, pull requests, or issues.
+- State branches are read-only. Map `state/nonproduction/example` to
+  `update_state/nonproduction/example`; naming alone never proves automation ownership.
+- Rewrite and deletion operations use exact expected remote OIDs. Never use unconditional force.
+- Built-in-token publication requires manual approval for generated PR checks. App mode is required
+  for unattended required checks and keeps the effective `GITHUB_TOKEN` read-only.
+- Optional SSH signing has no unsigned fallback after selection. Materialise the key only in
+  reconciliation after candidate validation, verify the signature locally, and remove key files in
+  unconditional cleanup.
+- Pin every action to an immutable SHA with a release comment. Use these verified pins:
+
+  | Action | SHA | Release |
+  |---|---|---|
+  | `actions/checkout` | `3d3c42e5aac5ba805825da76410c181273ba90b1` | v7.0.1 |
+  | `actions/setup-go` | `b7ad1dad31e06c5925ef5d2fc7ad053ef454303e` | v7.0.0 |
+  | `hashicorp/setup-terraform` | `dfe3c3f87815947d99a8997f908cb6525fc44e9e` | v4.0.1 |
+  | `actions/upload-artifact` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | v7.0.1 |
+  | `actions/download-artifact` | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` | v8.0.1 |
+  | `actions/create-github-app-token` | `bcd2ba49218906704ab6c1aa796996da409d3eb1` | v3.2.0 |
+
+- The checked-in workflows target GitHub.com. Documentation must warn that GitHub Enterprise
+  Server consumers need compatible queue and artefact-action versions.
+- Do not mock `gh` or GitHub API behaviour. Test deterministic payload and Git operations locally;
+  verify tokens, PRs, issues, permissions, queueing, and event triggering against a disposable real
+  GitHub repository.
+
+---
+
+### Task 1: Make Per-File CLI Failures Observable to Automation
+
+**Files:**
+- Modify: `main.go`
+- Modify: `main_integration_test.go`
+- Modify: `integration_config_test.go`
+- Modify: `coverage_test.go`
+- Modify: `terraform_provider_test.go`
+- Modify: `cli_functions_test.go`
+- Modify: `main_coverage_test.go`
+
+**Interfaces:**
+- Produces:
+  - `type processingResult struct { updates int; failures int }`
+  - `func (r processingResult) add(other processingResult) processingResult`
+  - `func processFiles(files []string, updates []ModuleUpdate, flags *cliFlags) processingResult`
+  - `func processTerraformVersion(files []string, version string, dryRun bool, outputFormat string) processingResult`
+  - `func processProviderVersion(files []string, providerName, version string, dryRun bool, outputFormat string) processingResult`
+  - `func exitAfterProcessingFailures(failures int)`
+- Consumers: Tasks 3 and 7 rely on the CLI exiting non-zero after any file operation fails.
+
+- [ ] **Step 1: Add a failing aggregate-result test**
+
+  Add `TestProcessFiles_ReportsFailuresAfterLaterFilesRun` to `main_integration_test.go`. Create one
+  invalid HCL file followed by one valid matching module file, capture log output, and assert the
+  wished-for result:
+
+  ```go
+  result := processFiles(
+      []string{invalidFile, validFile},
+      []ModuleUpdate{{Source: "terraform-aws-modules/vpc/aws", Version: "2.0.0"}},
+      &cliFlags{output: "text"},
+  )
+
+  if result.updates != 1 || result.failures != 1 {
+      t.Fatalf("processFiles() = %+v, want 1 update and 1 failure", result)
+  }
+  updated, err := os.ReadFile(validFile)
+  if err != nil {
+      t.Fatal(err)
+  }
+  if !strings.Contains(string(updated), `version = "2.0.0"`) {
+      t.Fatalf("later valid file was not processed: %s", updated)
+  }
+  ```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+  Run: `go test -run TestProcessFiles_ReportsFailuresAfterLaterFilesRun -v`
+
+  Expected: compilation fails because `processFiles` still returns `int`.
+
+- [ ] **Step 3: Return update and failure counts from every processing loop**
+
+  Add this domain result near the processing functions:
+
+  ```go
+  type processingResult struct {
+      updates  int
+      failures int
+  }
+
+  func (r processingResult) add(other processingResult) processingResult {
+      r.updates += other.updates
+      r.failures += other.failures
+      return r
+  }
+  ```
+
+  Change all three file-processing loops to increment `failures` when an update function returns an
+  error, continue to later files, and return the struct. Preserve the existing per-file error log.
+  Update existing tests and summaries to read `.updates` rather than expecting an `int`.
+
+- [ ] **Step 4: Add the failing non-zero-exit test**
+
+  Add `TestExitAfterProcessingFailures_UsesDeterministicCount` to `cli_functions_test.go`. Capture
+  stderr and replace `exitFunc` with the existing panic-based test helper. Assert exit code `1` and
+  this exact final line:
+
+  ```text
+  Failed to process 2 file operation(s)
+  ```
+
+- [ ] **Step 5: Run the exit test and verify RED**
+
+  Run: `go test -run TestExitAfterProcessingFailures_UsesDeterministicCount -v`
+
+  Expected: compilation fails because `exitAfterProcessingFailures` is undefined.
+
+- [ ] **Step 6: Exit only after summaries and all file processing finish**
+
+  Implement:
+
+  ```go
+  func exitAfterProcessingFailures(failures int) {
+      if failures == 0 {
+          return
+      }
+      fmt.Fprintf(os.Stderr, "Failed to process %d file operation(s)\n", failures)
+      exitFunc(1)
+  }
+  ```
+
+  Accumulate results across Terraform, provider, and module operations in config mode. Print the
+  existing summary first, then call `exitAfterProcessingFailures`. Apply the same ordering to each
+  direct CLI mode.
+
+- [ ] **Step 7: Run focused and full Go verification**
+
+  Run:
+
+  ```text
+  go test -run 'TestProcessFiles_ReportsFailuresAfterLaterFilesRun|TestExitAfterProcessingFailures_UsesDeterministicCount' -v
+  make test-coverage
+  golangci-lint run --timeout=5m
+  go build ./...
+  ```
+
+  Expected: all pass; race coverage remains at least 80%; no warnings or uncaptured error output.
+
+- [ ] **Step 8: Create a signed checkpoint commit**
+
+  Write `/tmp/tfvb-task-1-commit.md` with:
+
+  ```text
+  fix: report aggregate file processing failures
+  ```
+
+  Stage only the files listed in this task and run:
+
+  ```text
+  /Users/dan/.codex/bin/codex-git add main.go main_integration_test.go integration_config_test.go coverage_test.go terraform_provider_test.go cli_functions_test.go main_coverage_test.go
+  /Users/dan/.codex/bin/codex-git commit -F /tmp/tfvb-task-1-commit.md
+  /Users/dan/.codex/bin/codex-git log -1 --show-signature --format=fuller
+  ```
+
+---
+
+### Task 2: Discover Immutable State-Branch Inputs
+
+**Files:**
+- Create: `examples/github-actions/.github/scripts/discover-state-branches.sh`
+- Create: `examples/github-actions/github-actions_test.sh`
+
+**Interfaces:**
+- Produces CLI:
+
+  ```text
+  discover-state-branches.sh \
+    --repository <path> \
+    --allowed-prefixes-file <path> \
+    --narrow-prefix <literal-or-empty> \
+    --control-oid <40-or-64-hex-oid> \
+    --output <matrix-json-path>
+  ```
+
+- Produces JSON:
+
+  ```json
+  {
+    "control_oid": "<oid>",
+    "include": [
+      {
+        "branch": "state/nonproduction/example",
+        "base_oid": "<oid>",
+        "artifact_key": "<sha256-of-full-ref>"
+      }
+    ]
+  }
+  ```
+
+- Consumers: Task 5 passes `.include` to all three per-branch matrices.
+
+- [ ] **Step 1: Build the shell-test harness and write discovery RED cases**
+
+  Create a Bash test that uses `mktemp -d`, real Git repositories, and bare remotes. Add focused
+  tests for:
+
+  - literal allow-list matches and manual narrowing;
+  - widening rejection;
+  - overlapping-prefix deduplication and bytewise sorting;
+  - no matches;
+  - exact base OIDs and one caller-supplied control OID;
+  - hostile valid refs containing slashes, semicolons, quotes, `$()`, leading dashes, Unicode, and
+    percent signs without command evaluation.
+
+  The key assertion should use `jq -e`, for example:
+
+  ```bash
+  jq -e '
+    .control_oid == $control_oid and
+    [.include[].branch] == [
+      "state/nonproduction/a",
+      "state/nonproduction/b"
+    ]
+  ' --arg control_oid "$control_oid" "$matrix_file" >/dev/null ||
+      fail "discovery output was not deterministic"
+  ```
+
+- [ ] **Step 2: Run the discovery tests and verify RED**
+
+  Run: `examples/github-actions/github-actions_test.sh discovery`
+
+  Expected: FAIL because `discover-state-branches.sh` does not exist.
+
+- [ ] **Step 3: Implement literal-prefix discovery**
+
+  The script must:
+
+  - use `git -C "$repository" ls-remote --heads origin` rather than checkout fetch depth;
+  - validate prefix lines and optional narrowing without `eval` or glob matching;
+  - compare with Bash literal slicing:
+
+    ```bash
+    [[ "$branch" == "$prefix"* ]]
+    ```
+
+  - hold refs as tab-separated or NUL-delimited data, never executable source;
+  - compute `artifact_key` with `shasum -a 256` on macOS or `sha256sum` on Linux through one
+    documented helper;
+  - build entries with `jq -n --arg`, sort with `LC_ALL=C`, deduplicate, reject an empty result, and
+    write atomically to the requested output path;
+  - provide complete `--help` output and stage-specific errors.
+
+- [ ] **Step 4: Run syntax and discovery tests GREEN**
+
+  Run:
+
+  ```text
+  bash -n examples/github-actions/.github/scripts/discover-state-branches.sh
+  examples/github-actions/github-actions_test.sh discovery
+  ```
+
+  Expected: PASS with no unexpected output.
+
+- [ ] **Step 5: Create a signed checkpoint commit**
+
+  Commit message file content:
+
+  ```text
+  feat: discover immutable state branches
+  ```
+
+  Run:
+
+  ```text
+  /Users/dan/.codex/bin/codex-git add examples/github-actions/.github/scripts/discover-state-branches.sh examples/github-actions/github-actions_test.sh
+  /Users/dan/.codex/bin/codex-git commit -F /tmp/tfvb-task-2-commit.md
+  /Users/dan/.codex/bin/codex-git log -1 --show-signature --format=fuller
+  ```
+
+---
+
+### Task 3: Prepare Immutable Candidates Before Provider Execution
+
+**Files:**
+- Create: `examples/github-actions/.github/scripts/process-state-branch.sh`
+- Modify: `examples/github-actions/github-actions_test.sh`
+- Create: `examples/github-actions/testdata/hostile-provider.sh`
+
+**Interfaces:**
+- Produces modes:
+
+  ```text
+  process-state-branch.sh prepare --control <path> --target <path> --branch <ref> \
+    --base-oid <oid> --control-oid <oid> --config <relative-path> \
+    --directories-file <path> --tf-version-bump <path> --terraform <path> \
+    --bundle <directory>
+
+  process-state-branch.sh validate --control <path> --target <path> \
+    --bundle <directory> --outcome <directory> --terraform <path>
+  ```
+
+- Produces successful `manifest.json` schema:
+
+  ```json
+  {
+    "schema_version": 1,
+    "control_oid": "<oid>",
+    "state_branch": "<ref>",
+    "base_oid": "<oid>",
+    "artifact_key": "<sha256-of-ref>",
+    "classification": "success",
+    "directories": [{"path": ".", "provider_dependencies": true}],
+    "files": [{"path": "main.tf", "mode": "100644", "kind": "terraform", "sha256": "<hex>"}],
+    "patch_sha256": "<hex>"
+  }
+  ```
+
+- Classification values are exactly `automation`, `shared/init`, `branch-update`,
+  `branch-validation`, and `success`.
+- A failed preparation bundle contains `manifest.json` and logs but no `candidate.patch`.
+- A validation outcome contains `schema_version`, `candidate_manifest_sha256`, `classification`,
+  optional `directory`, and log names; it never contains source or lock bytes.
+- Consumers: Task 4 reconciles only a successful candidate plus its exact bound outcome.
+
+- [ ] **Step 1: Write preparation RED cases**
+
+  Extend the test harness with real `tf-version-bump` and Terraform executables. Add cases for:
+
+  - root-directory update and lock staging;
+  - two sequential Terraform roots;
+  - provider-free success without `.terraform.lock.hcl`;
+  - required provider lock creation and ignored-lock rejection;
+  - duplicate, missing, absolute, escaping, and symlinked directory/config paths;
+  - symlinked `.tf` and lock files;
+  - an unexpected changed path;
+  - aggregate CLI failure after a later valid `.tf` file changes;
+  - init failure classified `shared/init` with logs and no candidate patch.
+
+- [ ] **Step 2: Run preparation tests and verify RED**
+
+  Run: `examples/github-actions/github-actions_test.sh prepare`
+
+  Expected: FAIL because `process-state-branch.sh` is absent.
+
+- [ ] **Step 3: Implement containment and preflight helpers**
+
+  In `process-state-branch.sh`, implement and reuse:
+
+  ```text
+  canonical_under_root <root> <relative-path>
+  require_regular_file <root> <relative-path>
+  load_unique_directories <target-root> <directories-file>
+  enumerate_direct_tf_files <directory>
+  classify_changed_paths <target-root> <directories-json>
+  sha256_file <path>
+  ```
+
+  `canonical_under_root` must reject absolute paths, `..`, missing paths, symlinks, and canonical
+  paths outside the root. Use `lstat`-equivalent shell checks (`[[ -L ... ]]`, `[[ -f ... ]]`) before
+  any write and repeat checks for every staged path.
+
+- [ ] **Step 4: Implement preparation and immutable bundle creation**
+
+  For each canonical directory:
+
+  ```text
+  tf-version-bump -pattern '*.tf' -config <control-config>
+  terraform -chdir=<directory> init -upgrade -backend=false -input=false -no-color
+  ```
+
+  Inspect canonical `.terraform/providers` before deleting `.terraform/`. Require a regular lock
+  when any provider package exists; otherwise mark the root provider-free. Stage only declared
+  direct `.tf` files and required lock files in the disposable target index, then create a binary
+  full-index patch from the index so new lock files are included. Create every JSON value with
+  `jq --arg`, hash the manifest payload, patch, and declared files, and write logs with bounded
+  routine output.
+
+- [ ] **Step 5: Write validation and hostile-provider RED cases**
+
+  Add tests that:
+
+  - copy a successful preparation bundle aside, record all hashes, and validate from a fresh target
+    checkout;
+  - reject missing, duplicate, traversal, symlink-mode, hash-mismatched, ref-mismatched, and
+    candidate-digest-mismatched artefacts;
+  - install `hostile-provider.sh` through a temporary Terraform filesystem mirror. Its process-start
+    code tries to overwrite the validation checkout lock, alter a supplied control path, append to
+    `GITHUB_ENV` and `GITHUB_PATH`, and create a fake outcome before exiting with an invalid plugin
+    handshake;
+  - assert the original preparation bundle hashes are unchanged and the outcome is
+    `branch-validation` or `automation`, never `success`.
+
+- [ ] **Step 6: Run validation tests and verify RED**
+
+  Run: `examples/github-actions/github-actions_test.sh validate`
+
+  Expected: FAIL because validate mode is not implemented.
+
+- [ ] **Step 7: Implement fresh validation without publishable output**
+
+  Validate the candidate manifest and patch before applying them to a fresh exact-base checkout.
+  For provider roots run:
+
+  ```text
+  terraform -chdir=<directory> init -backend=false -input=false -no-color -lockfile=readonly
+  terraform -chdir=<directory> validate -no-color
+  ```
+
+  Omit `-lockfile=readonly` only for manifest-declared provider-free roots. Bind the outcome to the
+  SHA-256 of the exact candidate manifest. Write only outcome JSON and captured logs, then discard
+  the validation checkout. Never copy its `.tf` or lock files back to the bundle.
+
+- [ ] **Step 8: Run preparation and validation GREEN**
+
+  Run:
+
+  ```text
+  bash -n examples/github-actions/.github/scripts/process-state-branch.sh
+  bash -n examples/github-actions/testdata/hostile-provider.sh
+  examples/github-actions/github-actions_test.sh prepare
+  examples/github-actions/github-actions_test.sh validate
+  ```
+
+  Expected: PASS; the hostile provider cannot change the saved candidate.
+
+- [ ] **Step 9: Create a signed checkpoint commit**
+
+  Commit message file content:
+
+  ```text
+  feat: prepare and validate state branch candidates
+  ```
+
+  Run:
+
+  ```text
+  /Users/dan/.codex/bin/codex-git add examples/github-actions/.github/scripts/process-state-branch.sh examples/github-actions/github-actions_test.sh examples/github-actions/testdata/hostile-provider.sh
+  /Users/dan/.codex/bin/codex-git commit -F /tmp/tfvb-task-3-commit.md
+  /Users/dan/.codex/bin/codex-git log -1 --show-signature --format=fuller
+  ```
+
+---
+
+### Task 4: Reconcile Owned Branches, Pull Requests, and Issues
+
+**Files:**
+- Modify: `examples/github-actions/.github/scripts/process-state-branch.sh`
+- Modify: `examples/github-actions/github-actions_test.sh`
+
+**Interfaces:**
+- Adds mode:
+
+  ```text
+  process-state-branch.sh reconcile --control <path> --target <path> \
+    --bundle <directory> --outcome <directory-or-empty> --remote origin \
+    --repository <owner/name> --run-url <url> --token-mode <builtin|app> \
+    --bot-login <github-actions[bot]-or-app-slug[bot]> \
+    --signing-key <path-or-empty> --author-name <name-or-empty> \
+    --author-email <email-or-empty>
+  ```
+
+- Consumes publication credential only through `GH_TOKEN` in reconcile mode.
+- Produces update ref `update_<state-branch>`.
+- Produces commit trailers:
+
+  ```text
+  TF-Version-Bump-Managed: true
+  TF-Version-Bump-State-Branch: <full-ref>
+  TF-Version-Bump-Base-OID: <oid>
+  TF-Version-Bump-Control-OID: <oid>
+  ```
+
+- Produces PR/issue marker `<!-- tf-version-bump-managed:sha256:<artifact-key> -->`.
+
+- [ ] **Step 1: Write reconciliation safety RED cases**
+
+  Source the script from the harness and test its real Git helpers against bare remotes. Cover:
+
+  - independent reproduction of `.tf` changes before applying candidate lock bytes;
+  - base movement between validation and publication;
+  - stable automation-branch creation and regeneration;
+  - unowned existing ref refusal;
+  - ownership requiring both exact commit trailers and the marked PR record supplied to the helper;
+  - update force-with-lease mismatch;
+  - deletion expected-old-OID mismatch;
+  - no-change owned-ref deletion and obsolete PR payload;
+  - success after a previous marked failure issue;
+  - deterministic validation failure after a previous marked PR;
+  - PR and issue bodies containing hostile ref text as data.
+
+  Do not stub or mock `gh`; pass fixture JSON into pure selection/body functions and leave actual
+  API calls to real-service acceptance.
+
+- [ ] **Step 2: Run reconciliation tests and verify RED**
+
+  Run: `examples/github-actions/github-actions_test.sh reconcile`
+
+  Expected: FAIL because reconcile mode and ownership helpers are undefined.
+
+- [ ] **Step 3: Implement candidate revalidation and Git ownership**
+
+  Reconciliation must re-check both artefacts, bind the outcome to the candidate digest, fresh
+  checkout the exact control/base OIDs, rerun only `tf-version-bump`, and require the `.tf` hashes to
+  match. Apply only declared lock hunks from the pre-provider patch and verify the complete result.
+
+  Before changing an existing update ref, fetch its exact OID and require matching trailers plus a
+  marked PR. Use exact leases:
+
+  ```bash
+  git push --force-with-lease="refs/heads/$update_branch:$expected_oid" \
+      origin "HEAD:refs/heads/$update_branch"
+  git push --force-with-lease="refs/heads/$update_branch:$expected_oid" \
+      origin ":refs/heads/$update_branch"
+  ```
+
+  Use an empty expected OID only when creating a ref proven absent. Never retry without the lease.
+
+- [ ] **Step 4: Implement deterministic GitHub payloads and lifecycle calls**
+
+  Render PR and issue bodies to files with `jq --arg` and bounded log tails. Enumerate API results
+  with `gh api --paginate --method GET`, then select exact base/head refs and exact hidden markers;
+  never rely on a fuzzy title search. Use `gh pr create/edit/close` and `gh issue create/edit/close`
+  only after exact selection. A deterministic update/validation failure closes the stale marked PR,
+  lease-deletes its owned branch, and updates one marked issue. Init/automation failures leave the
+  prior PR untouched and fail the job. For unsigned commits, query the exact bot login with
+  `gh api "/users/$bot_login" --jq .id` and construct
+  `<id>+<bot-login>@users.noreply.github.com`; do not hard-code or guess the numeric ID.
+
+- [ ] **Step 5: Write signing RED cases**
+
+  Add tests for:
+
+  - unsigned commit when no key is supplied;
+  - signed commit with an ephemeral Ed25519 key and explicit identity;
+  - local signature verification with a generated allowed-signers file;
+  - partial identity/key rejection;
+  - signing failure with no unsigned fallback;
+  - unconditional private-key and allowed-signers cleanup.
+
+- [ ] **Step 6: Run signing tests and verify RED**
+
+  Run: `examples/github-actions/github-actions_test.sh signing`
+
+  Expected: FAIL until reconcile signing is implemented.
+
+- [ ] **Step 7: Implement repository-scoped optional SSH signing**
+
+  Configure only the disposable target repository:
+
+  ```bash
+  git -C "$target" config gpg.format ssh
+  git -C "$target" config user.signingkey "$temporary_key"
+  git -C "$target" config commit.gpgsign true
+  ```
+
+  Derive the public key with `ssh-keygen -y`, create an allowed-signers file for the exact author
+  email, commit with the stable subject, and verify with `git verify-commit`. A trap removes both
+  files on every exit path.
+
+- [ ] **Step 8: Run all local script tests GREEN**
+
+  Run:
+
+  ```text
+  examples/github-actions/github-actions_test.sh reconcile
+  examples/github-actions/github-actions_test.sh signing
+  examples/github-actions/github-actions_test.sh all
+  ```
+
+  Expected: PASS; no GitHub network mutation occurs.
+
+- [ ] **Step 9: Create a signed checkpoint commit**
+
+  Commit message file content:
+
+  ```text
+  feat: reconcile managed state branch updates
+  ```
+
+  Run:
+
+  ```text
+  /Users/dan/.codex/bin/codex-git add examples/github-actions/.github/scripts/process-state-branch.sh examples/github-actions/github-actions_test.sh
+  /Users/dan/.codex/bin/codex-git commit -F /tmp/tfvb-task-4-commit.md
+  /Users/dan/.codex/bin/codex-git log -1 --show-signature --format=fuller
+  ```
+
+---
+
+### Task 5: Wire the Four-Stage Reusable Workflow
+
+**Files:**
+- Create: `examples/github-actions/.github/workflows/tf-version-bump-reusable.yml`
+- Modify: `examples/github-actions/github-actions_test.sh`
+
+**Interfaces:**
+- Implements these exact `workflow_call` inputs: `allowed_branch_prefixes`, `branch_prefix`,
+  `config_path`, `terraform_directories`, `terraform_version`, `tf_version_bump_version`,
+  `go_version`, `dry_run`, `max_parallel`, `commit_author_name`, `commit_author_email`,
+  `github_app_client_id`, and `publication_environment`.
+- Exposes jobs `discover`, `prepare`, `validate`, and `reconcile`.
+- Consumes `TF_VERSION_BUMP_GITHUB_APP_PRIVATE_KEY` and
+  `TF_VERSION_BUMP_COMMIT_SIGNING_PRIVATE_KEY` only from the reconciliation environment.
+
+- [ ] **Step 1: Add failing workflow-structure assertions**
+
+  Extend the harness to copy the example `.github` tree into a temporary consumer repository and
+  assert with actionlint plus exact `rg` checks that:
+
+  - all required inputs and defaults exist;
+  - manual dispatch from a non-default ref fails before matrix creation;
+  - the shared tf-version-bump config is validated once against a trusted temporary fixture before
+    branch discovery;
+  - discovery/preparation/validation have `contents: read` only;
+  - reconciliation declares the three write scopes but receives the caller's effective ceiling;
+  - every checkout disables persisted credentials;
+  - matrices use `fail-fast: false` and the `max_parallel` input;
+  - validate and reconcile use `if: always()` as required;
+  - dry run cannot enter the reconciliation environment;
+  - no `${{ matrix.branch }}`, input, ref, or manifest expression appears directly inside `run:`;
+  - every `uses:` value is one of the exact pinned SHAs in Global Constraints.
+
+- [ ] **Step 2: Run workflow structure tests and verify RED**
+
+  Run: `examples/github-actions/github-actions_test.sh workflow`
+
+  Expected: FAIL because the reusable workflow does not exist.
+
+- [ ] **Step 3: Implement discovery and credential-free matrices**
+
+  Reject manual execution unless `github.ref` equals
+  `refs/heads/${{ github.event.repository.default_branch }}`. Use exact control checkout
+  `github.sha`, validate the shared config once with the pinned CLI against a trusted temporary
+  Terraform fixture, emit the discovery JSON through `$GITHUB_OUTPUT`, and pass all untrusted matrix
+  values through step `env:`. Install Go and Terraform from their exact workflow inputs, with
+  `terraform_wrapper: false`, and install `tf-version-bump` from its exact tag input.
+
+  Preparation must always upload one collision-resistant artefact. Validation runs with `always()`,
+  downloads only the expected successful candidate, uploads only its bound outcome/log artefact,
+  and never receives secrets or write permissions. Preserve script exit status through
+  `continue-on-error` steps and a final status step whose value arrives through `env:`.
+
+- [ ] **Step 4: Implement protected reconciliation**
+
+  Run only when `dry_run == false`, after all preparation and validation matrix jobs. Set
+  `environment.name` from `publication_environment`, download only exact run/branch artefact names,
+  and validate before credential creation.
+
+  For App mode use the pinned token action with:
+
+  ```yaml
+  client-id: ${{ inputs.github_app_client_id }}
+  private-key: ${{ secrets.TF_VERSION_BUMP_GITHUB_APP_PRIVATE_KEY }}
+  permission-contents: write
+  permission-pull-requests: write
+  permission-issues: write
+  ```
+
+  Leave `owner` and `repositories` unset so the token is scoped to the current repository. Pass
+  either the App token or built-in token as `GH_TOKEN` only to exact identity/publication steps.
+  Pass `${{ steps.app-token.outputs.app-slug }}[bot]` as the App bot login and
+  `github-actions[bot]` as the built-in bot login through `env:` rather than interpolating either
+  value into shell source.
+  After artefact validation, reject an App client ID without a private key, a private key without a
+  client ID, or a signing key without both explicit commit identity inputs. Materialise the signing
+  secret immediately before reconcile and remove it in `if: always()` cleanup.
+
+- [ ] **Step 5: Validate workflow syntax GREEN**
+
+  Run actionlint 1.7.12 against the temporary consumer root with only this exact temporary ignore:
+
+  ```text
+  -ignore '^unexpected key "queue" for "concurrency" section\.'
+  ```
+
+  Then run: `examples/github-actions/github-actions_test.sh workflow`
+
+  Expected: PASS with no other ignored diagnostics.
+
+- [ ] **Step 6: Create a signed checkpoint commit**
+
+  Commit message file content:
+
+  ```text
+  feat: add reusable state branch workflow
+  ```
+
+  Run:
+
+  ```text
+  /Users/dan/.codex/bin/codex-git add examples/github-actions/.github/workflows/tf-version-bump-reusable.yml examples/github-actions/github-actions_test.sh
+  /Users/dan/.codex/bin/codex-git commit -F /tmp/tfvb-task-5-commit.md
+  /Users/dan/.codex/bin/codex-git log -1 --show-signature --format=fuller
+  ```
+
+---
+
+### Task 6: Add Production and Non-Production Consumers
+
+**Files:**
+- Create: `examples/github-actions/.github/workflows/tf-version-bump-nonproduction.yml`
+- Create: `examples/github-actions/.github/workflows/tf-version-bump-production.yml`
+- Create: `examples/github-actions/.github/tf-version-bump/nonproduction.yml`
+- Create: `examples/github-actions/.github/tf-version-bump/production.yml`
+- Modify: `examples/github-actions/github-actions_test.sh`
+
+**Interfaces:**
+- Non-production prefixes:
+
+  ```text
+  state/nonproduction/
+  state/staging/
+  aws-state/nonproduction/
+  ```
+
+- Production prefixes:
+
+  ```text
+  state/production/
+  aws-state/production/
+  ```
+
+- Both callers expose `branch_prefix` string and `dry_run` Boolean (`false`) manual inputs.
+
+- [ ] **Step 1: Add caller-policy RED assertions**
+
+  Assert exact schedules, timezones, prefix sets, config paths, tool pins, manual inputs, separate
+  concurrency groups, `queue: max`, no in-progress cancellation, and local reusable-workflow paths.
+  Assert scheduled calls supply an empty narrowing prefix and `dry_run: false`.
+
+- [ ] **Step 2: Run caller tests and verify RED**
+
+  Run: `examples/github-actions/github-actions_test.sh callers`
+
+  Expected: FAIL because caller workflows/configs are missing.
+
+- [ ] **Step 3: Create built-in-token caller examples**
+
+  The checked-in callers use built-in-token mode with job permissions:
+
+  ```yaml
+  contents: write
+  pull-requests: write
+  issues: write
+  ```
+
+  They pass exact illustrative versions `go_version: '1.25.0'`,
+  `terraform_version: '1.15.5'`, and `tf_version_bump_version: 'v1.0.0-rc.6'`, use
+  `terraform_directories: '.'`, and leave `github_app_client_id` empty. README instructions in Task
+  8 show the deliberate three-permission change to `contents: read` plus App client ID when
+  switching modes; do not imply runtime permission toggling.
+
+  Use schedules:
+
+  ```yaml
+  # Non-production
+  - cron: '17 4 * * *'
+    timezone: Australia/Melbourne
+
+  # Production
+  - cron: '43 4 * * 0'
+    timezone: Australia/Melbourne
+  ```
+
+- [ ] **Step 4: Add separate illustrative YAML configs**
+
+  Keep the configs valid under the existing schema and deliberately different so consumers can see
+  that production and non-production policy are independent. Use syntax examples, not claims that
+  module/provider versions are recommendations.
+
+- [ ] **Step 5: Run callers and actionlint GREEN**
+
+  Run:
+
+  ```text
+  examples/github-actions/github-actions_test.sh callers
+  examples/github-actions/github-actions_test.sh workflow
+  ```
+
+  Expected: PASS, including timezone and local reusable-path validation.
+
+- [ ] **Step 6: Create a signed checkpoint commit**
+
+  Commit message file content:
+
+  ```text
+  feat: add state branch workflow consumers
+  ```
+
+  Run:
+
+  ```text
+  /Users/dan/.codex/bin/codex-git add examples/github-actions/.github/workflows/tf-version-bump-nonproduction.yml examples/github-actions/.github/workflows/tf-version-bump-production.yml examples/github-actions/.github/tf-version-bump/nonproduction.yml examples/github-actions/.github/tf-version-bump/production.yml examples/github-actions/github-actions_test.sh
+  /Users/dan/.codex/bin/codex-git commit -F /tmp/tfvb-task-6-commit.md
+  /Users/dan/.codex/bin/codex-git log -1 --show-signature --format=fuller
+  ```
+
+---
+
+### Task 7: Integrate Local Validation into Make and CI
+
+**Files:**
+- Modify: `Makefile`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `examples/github-actions/github-actions_test.sh`
+
+**Interfaces:**
+- Produces `make test-github-actions`.
+- CI runs the example suite once on Go 1.25 after installing Terraform 1.15.5.
+
+- [ ] **Step 1: Add a failing Make target test**
+
+  Add a harness assertion that `make -n test-github-actions` resolves to the maintained test script
+  and does not silently skip actionlint or either helper's `bash -n` checks.
+
+- [ ] **Step 2: Run the target assertion and verify RED**
+
+  Run: `examples/github-actions/github-actions_test.sh repository-integration`
+
+  Expected: FAIL because the Make target is absent.
+
+- [ ] **Step 3: Add the Make target and CI step**
+
+  Add `test-github-actions` to `.PHONY` and help, with one recipe invoking
+  `examples/github-actions/github-actions_test.sh all`. In CI's Go 1.25 matrix entry, install
+  Terraform with the pinned setup action and `terraform_wrapper: false`, then run the Make target.
+  Keep the existing `update-branches_test.sh` step.
+
+- [ ] **Step 4: Run repository integration GREEN**
+
+  Run:
+
+  ```text
+  examples/github-actions/github-actions_test.sh repository-integration
+  make test-github-actions
+  actionlint
+  ```
+
+  Expected: PASS with only the exact documented queue diagnostic filtered inside the example
+  validator; repository workflows produce no actionlint output.
+
+- [ ] **Step 5: Create a signed checkpoint commit**
+
+  Commit message file content:
+
+  ```text
+  ci: validate GitHub Actions automation example
+  ```
+
+  Run:
+
+  ```text
+  /Users/dan/.codex/bin/codex-git add Makefile .github/workflows/ci.yml examples/github-actions/github-actions_test.sh
+  /Users/dan/.codex/bin/codex-git commit -F /tmp/tfvb-task-7-commit.md
+  /Users/dan/.codex/bin/codex-git log -1 --show-signature --format=fuller
+  ```
+
+---
+
+### Task 8: Document Installation, Security, and Real-Service Acceptance
+
+**Files:**
+- Create: `examples/github-actions/README.md`
+- Modify: `examples/README.md`
+- Modify: `docs/ADVANCED-USAGE.md`
+- Modify: `README.md`
+
+**Interfaces:**
+- Documents the copy boundary: `examples/github-actions/.github/` to consumer `.github/`.
+- Documents fixed secrets:
+  - `TF_VERSION_BUMP_GITHUB_APP_PRIVATE_KEY`
+  - `TF_VERSION_BUMP_COMMIT_SIGNING_PRIVATE_KEY`
+- Documents the complete disposable-repository acceptance transcript required by the spec.
+
+- [ ] **Step 1: Write documentation acceptance checks before prose**
+
+  Extend the harness to require links and headings for installation, built-in token, App mode,
+  signing, single/multiple roots, dry run, lock files/provider-free roots, ownership/leases,
+  troubleshooting, orphan cleanup, GHES compatibility, and real-service acceptance.
+
+- [ ] **Step 2: Run documentation checks and verify RED**
+
+  Run: `examples/github-actions/github-actions_test.sh documentation`
+
+  Expected: FAIL because the example README and cross-links are absent.
+
+- [ ] **Step 3: Write the consumer guide**
+
+  Include exact copy commands, files to customise, protected environment setup, default-branch
+  restrictions, trusted-dispatch assumptions, repository setting for Actions-created PRs, exact
+  version pins, and prefix/config separation.
+
+  Clearly distinguish:
+
+  - built-in mode: three write permissions, no App client ID, suppressed push workflows, and
+    approval-required PR checks;
+  - App mode: `contents: read` caller ceiling, client ID input, protected App key, and unattended PR
+    checks;
+  - unsigned mode versus explicit SSH signing with non-interactive key and registered public key;
+  - required lock for installed providers versus valid provider-free absence;
+  - GitHub.com support versus GHES queue and artefact-action compatibility checks.
+
+- [ ] **Step 4: Document deterministic recovery and deferred orphan cleanup**
+
+  Explain stable refs, ownership trailers/markers, state/base OIDs, update/deletion leases, unowned
+  collisions, stale-base failures, no-change cleanup, and the manual dry-run-first procedure for
+  orphaned refs/issues. Do not add automatic garbage collection.
+
+- [ ] **Step 5: Write the real-service acceptance procedure**
+
+  Provide exact steps for a disposable repository covering:
+
+  - matching/non-matching branches, provider and provider-free roots;
+  - default-branch-only protected publication environment;
+  - built-in and App permission summaries;
+  - alternate-ref rejection;
+  - hostile-provider candidate isolation;
+  - success, idempotence, validation failure/issue, recovery, and obsolete PR cleanup;
+  - three rapid queued dispatches;
+  - built-in approval-required checks versus App automatic checks;
+  - dry-run no-mutation comparison;
+  - unowned ref, lease races, and state-base movement;
+  - optional signed commit locally and GitHub-verified.
+
+  State explicitly that whoever executes acceptance must retain the terminal transcript and inspect
+  repository refs, PRs, issues, Actions permissions, and artefacts before claiming completion.
+
+- [ ] **Step 6: Add concise cross-links**
+
+  Add the GitHub Actions example to `examples/README.md`, distinguish it from local sequential
+  `update-branches.sh` in `docs/ADVANCED-USAGE.md`, and update the root README documentation table
+  without duplicating the consumer guide.
+
+- [ ] **Step 7: Run documentation checks GREEN**
+
+  Run:
+
+  ```text
+  examples/github-actions/github-actions_test.sh documentation
+  /Users/dan/.codex/bin/codex-git diff --check
+  ```
+
+  Expected: PASS; no placeholders, broken relative links, or trailing whitespace.
+
+- [ ] **Step 8: Create a signed checkpoint commit**
+
+  Commit message file content:
+
+  ```text
+  docs: explain state branch Actions automation
+  ```
+
+  Run:
+
+  ```text
+  /Users/dan/.codex/bin/codex-git add examples/github-actions/README.md examples/README.md docs/ADVANCED-USAGE.md README.md
+  /Users/dan/.codex/bin/codex-git commit -F /tmp/tfvb-task-8-commit.md
+  /Users/dan/.codex/bin/codex-git log -1 --show-signature --format=fuller
+  ```
+
+---
+
+### Task 9: Cleanup, Full Verification, and Real-Service Gate
+
+**Files:**
+- Review all files changed by Tasks 1-8.
+- Modify only files required by findings from cleanup/review.
+
+**Interfaces:**
+- Produces the evidence required by the design completion criteria.
+
+- [ ] **Step 1: Run the mandatory independent test-cleanup pass**
+
+  Commit or stash a clean implementation checkpoint, then invoke the `test-cleanup` skill as a
+  fresh subagent. It must classify every Go and shell test changed on the branch, remove only
+  low-value duplication, rerun affected suites, and signed-commit any cleanup. Do not let an
+  implementation agent clean its own tests.
+
+- [ ] **Step 2: Request an adversarial implementation review**
+
+  Use `superpowers:requesting-code-review` after cleanup. Require the reviewer to compare the branch
+  against the design and concentrate on credential boundaries, artefact trust, hostile refs/paths,
+  provider execution, leases, ownership, dry-run mutations, and GitHub event behaviour. Resolve all
+  verified findings with TDD and signed commits.
+
+- [ ] **Step 3: Run the full local verification gate**
+
+  Run each command separately and inspect its complete output:
+
+  ```text
+  go mod download
+  go mod verify
+  go build ./...
+  make test-coverage
+  golangci-lint run --timeout=5m
+  examples/update-branches_test.sh
+  make test-github-actions
+  actionlint
+  /Users/dan/.codex/bin/codex-git diff --check main...HEAD
+  ```
+
+  Expected: every command exits zero, coverage remains at least 80%, and output contains no
+  warnings, ignored failures, uncaptured expected errors, or diagnostics other than the one exact
+  queue false positive filtered within the example validator.
+
+- [ ] **Step 4: Verify every branch commit signature**
+
+  List `main..HEAD`, inspect each with `--show-signature`, and stop if any Codex-created commit lacks
+  a good signature. Do not amend or rewrite with an unsigned fallback.
+
+- [ ] **Step 5: Obtain authority for disposable GitHub acceptance**
+
+  If Dan has not already authorised creation and deletion of the disposable repository and its App
+  installation/environment configuration, stop and request that authority. This gate must not be
+  replaced by mocks or claims based only on local tests.
+
+- [ ] **Step 6: Execute and retain the real-service transcript**
+
+  Follow `examples/github-actions/README.md` exactly. Verify every case enumerated in Task 8,
+  including three queued dispatches, App-mode read-only `GITHUB_TOKEN`, hostile-provider isolation,
+  built-in/App check triggering, dry-run no-mutation, leases, and optional signing. Save the
+  transcript outside the repository unless Dan explicitly requests a committed evidence file.
+
+- [ ] **Step 7: Run final repository-state checks**
+
+  Run:
+
+  ```text
+  /Users/dan/.codex/bin/codex-git status --short --branch
+  /Users/dan/.codex/bin/codex-git log --oneline --show-signature main..HEAD
+  ```
+
+  Expected: clean feature branch, no generated binaries/coverage artefacts staged, and every branch
+  commit signed.
+
+- [ ] **Step 8: Hand off with evidence**
+
+  Report the implementation commits, local verification results, coverage, cleanup/review outcome,
+  real-service acceptance repository/transcript location, and any operational setup Dan must retain.
+  Do not push or open a PR unless Dan requests it.

--- a/docs/superpowers/plans/2026-08-18-github-actions-branch-automation.md
+++ b/docs/superpowers/plans/2026-08-18-github-actions-branch-automation.md
@@ -55,8 +55,11 @@ reopen the partial-publication defect.
 - Only **Re-run all jobs** is supported. Every downstream matrix job rejects a discovery attempt
   that differs from its current `github.run_attempt`, with a diagnostic explaining that partial
   reruns cannot produce a complete current-attempt artefact lineage.
-- Preparation and validation each use one cumulative 20-minute deadline per state branch, not per
-  Terraform root, inside their 30-minute job limits.
+- The first executable step of each preparation and validation job records one absolute 20-minute
+  deadline before checkout and setup. Setup and all Terraform roots consume that same budget
+  inside the 30-minute job limit. Every third-party `uses:` step in those jobs has
+  `timeout-minutes: 10`; collectively overrunning the absolute deadline is a job-level failure for
+  which cleanup cannot be guaranteed.
 - Action pins:
   - `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1` (`v7.0.1`)
   - `actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e` (`v7.0.0`)
@@ -202,16 +205,20 @@ and create a signed commit.
    recorded SHA-256 before extraction, checking the binary's reported version, and running it with
    `*.tf` plus the control config in one real Terraform root. Implement only that download,
    verification, and update path.
-2. Add a RED test for `terraform init -upgrade -backend=false -input=false -no-color` using the
-   trusted data directory and the state branch's cumulative 20-minute preparation deadline.
+2. Add a RED test that records the absolute 20-minute preparation deadline before checkout and
+   setup, then runs `terraform init -upgrade -backend=false -input=false -no-color` using the
+   trusted data directory and only the remaining preparation budget.
    Implement and rerun GREEN.
 3. Add separate RED/GREEN cases for a provider root requiring a regular persisted lock, a
    provider-free root legitimately omitting one, and an ignored newly required lock failing without
    force-add.
-4. Add a RED test for two roots and deterministic failure attribution. Implement sequential root
-   handling with one shared deadline; the second root receives only the remaining budget. Use an
-   injectable short duration to prove cleanup and bundle upload retain the job-level reserve, then
-   rerun GREEN.
+4. Add a RED test for setup plus two roots and deterministic failure attribution. Implement
+   sequential handling with one absolute deadline recorded before setup; setup and the first root
+   reduce the second root's remaining budget. Use an injectable short duration to prove normal
+   timeout handling reaches cleanup and bundle upload before the larger job deadline. Add
+   separate late-returning and non-returning setup cases that expect a job-level automation failure
+   and make no cleanup/upload assertion. Add a structural assertion that every third-party action
+   step in the preparation job has `timeout-minutes: 10`, then rerun GREEN.
 5. Add one manifest field at a time with a focused assertion: schema version; run ID/attempt/policy;
    control/ref/base identity; config and exact tool/archive/image pins; classification; roots and
    provider dependency state; changed paths, modes, and SHA-256 hashes.
@@ -256,8 +263,12 @@ commit.
    the reviewed test mirror and CLI config read-only only when the harness enables its internal test
    mode. The trusted host—not a mounted target process—must create the outcome from the observed
    container status after termination.
-8. Add a hanging-provider RED test. Enforce the cumulative 20-minute branch-validation deadline
-   with an injectable shorter duration and classify it as `branch-validation`.
+8. Add a hanging-provider RED test. Record the absolute 20-minute branch-validation deadline before
+   candidate, checkout, and image setup; enforce its remaining time with an injectable shorter
+   duration and classify it as `branch-validation`. Add late-returning and non-returning setup
+   cases that expect a job-level automation failure without promising cleanup or outcome upload.
+   Add a structural assertion that every third-party action step in the validation job has
+   `timeout-minutes: 10`.
 9. State in test names and assertions that a zero supervised exit is all this boundary authenticates;
    it cannot prove an adversarial provider's semantic honesty.
 
@@ -339,8 +350,9 @@ gate. Run the subset and create a signed commit.
 7. Add failpoints after ref create/update. A later PR failure exact-lease-deletes a newly created
    ref or restores the previous OID. An ambiguous response first re-reads markers. A compensation
    lease mismatch reports manual recovery and preserves the unseen writer's change. A termination-
-   after-push failpoint must leave the documented recoverable managed pair or bounded manual-
-   recovery result for a new ref without a PR.
+   after-push failpoint must cover both a new ref without a PR and an updated ref whose PR retains
+   its previous marker. On the next run, both cases fail the two-marker ownership check, emit
+   bounded manual-recovery instructions, and are not adopted automatically.
 8. For no-change cleanup, recheck state, exact-lease-delete the marked ref, recheck state again, and
    restore the deleted OID with an exact absent-ref lease if movement is detected. Delete before
    closing the PR and add recovery for API failure or runner termination after deletion.
@@ -393,7 +405,9 @@ Add each workflow contract through a focused structural or actionlint RED/GREEN 
    timeout.
 3. Add `prepare` and `validate` matrices with `fail-fast: false`, `max-parallel`, `contents: read`,
    exact OID checkouts, no credentials/secrets, run-attempt artefact names, unconditional result
-   upload, cumulative 20-minute per-branch operation deadlines, and 30-minute job timeouts. Set
+   upload, absolute 20-minute per-branch deadlines recorded by the first executable step before
+   checkout/setup, and 30-minute job timeouts. Every later workflow-controlled step checks the
+   deadline before starting work; every third-party action step has `timeout-minutes: 10`. Set
    `terraform_wrapper: false` on every setup action. Validation uses separate networked-init and
    `--network=none` validate containers with the exact fixed resource limits from Task 6.
 4. Add a separate `verify` matrix with `always()`, `contents: read`, no publication environment or
@@ -492,7 +506,8 @@ Write the example guide specified by the design, including:
   App event delivery is not itself a security boundary.
 - Stable `update_<state-branch>` names, policy-scoped ownership, exact leases, best-effort Git/API
   compensation, the lack of cross-ref atomicity, crash windows, and manual recovery after a
-  compensation lease conflict or newly created ref without a PR.
+  compensation lease conflict, a newly created ref without a PR, or an updated ref whose PR marker
+  still identifies the previous commit.
 - Run-attempt artefact identity, the **Re-run all jobs** requirement and partial-rerun diagnostic,
   GitHub.com's `queue: max` behaviour and bound, and GitHub Enterprise Server compatibility checks.
 - Failure classification and the manual, strongly marked orphan-cleanup procedure; automatic
@@ -529,7 +544,8 @@ already present in the repository, if any, and create a signed docs commit.
    disposable private repository. It must cover authenticated discovery/push/delete, built-in and
    audited App modes, alternate-ref environment denial, hostile-container and hostile-downstream
    push/PR cases, provider/provider-free roots, complete and rejected partial reruns,
-   policy/unowned collisions, advertisement-to-update state movement, termination after push,
+   policy/unowned collisions, advertisement-to-update state movement, termination after both ref
+   creation and ref update with bounded manual recovery on the next run,
    deletion races, a real post-push PR-creation rejection with exact-lease rollback, dry run,
    failure/recovery/cleanup, three rapid dispatches, and optional signed publication.
 5. Review the transcript against every completion criterion in the design. Do not claim completion

--- a/docs/superpowers/plans/2026-08-18-github-actions-branch-automation.md
+++ b/docs/superpowers/plans/2026-08-18-github-actions-branch-automation.md
@@ -1,1086 +1,504 @@
 # GitHub Actions State-Branch Automation Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
-> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
-> checkbox (`- [ ]`) syntax for tracking.
+> **For Codex:** Execute this plan with `superpowers:executing-plans`. Use
+> `superpowers:test-driven-development` for every behaviour. After implementation, run the
+> `test-cleanup` skill in a separate subagent, then use
+> `superpowers:verification-before-completion` and `superpowers:requesting-code-review`.
 
-**Goal:** Add a copyable GitHub Actions example that safely updates, initialises, validates, and
-opens one managed pull request or failure issue for each selected Terraform state branch.
+**Goal:** Ship a copyable GitHub Actions example that safely prepares, validates, and reconciles
+Terraform dependency updates across selected state branches, with manual and scheduled production
+and non-production callers.
 
-**Architecture:** Two Bash helpers provide branch discovery and per-branch preparation,
-validation, and reconciliation. A four-stage reusable workflow runs target-controlled Terraform
-only in credential-free jobs, uploads the publishable candidate before provider execution, and
-publishes from a fresh protected reconciliation runner. Production and non-production caller
-workflows supply separate prefix policy, schedules, and configurations.
+**Architecture:** A reusable workflow discovers immutable state refs, prepares candidates before
+provider execution, validates them in a constrained Terraform container under a trusted host
+supervisor, verifies candidates in a separate read-only job, and reconciles verified results on a
+fresh protected publication runner. The helper scripts keep untrusted values out of workflow source
+and split reconciliation into credential-free verification, authenticated preflight, and the
+smallest possible publication step.
 
-**Tech Stack:** Go 1.25, Bash, Git, `jq`, Terraform 1.15.5, GitHub CLI, GitHub Actions,
-actionlint 1.7.12
+**Tech stack:** Bash, Git, GitHub CLI, GitHub Actions, jq, Docker,
+`tf-version-bump v1.0.0-rc.7`, Terraform 1.15.5, actionlint 1.7.12.
 
 **Spec:** `docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md`
 
-## Global Constraints
-
-- Work on a feature branch or isolated worktree created with `superpowers:using-git-worktrees`;
-  never implement directly on `main`.
-- Use `/Users/dan/.codex/bin/codex-git` for every Git operation. Every created or rewritten commit
-  must be signed; signing failure is a hard stop.
-- Follow TDD for every behaviour change: write one failing test, run it and inspect the expected
-  failure, implement the smallest fix, then rerun the focused and affected suites.
-- Run `test-cleanup` as a separate subagent after implementation and before final verification.
-- Keep the example under `examples/github-actions/`; consumers copy its `.github` directory into
-  their default branch.
-- Match branch names by literal prefixes only. A manual prefix may narrow but never widen the
-  caller allow-list.
-- Treat workflow contexts, inputs, refs, manifests, target files, and artefacts as untrusted data.
-  Pass them into shell through `env:`, double-quote expansions, use full refspecs and `--`, create
-  JSON with `jq --arg`, and create Markdown bodies through files.
-- Every checkout uses `persist-credentials: false`. Discovery, preparation, and validation receive
-  `contents: read` only and never receive publication or signing secrets.
-- Run `terraform init -upgrade -backend=false -input=false -no-color` in preparation. Upload the
-  immutable candidate before running `terraform validate` or any provider RPC.
-- Validate provider-using candidates with
-  `terraform init -backend=false -input=false -no-color -lockfile=readonly`; provider-free roots
-  may omit `.terraform.lock.hcl`.
-- Reconciliation executes neither Terraform nor target-supplied executables. It independently
-  reproduces the `.tf` diff and accepts lock bytes only from the pre-provider candidate.
-- Dry run performs real disposable updates, initialisation, and validation but never enters the
-  publication environment or mutates refs, repository content, pull requests, or issues.
-- State branches are read-only. Map `state/nonproduction/example` to
-  `update_state/nonproduction/example`; naming alone never proves automation ownership.
-- Rewrite and deletion operations use exact expected remote OIDs. Never use unconditional force.
-- Built-in-token publication requires manual approval for generated PR checks. App mode is required
-  for unattended required checks and keeps the effective `GITHUB_TOKEN` read-only.
-- Optional SSH signing has no unsigned fallback after selection. Materialise the key only in
-  reconciliation after candidate validation, verify the signature locally, and remove key files in
-  unconditional cleanup.
-- Pin every action to an immutable SHA with a release comment. Use these verified pins:
-
-  | Action | SHA | Release |
-  |---|---|---|
-  | `actions/checkout` | `3d3c42e5aac5ba805825da76410c181273ba90b1` | v7.0.1 |
-  | `actions/setup-go` | `b7ad1dad31e06c5925ef5d2fc7ad053ef454303e` | v7.0.0 |
-  | `hashicorp/setup-terraform` | `dfe3c3f87815947d99a8997f908cb6525fc44e9e` | v4.0.1 |
-  | `actions/upload-artifact` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | v7.0.1 |
-  | `actions/download-artifact` | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` | v8.0.1 |
-  | `actions/create-github-app-token` | `bcd2ba49218906704ab6c1aa796996da409d3eb1` | v3.2.0 |
-
-- The checked-in workflows target GitHub.com. Documentation must warn that GitHub Enterprise
-  Server consumers need compatible queue and artefact-action versions.
-- Do not mock `gh` or GitHub API behaviour. Test deterministic payload and Git operations locally;
-  verify tokens, PRs, issues, permissions, queueing, and event triggering against a disposable real
-  GitHub repository.
-
 ---
 
-### Task 1: Make Per-File CLI Failures Observable to Automation
+## Hard prerequisite
+
+Do not begin Task 1 until
+`docs/superpowers/plans/2026-08-19-tf-version-bump-aggregate-failures.md` is complete and the
+published `v1.0.0-rc.7` Linux artefact has passed checksum, provenance, version, and aggregate-exit
+verification. Record the actual Linux x86-64 archive SHA-256 in the release acceptance transcript.
+Tests and workflows must download and verify that archive; substituting a working-tree build would
+reopen the partial-publication defect.
+
+## Global constraints
+
+- Work on a topic branch and use `/Users/dan/.codex/bin/codex-git` for every Git operation.
+- Every Codex-created commit must be signed. Stop immediately if signing fails.
+- Do not push or mutate a non-disposable GitHub repository without Dan's explicit approval.
+- Use `apply_patch` for edits. Preserve unrelated worktree changes.
+- Before starting, pull the latest base with rebase and stop for direction if the worktree is not
+  clean.
+- Use real Git repositories, bare remotes, Docker containers, executables, and local authenticated
+  HTTP services in tests. Do not mock `gh`, provider execution, or Git transport behaviour.
+- Test deterministic local payload construction separately from GitHub API behaviour. Verify API,
+  token, permissions, event, environment, and queue behaviour in a disposable private GitHub
+  repository.
+- Introduce one behaviour at a time: focused failing test, observed RED for the intended reason,
+  smallest GREEN implementation, focused rerun, then broader suite. A missing script or mode may
+  establish only its scaffold, not a batch of unrelated requirements.
+- Every checkout uses `persist-credentials: false`. Every untrusted Actions value enters shell via
+  `env:`, never direct expression interpolation into `run:`.
+- Action pins:
+  - `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1` (`v7.0.1`)
+  - `actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e` (`v7.0.0`)
+  - `hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e`
+    (`v4.0.1`)
+  - `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`
+    (`v7.0.1`)
+  - `actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c`
+    (`v8.0.1`)
+  - `actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1`
+    (`v3.2.0`)
+- Tool pins:
+  - `tf-version-bump v1.0.0-rc.7`
+  - Terraform `1.15.5`
+  - `hashicorp/terraform:1.15.5@sha256:15bf5a08b1fb9c9747c8ff01098aeeefb4aec9a6c24eb13e7661bdf9447e4aee`
+  - `github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
+
+## Planned files
+
+```text
+scripts/run-actionlint.sh
+examples/github-actions/README.md
+examples/github-actions/.github/scripts/discover-state-branches.sh
+examples/github-actions/.github/scripts/process-state-branch.sh
+examples/github-actions/.github/tf-version-bump/nonproduction.yml
+examples/github-actions/.github/tf-version-bump/production.yml
+examples/github-actions/.github/workflows/tf-version-bump-reusable.yml
+examples/github-actions/.github/workflows/tf-version-bump-nonproduction.yml
+examples/github-actions/.github/workflows/tf-version-bump-production.yml
+examples/github-actions/test-fixtures/hostile-provider/**
+examples/github-actions/test.sh
+examples/README.md
+docs/ADVANCED-USAGE.md
+README.md
+Makefile
+.github/workflows/ci.yml
+```
+
+Keep the two runtime helpers small. `discover-state-branches.sh` owns discovery only.
+`process-state-branch.sh` exposes explicit `prepare`, `validate`, `verify`, `prepublish`, and
+`publish` modes; each mode validates its own input contract and cannot silently perform a later
+phase.
+
+### Task 1: Pin workflow linting and scaffold the harness
 
 **Files:**
-- Modify: `main.go`
-- Modify: `main_integration_test.go`
-- Modify: `integration_config_test.go`
-- Modify: `coverage_test.go`
-- Modify: `terraform_provider_test.go`
-- Modify: `cli_functions_test.go`
-- Modify: `main_coverage_test.go`
 
-**Interfaces:**
-- Produces:
-  - `type processingResult struct { updates int; failures int }`
-  - `func (r processingResult) add(other processingResult) processingResult`
-  - `func processFiles(files []string, updates []ModuleUpdate, flags *cliFlags) processingResult`
-  - `func processTerraformVersion(files []string, version string, dryRun bool, outputFormat string) processingResult`
-  - `func processProviderVersion(files []string, providerName, version string, dryRun bool, outputFormat string) processingResult`
-  - `func exitAfterProcessingFailures(failures int)`
-- Consumers: Tasks 3 and 7 rely on the CLI exiting non-zero after any file operation fails.
+- Create: `scripts/run-actionlint.sh`
+- Create: `examples/github-actions/test.sh`
+- Modify: `Makefile`
 
-- [ ] **Step 1: Add a failing aggregate-result test**
+1. Add one harness assertion that the actionlint launcher exists and reports 1.7.12. Run it and
+   observe RED because the launcher is absent.
+2. Add the smallest documented launcher using exactly
+   `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`. It accepts workflow paths, has
+   `--help`, and emits no output on success. Rerun GREEN.
+3. Add one harness assertion that both runtime helpers support `--help`. Observe RED, then create
+   only minimal executable help/usage scaffolds. Rerun GREEN.
+4. Add `branch-automation-test` and `actionlint` Make targets that delegate to these scripts. Do not
+   duplicate their command bodies in Make.
+5. Run `bash -n` on all three scripts and the focused harness cases. Create a signed scaffold commit.
 
-  Add `TestProcessFiles_ReportsFailuresAfterLaterFilesRun` to `main_integration_test.go`. Create one
-  invalid HCL file followed by one valid matching module file, capture log output, and assert the
-  wished-for result:
-
-  ```go
-  result := processFiles(
-      []string{invalidFile, validFile},
-      []ModuleUpdate{{Source: "terraform-aws-modules/vpc/aws", Version: "2.0.0"}},
-      &cliFlags{output: "text"},
-  )
-
-  if result.updates != 1 || result.failures != 1 {
-      t.Fatalf("processFiles() = %+v, want 1 update and 1 failure", result)
-  }
-  updated, err := os.ReadFile(validFile)
-  if err != nil {
-      t.Fatal(err)
-  }
-  if !strings.Contains(string(updated), `version = "2.0.0"`) {
-      t.Fatalf("later valid file was not processed: %s", updated)
-  }
-  ```
-
-- [ ] **Step 2: Run the focused test and verify RED**
-
-  Run: `go test -run TestProcessFiles_ReportsFailuresAfterLaterFilesRun -v`
-
-  Expected: compilation fails because `processFiles` still returns `int`.
-
-- [ ] **Step 3: Return update and failure counts from every processing loop**
-
-  Add this domain result near the processing functions:
-
-  ```go
-  type processingResult struct {
-      updates  int
-      failures int
-  }
-
-  func (r processingResult) add(other processingResult) processingResult {
-      r.updates += other.updates
-      r.failures += other.failures
-      return r
-  }
-  ```
-
-  Change all three file-processing loops to increment `failures` when an update function returns an
-  error, continue to later files, and return the struct. Preserve the existing per-file error log.
-  Update existing tests and summaries to read `.updates` rather than expecting an `int`.
-
-- [ ] **Step 4: Add the failing non-zero-exit test**
-
-  Add `TestExitAfterProcessingFailures_UsesDeterministicCount` to `cli_functions_test.go`. Capture
-  stderr and replace `exitFunc` with the existing panic-based test helper. Assert exit code `1` and
-  this exact final line:
-
-  ```text
-  Failed to process 2 file operation(s)
-  ```
-
-- [ ] **Step 5: Run the exit test and verify RED**
-
-  Run: `go test -run TestExitAfterProcessingFailures_UsesDeterministicCount -v`
-
-  Expected: compilation fails because `exitAfterProcessingFailures` is undefined.
-
-- [ ] **Step 6: Exit only after summaries and all file processing finish**
-
-  Implement:
-
-  ```go
-  func exitAfterProcessingFailures(failures int) {
-      if failures == 0 {
-          return
-      }
-      fmt.Fprintf(os.Stderr, "Failed to process %d file operation(s)\n", failures)
-      exitFunc(1)
-  }
-  ```
-
-  Accumulate results across Terraform, provider, and module operations in config mode. Print the
-  existing summary first, then call `exitAfterProcessingFailures`. Apply the same ordering to each
-  direct CLI mode.
-
-- [ ] **Step 7: Run focused and full Go verification**
-
-  Run:
-
-  ```text
-  go test -run 'TestProcessFiles_ReportsFailuresAfterLaterFilesRun|TestExitAfterProcessingFailures_UsesDeterministicCount' -v
-  make test-coverage
-  golangci-lint run --timeout=5m
-  go build ./...
-  ```
-
-  Expected: all pass; race coverage remains at least 80%; no warnings or uncaptured error output.
-
-- [ ] **Step 8: Create a signed checkpoint commit**
-
-  Write `/tmp/tfvb-task-1-commit.md` with:
-
-  ```text
-  fix: report aggregate file processing failures
-  ```
-
-  Stage only the files listed in this task and run:
-
-  ```text
-  /Users/dan/.codex/bin/codex-git add main.go main_integration_test.go integration_config_test.go coverage_test.go terraform_provider_test.go cli_functions_test.go main_coverage_test.go
-  /Users/dan/.codex/bin/codex-git commit -F /tmp/tfvb-task-1-commit.md
-  /Users/dan/.codex/bin/codex-git log -1 --show-signature --format=fuller
-  ```
-
----
-
-### Task 2: Discover Immutable State-Branch Inputs
+### Task 2: Discover immutable branch inputs
 
 **Files:**
-- Create: `examples/github-actions/.github/scripts/discover-state-branches.sh`
-- Create: `examples/github-actions/github-actions_test.sh`
 
-**Interfaces:**
-- Produces CLI:
+- Modify: `examples/github-actions/.github/scripts/discover-state-branches.sh`
+- Modify: `examples/github-actions/test.sh`
 
-  ```text
-  discover-state-branches.sh \
-    --repository <path> \
-    --allowed-prefixes-file <path> \
-    --narrow-prefix <literal-or-empty> \
-    --control-oid <40-or-64-hex-oid> \
-    --output <matrix-json-path>
-  ```
+Use a temporary real repository and bare remote. For each item below, add one focused test, run it
+RED for that behaviour, implement only that behaviour, and rerun GREEN:
 
-- Produces JSON:
+1. Literal allowed prefixes select branches and emit sorted JSON containing branch and exact remote
+   OID.
+2. An optional manual prefix narrows but cannot widen the allow-list.
+3. Overlapping prefixes deduplicate a branch.
+4. Empty, malformed, control-character, absolute-looking, no-match, and non-default-ref inputs fail
+   with stage-specific diagnostics.
+5. Valid hostile refs containing command substitutions, quotes, semicolons, leading dashes,
+   Unicode, percent signs, and GitHub's documented injection example remain inert data.
+6. Exactly 256 results succeed; 257 fail before matrix emission with a narrowing/partitioning
+   instruction.
+7. Output binds run ID, run attempt, policy ID, and one immutable control OID. A default-branch move
+   during discovery does not change that OID.
+8. `automation_policy_id` accepts only `^[a-z0-9][a-z0-9-]{0,31}$`.
 
-  ```json
-  {
-    "control_oid": "<oid>",
-    "include": [
-      {
-        "branch": "state/nonproduction/example",
-        "base_oid": "<oid>",
-        "artifact_key": "<sha256-of-full-ref>"
-      }
-    ]
-  }
-  ```
+Finish by running the complete discovery subset plus `bash -n`, then create a signed commit.
 
-- Consumers: Task 5 passes `.include` to all three per-branch matrices.
-
-- [ ] **Step 1: Build the shell-test harness and write discovery RED cases**
-
-  Create a Bash test that uses `mktemp -d`, real Git repositories, and bare remotes. Add focused
-  tests for:
-
-  - literal allow-list matches and manual narrowing;
-  - widening rejection;
-  - overlapping-prefix deduplication and bytewise sorting;
-  - no matches;
-  - exact base OIDs and one caller-supplied control OID;
-  - hostile valid refs containing slashes, semicolons, quotes, `$()`, leading dashes, Unicode, and
-    percent signs without command evaluation.
-
-  The key assertion should use `jq -e`, for example:
-
-  ```bash
-  jq -e '
-    .control_oid == $control_oid and
-    [.include[].branch] == [
-      "state/nonproduction/a",
-      "state/nonproduction/b"
-    ]
-  ' --arg control_oid "$control_oid" "$matrix_file" >/dev/null ||
-      fail "discovery output was not deterministic"
-  ```
-
-- [ ] **Step 2: Run the discovery tests and verify RED**
-
-  Run: `examples/github-actions/github-actions_test.sh discovery`
-
-  Expected: FAIL because `discover-state-branches.sh` does not exist.
-
-- [ ] **Step 3: Implement literal-prefix discovery**
-
-  The script must:
-
-  - use `git -C "$repository" ls-remote --heads origin` rather than checkout fetch depth;
-  - validate prefix lines and optional narrowing without `eval` or glob matching;
-  - compare with Bash literal slicing:
-
-    ```bash
-    [[ "$branch" == "$prefix"* ]]
-    ```
-
-  - hold refs as tab-separated or NUL-delimited data, never executable source;
-  - compute `artifact_key` with `shasum -a 256` on macOS or `sha256sum` on Linux through one
-    documented helper;
-  - build entries with `jq -n --arg`, sort with `LC_ALL=C`, deduplicate, reject an empty result, and
-    write atomically to the requested output path;
-  - provide complete `--help` output and stage-specific errors.
-
-- [ ] **Step 4: Run syntax and discovery tests GREEN**
-
-  Run:
-
-  ```text
-  bash -n examples/github-actions/.github/scripts/discover-state-branches.sh
-  examples/github-actions/github-actions_test.sh discovery
-  ```
-
-  Expected: PASS with no unexpected output.
-
-- [ ] **Step 5: Create a signed checkpoint commit**
-
-  Commit message file content:
-
-  ```text
-  feat: discover immutable state branches
-  ```
-
-  Run:
-
-  ```text
-  /Users/dan/.codex/bin/codex-git add examples/github-actions/.github/scripts/discover-state-branches.sh examples/github-actions/github-actions_test.sh
-  /Users/dan/.codex/bin/codex-git commit -F /tmp/tfvb-task-2-commit.md
-  /Users/dan/.codex/bin/codex-git log -1 --show-signature --format=fuller
-  ```
-
----
-
-### Task 3: Prepare Immutable Candidates Before Provider Execution
+### Task 3: Add command-scoped authenticated Git transport
 
 **Files:**
-- Create: `examples/github-actions/.github/scripts/process-state-branch.sh`
-- Modify: `examples/github-actions/github-actions_test.sh`
-- Create: `examples/github-actions/testdata/hostile-provider.sh`
 
-**Interfaces:**
-- Produces modes:
-
-  ```text
-  process-state-branch.sh prepare --control <path> --target <path> --branch <ref> \
-    --base-oid <oid> --control-oid <oid> --config <relative-path> \
-    --directories-file <path> --tf-version-bump <path> --terraform <path> \
-    --bundle <directory>
-
-  process-state-branch.sh validate --control <path> --target <path> \
-    --bundle <directory> --outcome <directory> --terraform <path>
-  ```
-
-- Produces successful `manifest.json` schema:
-
-  ```json
-  {
-    "schema_version": 1,
-    "control_oid": "<oid>",
-    "state_branch": "<ref>",
-    "base_oid": "<oid>",
-    "artifact_key": "<sha256-of-ref>",
-    "classification": "success",
-    "directories": [{"path": ".", "provider_dependencies": true}],
-    "files": [{"path": "main.tf", "mode": "100644", "kind": "terraform", "sha256": "<hex>"}],
-    "patch_sha256": "<hex>"
-  }
-  ```
-
-- Classification values are exactly `automation`, `shared/init`, `branch-update`,
-  `branch-validation`, and `success`.
-- A failed preparation bundle contains `manifest.json` and logs but no `candidate.patch`.
-- A validation outcome contains `schema_version`, `candidate_manifest_sha256`, `classification`,
-  optional `directory`, and log names; it never contains source or lock bytes.
-- Consumers: Task 4 reconciles only a successful candidate plus its exact bound outcome.
-
-- [ ] **Step 1: Write preparation RED cases**
-
-  Extend the test harness with real `tf-version-bump` and Terraform executables. Add cases for:
-
-  - root-directory update and lock staging;
-  - two sequential Terraform roots;
-  - provider-free success without `.terraform.lock.hcl`;
-  - required provider lock creation and ignored-lock rejection;
-  - duplicate, missing, absolute, escaping, and symlinked directory/config paths;
-  - symlinked `.tf` and lock files;
-  - an unexpected changed path;
-  - aggregate CLI failure after a later valid `.tf` file changes;
-  - init failure classified `shared/init` with logs and no candidate patch.
-
-- [ ] **Step 2: Run preparation tests and verify RED**
-
-  Run: `examples/github-actions/github-actions_test.sh prepare`
-
-  Expected: FAIL because `process-state-branch.sh` is absent.
-
-- [ ] **Step 3: Implement containment and preflight helpers**
-
-  In `process-state-branch.sh`, implement and reuse:
-
-  ```text
-  canonical_under_root <root> <relative-path>
-  require_regular_file <root> <relative-path>
-  load_unique_directories <target-root> <directories-file>
-  enumerate_direct_tf_files <directory>
-  classify_changed_paths <target-root> <directories-json>
-  sha256_file <path>
-  ```
-
-  `canonical_under_root` must reject absolute paths, `..`, missing paths, symlinks, and canonical
-  paths outside the root. Use `lstat`-equivalent shell checks (`[[ -L ... ]]`, `[[ -f ... ]]`) before
-  any write and repeat checks for every staged path.
-
-- [ ] **Step 4: Implement preparation and immutable bundle creation**
-
-  For each canonical directory:
-
-  ```text
-  tf-version-bump -pattern '*.tf' -config <control-config>
-  terraform -chdir=<directory> init -upgrade -backend=false -input=false -no-color
-  ```
-
-  Inspect canonical `.terraform/providers` before deleting `.terraform/`. Require a regular lock
-  when any provider package exists; otherwise mark the root provider-free. Stage only declared
-  direct `.tf` files and required lock files in the disposable target index, then create a binary
-  full-index patch from the index so new lock files are included. Create every JSON value with
-  `jq --arg`, hash the manifest payload, patch, and declared files, and write logs with bounded
-  routine output.
-
-- [ ] **Step 5: Write validation and hostile-provider RED cases**
-
-  Add tests that:
-
-  - copy a successful preparation bundle aside, record all hashes, and validate from a fresh target
-    checkout;
-  - reject missing, duplicate, traversal, symlink-mode, hash-mismatched, ref-mismatched, and
-    candidate-digest-mismatched artefacts;
-  - install `hostile-provider.sh` through a temporary Terraform filesystem mirror. Its process-start
-    code tries to overwrite the validation checkout lock, alter a supplied control path, append to
-    `GITHUB_ENV` and `GITHUB_PATH`, and create a fake outcome before exiting with an invalid plugin
-    handshake;
-  - assert the original preparation bundle hashes are unchanged and the outcome is
-    `branch-validation` or `automation`, never `success`.
-
-- [ ] **Step 6: Run validation tests and verify RED**
-
-  Run: `examples/github-actions/github-actions_test.sh validate`
-
-  Expected: FAIL because validate mode is not implemented.
-
-- [ ] **Step 7: Implement fresh validation without publishable output**
-
-  Validate the candidate manifest and patch before applying them to a fresh exact-base checkout.
-  For provider roots run:
-
-  ```text
-  terraform -chdir=<directory> init -backend=false -input=false -no-color -lockfile=readonly
-  terraform -chdir=<directory> validate -no-color
-  ```
-
-  Omit `-lockfile=readonly` only for manifest-declared provider-free roots. Bind the outcome to the
-  SHA-256 of the exact candidate manifest. Write only outcome JSON and captured logs, then discard
-  the validation checkout. Never copy its `.tf` or lock files back to the bundle.
-
-- [ ] **Step 8: Run preparation and validation GREEN**
-
-  Run:
-
-  ```text
-  bash -n examples/github-actions/.github/scripts/process-state-branch.sh
-  bash -n examples/github-actions/testdata/hostile-provider.sh
-  examples/github-actions/github-actions_test.sh prepare
-  examples/github-actions/github-actions_test.sh validate
-  ```
-
-  Expected: PASS; the hostile provider cannot change the saved candidate.
-
-- [ ] **Step 9: Create a signed checkpoint commit**
-
-  Commit message file content:
-
-  ```text
-  feat: prepare and validate state branch candidates
-  ```
-
-  Run:
-
-  ```text
-  /Users/dan/.codex/bin/codex-git add examples/github-actions/.github/scripts/process-state-branch.sh examples/github-actions/github-actions_test.sh examples/github-actions/testdata/hostile-provider.sh
-  /Users/dan/.codex/bin/codex-git commit -F /tmp/tfvb-task-3-commit.md
-  /Users/dan/.codex/bin/codex-git log -1 --show-signature --format=fuller
-  ```
-
----
-
-### Task 4: Reconcile Owned Branches, Pull Requests, and Issues
-
-**Files:**
+- Modify: `examples/github-actions/.github/scripts/discover-state-branches.sh`
 - Modify: `examples/github-actions/.github/scripts/process-state-branch.sh`
-- Modify: `examples/github-actions/github-actions_test.sh`
+- Modify: `examples/github-actions/test.sh`
 
-**Interfaces:**
-- Adds mode:
+1. Add a real authenticated bare HTTP Git service to the test harness. First prove unauthenticated
+   `ls-remote`, fetch, and push fail.
+2. Add a focused discovery test requiring authenticated `ls-remote`. Observe RED.
+3. Implement a token-free `GIT_ASKPASS` helper plus mode-`0600` token file for the exact child Git
+   command. Keep the token out of URLs and process arguments, disable prompts, and remove both files
+   in unconditional cleanup. Rerun GREEN and inspect the service request.
+4. Repeat focused RED/GREEN tests for authenticated fetch, atomic update, and exact-lease deletion
+   through the processing helper.
+5. Add a failure-path test proving credential files are removed and no repository config or remote
+   URL retains the token.
 
-  ```text
-  process-state-branch.sh reconcile --control <path> --target <path> \
-    --bundle <directory> --outcome <directory-or-empty> --remote origin \
-    --repository <owner/name> --run-url <url> --token-mode <builtin|app> \
-    --bot-login <github-actions[bot]-or-app-slug[bot]> \
-    --signing-key <path-or-empty> --author-name <name-or-empty> \
-    --author-email <email-or-empty>
-  ```
+Run the authentication subset under shell tracing disabled, then create a signed commit.
 
-- Consumes publication credential only through `GH_TOKEN` in reconcile mode.
-- Produces update ref `update_<state-branch>`.
-- Produces commit trailers:
-
-  ```text
-  TF-Version-Bump-Managed: true
-  TF-Version-Bump-State-Branch: <full-ref>
-  TF-Version-Bump-Base-OID: <oid>
-  TF-Version-Bump-Control-OID: <oid>
-  ```
-
-- Produces PR/issue marker `<!-- tf-version-bump-managed:sha256:<artifact-key> -->`.
-
-- [ ] **Step 1: Write reconciliation safety RED cases**
-
-  Source the script from the harness and test its real Git helpers against bare remotes. Cover:
-
-  - independent reproduction of `.tf` changes before applying candidate lock bytes;
-  - base movement between validation and publication;
-  - stable automation-branch creation and regeneration;
-  - unowned existing ref refusal;
-  - ownership requiring both exact commit trailers and the marked PR record supplied to the helper;
-  - update force-with-lease mismatch;
-  - deletion expected-old-OID mismatch;
-  - no-change owned-ref deletion and obsolete PR payload;
-  - success after a previous marked failure issue;
-  - deterministic validation failure after a previous marked PR;
-  - PR and issue bodies containing hostile ref text as data.
-
-  Do not stub or mock `gh`; pass fixture JSON into pure selection/body functions and leave actual
-  API calls to real-service acceptance.
-
-- [ ] **Step 2: Run reconciliation tests and verify RED**
-
-  Run: `examples/github-actions/github-actions_test.sh reconcile`
-
-  Expected: FAIL because reconcile mode and ownership helpers are undefined.
-
-- [ ] **Step 3: Implement candidate revalidation and Git ownership**
-
-  Reconciliation must re-check both artefacts, bind the outcome to the candidate digest, fresh
-  checkout the exact control/base OIDs, rerun only `tf-version-bump`, and require the `.tf` hashes to
-  match. Apply only declared lock hunks from the pre-provider patch and verify the complete result.
-
-  Before changing an existing update ref, fetch its exact OID and require matching trailers plus a
-  marked PR. Use exact leases:
-
-  ```bash
-  git push --force-with-lease="refs/heads/$update_branch:$expected_oid" \
-      origin "HEAD:refs/heads/$update_branch"
-  git push --force-with-lease="refs/heads/$update_branch:$expected_oid" \
-      origin ":refs/heads/$update_branch"
-  ```
-
-  Use an empty expected OID only when creating a ref proven absent. Never retry without the lease.
-
-- [ ] **Step 4: Implement deterministic GitHub payloads and lifecycle calls**
-
-  Render PR and issue bodies to files with `jq --arg` and bounded log tails. Enumerate API results
-  with `gh api --paginate --method GET`, then select exact base/head refs and exact hidden markers;
-  never rely on a fuzzy title search. Use `gh pr create/edit/close` and `gh issue create/edit/close`
-  only after exact selection. A deterministic update/validation failure closes the stale marked PR,
-  lease-deletes its owned branch, and updates one marked issue. Init/automation failures leave the
-  prior PR untouched and fail the job. For unsigned commits, query the exact bot login with
-  `gh api "/users/$bot_login" --jq .id` and construct
-  `<id>+<bot-login>@users.noreply.github.com`; do not hard-code or guess the numeric ID.
-
-- [ ] **Step 5: Write signing RED cases**
-
-  Add tests for:
-
-  - unsigned commit when no key is supplied;
-  - signed commit with an ephemeral Ed25519 key and explicit identity;
-  - local signature verification with a generated allowed-signers file;
-  - partial identity/key rejection;
-  - signing failure with no unsigned fallback;
-  - unconditional private-key and allowed-signers cleanup.
-
-- [ ] **Step 6: Run signing tests and verify RED**
-
-  Run: `examples/github-actions/github-actions_test.sh signing`
-
-  Expected: FAIL until reconcile signing is implemented.
-
-- [ ] **Step 7: Implement repository-scoped optional SSH signing**
-
-  Configure only the disposable target repository:
-
-  ```bash
-  git -C "$target" config gpg.format ssh
-  git -C "$target" config user.signingkey "$temporary_key"
-  git -C "$target" config commit.gpgsign true
-  ```
-
-  Derive the public key with `ssh-keygen -y`, create an allowed-signers file for the exact author
-  email, commit with the stable subject, and verify with `git verify-commit`. A trap removes both
-  files on every exit path.
-
-- [ ] **Step 8: Run all local script tests GREEN**
-
-  Run:
-
-  ```text
-  examples/github-actions/github-actions_test.sh reconcile
-  examples/github-actions/github-actions_test.sh signing
-  examples/github-actions/github-actions_test.sh all
-  ```
-
-  Expected: PASS; no GitHub network mutation occurs.
-
-- [ ] **Step 9: Create a signed checkpoint commit**
-
-  Commit message file content:
-
-  ```text
-  feat: reconcile managed state branch updates
-  ```
-
-  Run:
-
-  ```text
-  /Users/dan/.codex/bin/codex-git add examples/github-actions/.github/scripts/process-state-branch.sh examples/github-actions/github-actions_test.sh
-  /Users/dan/.codex/bin/codex-git commit -F /tmp/tfvb-task-4-commit.md
-  /Users/dan/.codex/bin/codex-git log -1 --show-signature --format=fuller
-  ```
-
----
-
-### Task 5: Wire the Four-Stage Reusable Workflow
+### Task 4: Enforce path and workspace safety
 
 **Files:**
+
+- Modify: `examples/github-actions/.github/scripts/process-state-branch.sh`
+- Modify: `examples/github-actions/test.sh`
+
+Introduce each rejection through an independent RED/GREEN cycle:
+
+1. Config paths and Terraform roots must be relative, present, canonical, inside their checkout,
+   and unique after canonicalisation.
+2. Nested roots are allowed, but each `*.tf` file belongs directly to exactly one configured root.
+3. Matching `.tf` files and lock files must be regular, non-symlink files whose canonical paths stay
+   under the target root.
+4. A repository `.terraform` entry is rejected whether it is a directory, symlink, or has a
+   symlinked ancestor.
+5. Every Terraform root receives a fresh absolute trusted `TF_DATA_DIR` outside both checkouts.
+6. NUL-delimited status inspection rejects every changed or untracked path except a direct `.tf`
+   file or its root's `.terraform.lock.hcl`.
+
+Cover escapes into the sibling control checkout and outside both checkouts. Run the focused suite
+and create a signed commit.
+
+### Task 5: Prepare immutable candidates
+
+**Files:**
+
+- Modify: `examples/github-actions/.github/scripts/process-state-branch.sh`
+- Modify: `examples/github-actions/test.sh`
+
+1. Add a RED test for `prepare` downloading the `v1.0.0-rc.7` Linux x86-64 archive, verifying its
+   recorded SHA-256 before extraction, checking the binary's reported version, and running it with
+   `*.tf` plus the control config in one real Terraform root. Implement only that download,
+   verification, and update path.
+2. Add a RED test for `terraform init -upgrade -backend=false -input=false -no-color` using the
+   trusted data directory and a 20-minute command timeout. Implement and rerun GREEN.
+3. Add separate RED/GREEN cases for a provider root requiring a regular persisted lock, a
+   provider-free root legitimately omitting one, and an ignored newly required lock failing without
+   force-add.
+4. Add a RED test for two roots and deterministic failure attribution. Implement sequential root
+   handling and rerun GREEN.
+5. Add one manifest field at a time with a focused assertion: schema version; run ID/attempt/policy;
+   control/ref/base identity; config and exact tool/archive/image pins; classification; roots and
+   provider dependency state; changed paths, modes, and SHA-256 hashes.
+6. Add a RED test for an immutable binary patch and collision-resistant artefact key containing run
+   ID, attempt, policy, and complete-ref hash. Implement and rerun GREEN.
+7. Add failure-bundle cases for aggregate CLI failure and init timeout. Neither may contain a
+   publishable patch; the latter is classified `branch-init` for bounded issue reporting.
+
+Run all preparation cases with the released CLI and pinned Terraform version, then create a signed
+commit.
+
+### Task 6: Validate inside the constrained container
+
+**Files:**
+
+- Create/modify: `examples/github-actions/test-fixtures/hostile-provider/**`
+- Modify: `examples/github-actions/.github/scripts/process-state-branch.sh`
+- Modify: `examples/github-actions/test.sh`
+
+1. Build the smallest real Linux hostile provider fixture needed to observe its environment and
+   attempted filesystem writes. Pin its test build inputs, place it in a trusted read-only
+   filesystem mirror, and generate a host-owned Terraform CLI configuration for test mode only. Do
+   not introduce a mock provider, workflow input, or state-branch-controlled mirror/config path.
+2. Add a RED `validate` test that verifies the candidate manifest and applies its patch only to a
+   disposable validation checkout. Implement that boundary.
+3. Add a RED test that starts the digest-pinned image with no Docker socket, dropped capabilities,
+   `no-new-privileges`, resource/process limits, runner UID/GID, and only the disposable checkout
+   plus trusted data directory mounted. Pass only explicit non-secret Terraform variables. Implement
+   the smallest container invocation and rerun GREEN.
+4. Add a RED test that checks `terraform version -json` in the image before target content is used.
+   Reject a tag/digest/version mismatch.
+5. Add focused tests for provider and provider-free init/validate commands, including
+   `-lockfile=readonly` only when a lock exists.
+6. Add hostile delayed/background attempts against credentials, candidate, lock, control checkout,
+   `GITHUB_ENV`, `GITHUB_PATH`, outcome path, and container socket. The constrained container mounts
+   the reviewed test mirror and CLI config read-only only when the harness enables its internal test
+   mode. The trusted host—not a mounted target process—must create the outcome from the observed
+   container status after termination.
+7. Add a hanging-provider RED test. Enforce the 20-minute per-root timeout with injectable shorter
+   test duration and classify it as `branch-validation`.
+8. State in test names and assertions that a zero supervised exit is all this boundary authenticates;
+   it cannot prove an adversarial provider's semantic honesty.
+
+Run the tests on a host with Docker available and create a signed commit.
+
+### Task 7: Verify artefacts without credentials
+
+**Files:**
+
+- Modify: `examples/github-actions/.github/scripts/process-state-branch.sh`
+- Modify: `examples/github-actions/test.sh`
+
+For each check, add a targeted corrupt bundle, observe RED, implement rejection, and rerun GREEN:
+
+1. Unknown schema, missing/duplicate/unexpected artefact, wrong run ID or attempt, wrong policy,
+   control OID, branch, base OID, or candidate digest.
+2. Absolute, escaping, duplicate, symlink, non-regular, mode-mismatched, hash-mismatched, or
+   undeclared paths.
+3. Patch paths outside the declaration or a changed `.tf` file not mapped directly to one root.
+4. Contradictory or unknown result classifications.
+5. Independent `v1.0.0-rc.7` source reproduction against a fresh exact-base checkout, accepting only
+   an exact source diff before applying declared lock bytes.
+6. Full-run and failed-job rerun fixtures whose run-attempt-specific artefacts cannot cross-consume.
+
+The resulting `verify` mode writes only a local verified-result file. Add a test proving no GitHub
+write token, App key, or signing key exists in its environment or temporary tree. Run the complete
+subset and create a signed commit.
+
+### Task 8: Preflight ownership and remote state
+
+**Files:**
+
+- Modify: `examples/github-actions/.github/scripts/process-state-branch.sh`
+- Modify: `examples/github-actions/test.sh`
+
+1. Add focused RED/GREEN tests for the exact mapping
+   `state/nonproduction/example-thing` to
+   `update_state/nonproduction/example-thing`.
+2. Define exact machine commit trailers and hidden PR/issue markers containing policy, state/base,
+   control OID, run ID, and run attempt. Add parser tests for missing, duplicate, malformed, and
+   mismatched markers before accepting valid ownership.
+3. Add a foreign-policy collision test. Even with the required branch name, it must fail without
+   adoption or mutation.
+4. Add tests that an existing ref requires both its marked tip commit and corresponding exact-base/
+   exact-head PR to agree. Cover open and closed PRs.
+5. Add issue ownership tests requiring the expected marker, policy, and immutable bot author login.
+6. Add a `prepublish` test that command-scoped auth fetches current state/update refs and queries
+   records only after credential-free verification. The signing key remains absent.
+7. Add a test for policy-independent per-state publication locking so overlapping policies cannot
+   publish the same update ref concurrently.
+
+Local tests cover parsers and real Git. Defer GitHub API assertions to the disposable-repository
+gate. Run the subset and create a signed commit.
+
+### Task 9: Sign and publish with atomic Git guards
+
+**Files:**
+
+- Modify: `examples/github-actions/.github/scripts/process-state-branch.sh`
+- Modify: `examples/github-actions/test.sh`
+
+1. Add a RED test that signing material is created only after a verified-result and successful
+   preflight. Implement the publish-only key materialisation and unconditional cleanup.
+2. Add a RED signed-commit test using a temporary SSH key. Configure signing only in the target
+   repository, require explicit author identity, verify locally, and stop without unsigned fallback
+   on signing failure. Add a separate unsigned case when no key is configured.
+3. Add a RED real-bare-remote test for one atomic push containing a no-op state ref guarded by the
+   exact validated-base lease and the create/update automation ref guarded by its expected OID.
+   Implement and rerun GREEN.
+4. Move the state ref at the push boundary and prove neither ref update is accepted. This test must
+   exercise the atomic push, not only an earlier comparison.
+5. Add exact-lease tests for automation-ref update and deletion races. Never retry unconditionally.
+6. Add post-push and post-PR state checks. On detected movement, roll back only the OID written by
+   the current invocation with an exact lease.
+7. Add failpoints after ref create/update. A later PR failure exact-lease-deletes a newly created
+   ref or restores the previous OID. An ambiguous response first re-reads markers. A compensation
+   lease mismatch reports manual recovery and preserves the unseen writer's change.
+8. For no-change cleanup, delete the marked ref atomically before closing the PR. Add recovery for
+   API failure after deletion.
+
+Run the atomic publication suite repeatedly to expose races, then create a signed commit.
+
+### Task 10: Reconcile PRs, issues, and safe Markdown
+
+**Files:**
+
+- Modify: `examples/github-actions/.github/scripts/process-state-branch.sh`
+- Modify: `examples/github-actions/test.sh`
+
+1. Add one Markdown encoder test using hostile branch names, paths, diagnostics, HTML, links, and
+   mentions. Escape `&`, `<`, `>`, neutralise `@`, use bounded `<code>`/`<pre>` output, and pass JSON
+   values with `jq --arg` or body files.
+2. Add deterministic PR-body tests for every required identity, tool/image pin, changed file, root,
+   run link, ownership warning, and semantic-validation limitation.
+3. Add classification tests with precedence `automation`, `branch-update`, `branch-init`,
+   `branch-validation`, `success`. Only update, init, and validation failures produce branch issues;
+   auth, signing, lease, manifest, and repository-policy failures do not. Init issues explicitly
+   state that registry, authentication, rate-limit, network, or other dependency causes may be
+   transient.
+4. Add deterministic issue-body tests for exact stage/root/command, bounded captured output, run/log
+   links, and stable marker/title.
+5. Add lifecycle payload tests: success creates/refreshes one exact PR and closes a marked issue;
+   update/init/validation failure closes the stale marked PR, exact-lease-deletes its owned ref,
+   then creates or updates one issue; automation failure leaves the prior PR unchanged; recovery
+   adds a bounded comment and closes only the correctly authored issue.
+6. Add PR edit/close and issue edit/close failpoints. Each must have either explicit compensation or
+   a safe idempotent retry determined by re-reading exact markers.
+
+Do not mock `gh`. These local tests call pure payload/decision modes and real Git; Task 15 verifies
+API effects. Run the focused suite and create a signed commit.
+
+### Task 11: Wire the reusable workflow
+
+**Files:**
+
 - Create: `examples/github-actions/.github/workflows/tf-version-bump-reusable.yml`
-- Modify: `examples/github-actions/github-actions_test.sh`
+- Modify: `examples/github-actions/test.sh`
 
-**Interfaces:**
-- Implements these exact `workflow_call` inputs: `allowed_branch_prefixes`, `branch_prefix`,
-  `config_path`, `terraform_directories`, `terraform_version`, `tf_version_bump_version`,
-  `go_version`, `dry_run`, `max_parallel`, `commit_author_name`, `commit_author_email`,
-  `github_app_client_id`, and `publication_environment`.
-- Exposes jobs `discover`, `prepare`, `validate`, and `reconcile`.
-- Consumes `TF_VERSION_BUMP_GITHUB_APP_PRIVATE_KEY` and
-  `TF_VERSION_BUMP_COMMIT_SIGNING_PRIVATE_KEY` only from the reconciliation environment.
+Add each workflow contract through a focused structural or actionlint RED/GREEN cycle:
 
-- [ ] **Step 1: Add failing workflow-structure assertions**
+1. Declare the complete typed interface, including the release archive SHA-256, fixed protected-
+   environment secrets, semantic-version tag and digest validation, policy regex, paired
+   App/signing inputs, and `unattended_checks_safe` gate.
+2. Add `discover` with `contents: read`, immutable control SHA, released CLI download/verification,
+   command-scoped authenticated discovery, and a 10-minute job timeout.
+3. Add `prepare` and `validate` matrices with `fail-fast: false`, `max-parallel`, `contents: read`,
+   exact OID checkouts, no credentials/secrets, run-attempt artefact names, unconditional result
+   upload, 20-minute operation timeouts, and 30-minute job timeouts.
+4. Add a separate `verify` matrix with `always()`, `contents: read`, no publication environment or
+   protected secrets, exact artefact enumeration, a 15-minute operation limit, and a 20-minute job
+   timeout. It uploads one narrowly scoped verified-result artefact per current run attempt.
+5. Add a dependent `publish` matrix on a fresh protected runner with a 10-minute operation limit and
+   15-minute job timeout. It validates the verified-result identity without sourcing it, then uses
+   App/built-in auth only for `prepublish` and exact child commands; the signing secret is
+   materialised only for `publish`.
+6. Ensure dry run never references the protected publication environment or enters verification or
+   publication, but still executes real preparation and validation and retains diagnostics.
+7. Add App token creation pinned to the stated SHA and repository/permission limits. In App mode,
+   the caller ceiling leaves the effective `GITHUB_TOKEN` read-only; it is never passed to a write
+   child.
+8. Add policy-independent state-branch publication concurrency and supported caller concurrency
+   using only `group` and `cancel-in-progress`. Do not use a `queue` key.
+9. Verify every checkout has `persist-credentials: false`, every action pin matches the approved
+   SHA, and no untrusted expression appears directly in `run:` source.
 
-  Extend the harness to copy the example `.github` tree into a temporary consumer repository and
-  assert with actionlint plus exact `rg` checks that:
+Run the pinned actionlint launcher against the temporary consumer-style `.github` tree after every
+workflow increment. It must need no ignored diagnostics. Create a signed commit.
 
-  - all required inputs and defaults exist;
-  - manual dispatch from a non-default ref fails before matrix creation;
-  - the shared tf-version-bump config is validated once against a trusted temporary fixture before
-    branch discovery;
-  - discovery/preparation/validation have `contents: read` only;
-  - reconciliation declares the three write scopes but receives the caller's effective ceiling;
-  - every checkout disables persisted credentials;
-  - matrices use `fail-fast: false` and the `max_parallel` input;
-  - validate and reconcile use `if: always()` as required;
-  - dry run cannot enter the reconciliation environment;
-  - no `${{ matrix.branch }}`, input, ref, or manifest expression appears directly inside `run:`;
-  - every `uses:` value is one of the exact pinned SHAs in Global Constraints.
-
-- [ ] **Step 2: Run workflow structure tests and verify RED**
-
-  Run: `examples/github-actions/github-actions_test.sh workflow`
-
-  Expected: FAIL because the reusable workflow does not exist.
-
-- [ ] **Step 3: Implement discovery and credential-free matrices**
-
-  Reject manual execution unless `github.ref` equals
-  `refs/heads/${{ github.event.repository.default_branch }}`. Use exact control checkout
-  `github.sha`, validate the shared config once with the pinned CLI against a trusted temporary
-  Terraform fixture, emit the discovery JSON through `$GITHUB_OUTPUT`, and pass all untrusted matrix
-  values through step `env:`. Install Go and Terraform from their exact workflow inputs, with
-  `terraform_wrapper: false`, and install `tf-version-bump` from its exact tag input.
-
-  Preparation must always upload one collision-resistant artefact. Validation runs with `always()`,
-  downloads only the expected successful candidate, uploads only its bound outcome/log artefact,
-  and never receives secrets or write permissions. Preserve script exit status through
-  `continue-on-error` steps and a final status step whose value arrives through `env:`.
-
-- [ ] **Step 4: Implement protected reconciliation**
-
-  Run only when `dry_run == false`, after all preparation and validation matrix jobs. Set
-  `environment.name` from `publication_environment`, download only exact run/branch artefact names,
-  and validate before credential creation.
-
-  For App mode use the pinned token action with:
-
-  ```yaml
-  client-id: ${{ inputs.github_app_client_id }}
-  private-key: ${{ secrets.TF_VERSION_BUMP_GITHUB_APP_PRIVATE_KEY }}
-  permission-contents: write
-  permission-pull-requests: write
-  permission-issues: write
-  ```
-
-  Leave `owner` and `repositories` unset so the token is scoped to the current repository. Pass
-  either the App token or built-in token as `GH_TOKEN` only to exact identity/publication steps.
-  Pass `${{ steps.app-token.outputs.app-slug }}[bot]` as the App bot login and
-  `github-actions[bot]` as the built-in bot login through `env:` rather than interpolating either
-  value into shell source.
-  After artefact validation, reject an App client ID without a private key, a private key without a
-  client ID, or a signing key without both explicit commit identity inputs. Materialise the signing
-  secret immediately before reconcile and remove it in `if: always()` cleanup.
-
-- [ ] **Step 5: Validate workflow syntax GREEN**
-
-  Run actionlint 1.7.12 against the temporary consumer root with only this exact temporary ignore:
-
-  ```text
-  -ignore '^unexpected key "queue" for "concurrency" section\.'
-  ```
-
-  Then run: `examples/github-actions/github-actions_test.sh workflow`
-
-  Expected: PASS with no other ignored diagnostics.
-
-- [ ] **Step 6: Create a signed checkpoint commit**
-
-  Commit message file content:
-
-  ```text
-  feat: add reusable state branch workflow
-  ```
-
-  Run:
-
-  ```text
-  /Users/dan/.codex/bin/codex-git add examples/github-actions/.github/workflows/tf-version-bump-reusable.yml examples/github-actions/github-actions_test.sh
-  /Users/dan/.codex/bin/codex-git commit -F /tmp/tfvb-task-5-commit.md
-  /Users/dan/.codex/bin/codex-git log -1 --show-signature --format=fuller
-  ```
-
----
-
-### Task 6: Add Production and Non-Production Consumers
+### Task 12: Add production and non-production callers
 
 **Files:**
+
 - Create: `examples/github-actions/.github/workflows/tf-version-bump-nonproduction.yml`
 - Create: `examples/github-actions/.github/workflows/tf-version-bump-production.yml`
 - Create: `examples/github-actions/.github/tf-version-bump/nonproduction.yml`
 - Create: `examples/github-actions/.github/tf-version-bump/production.yml`
-- Modify: `examples/github-actions/github-actions_test.sh`
+- Modify: `examples/github-actions/test.sh`
 
-**Interfaces:**
-- Non-production prefixes:
+1. Add the non-production caller with manual `branch_prefix`/`dry_run`, a 04:17 daily
+   `Australia/Melbourne` schedule, policy `nonproduction`, the three documented prefixes, root `.`,
+   exact release/archive/image pins, and native last-pending-wins concurrency. Populate the archive
+   digest only from the completed `v1.0.0-rc.7` release acceptance record.
+2. Add the production caller with the same manual interface, a Sunday 04:43
+   `Australia/Melbourne` schedule, policy `production`, and the two production prefixes.
+3. Make built-in-token mode the copyable default. Add commented/documented App inputs only with the
+   explicit `unattended_checks_safe: true` acknowledgement.
+4. Add representative separate config files and validate each with the released CLI against a
+   trusted fixture before any matrix is created.
+5. Add tests for exact schedules, default-branch-only dispatch, permission ceilings, config paths,
+   prefix separation, and one-running/one-latest-pending semantics. Three rapid-run behaviour is a
+   real-service assertion, not an invented local scheduler.
 
-  ```text
-  state/nonproduction/
-  state/staging/
-  aws-state/nonproduction/
-  ```
+Run actionlint and the caller subset, then create a signed commit.
 
-- Production prefixes:
-
-  ```text
-  state/production/
-  aws-state/production/
-  ```
-
-- Both callers expose `branch_prefix` string and `dry_run` Boolean (`false`) manual inputs.
-
-- [ ] **Step 1: Add caller-policy RED assertions**
-
-  Assert exact schedules, timezones, prefix sets, config paths, tool pins, manual inputs, separate
-  concurrency groups, `queue: max`, no in-progress cancellation, and local reusable-workflow paths.
-  Assert scheduled calls supply an empty narrowing prefix and `dry_run: false`.
-
-- [ ] **Step 2: Run caller tests and verify RED**
-
-  Run: `examples/github-actions/github-actions_test.sh callers`
-
-  Expected: FAIL because caller workflows/configs are missing.
-
-- [ ] **Step 3: Create built-in-token caller examples**
-
-  The checked-in callers use built-in-token mode with job permissions:
-
-  ```yaml
-  contents: write
-  pull-requests: write
-  issues: write
-  ```
-
-  They pass exact illustrative versions `go_version: '1.25.0'`,
-  `terraform_version: '1.15.5'`, and `tf_version_bump_version: 'v1.0.0-rc.6'`, use
-  `terraform_directories: '.'`, and leave `github_app_client_id` empty. README instructions in Task
-  8 show the deliberate three-permission change to `contents: read` plus App client ID when
-  switching modes; do not imply runtime permission toggling.
-
-  Use schedules:
-
-  ```yaml
-  # Non-production
-  - cron: '17 4 * * *'
-    timezone: Australia/Melbourne
-
-  # Production
-  - cron: '43 4 * * 0'
-    timezone: Australia/Melbourne
-  ```
-
-- [ ] **Step 4: Add separate illustrative YAML configs**
-
-  Keep the configs valid under the existing schema and deliberately different so consumers can see
-  that production and non-production policy are independent. Use syntax examples, not claims that
-  module/provider versions are recommendations.
-
-- [ ] **Step 5: Run callers and actionlint GREEN**
-
-  Run:
-
-  ```text
-  examples/github-actions/github-actions_test.sh callers
-  examples/github-actions/github-actions_test.sh workflow
-  ```
-
-  Expected: PASS, including timezone and local reusable-path validation.
-
-- [ ] **Step 6: Create a signed checkpoint commit**
-
-  Commit message file content:
-
-  ```text
-  feat: add state branch workflow consumers
-  ```
-
-  Run:
-
-  ```text
-  /Users/dan/.codex/bin/codex-git add examples/github-actions/.github/workflows/tf-version-bump-nonproduction.yml examples/github-actions/.github/workflows/tf-version-bump-production.yml examples/github-actions/.github/tf-version-bump/nonproduction.yml examples/github-actions/.github/tf-version-bump/production.yml examples/github-actions/github-actions_test.sh
-  /Users/dan/.codex/bin/codex-git commit -F /tmp/tfvb-task-6-commit.md
-  /Users/dan/.codex/bin/codex-git log -1 --show-signature --format=fuller
-  ```
-
----
-
-### Task 7: Integrate Local Validation into Make and CI
+### Task 13: Integrate repository CI
 
 **Files:**
+
 - Modify: `Makefile`
 - Modify: `.github/workflows/ci.yml`
-- Modify: `examples/github-actions/github-actions_test.sh`
+- Modify: `examples/github-actions/test.sh`
 
-**Interfaces:**
-- Produces `make test-github-actions`.
-- CI runs the example suite once on Go 1.25 after installing Terraform 1.15.5.
+1. Add a focused self-test proving `make branch-automation-test` invokes shell syntax checks, the
+   full harness, Docker-boundary tests, and `scripts/run-actionlint.sh`; it must not call a bare PATH
+   `actionlint`.
+2. Add one CI step on Go 1.25 for the branch-automation target while preserving the existing
+   `examples/update-branches_test.sh` coverage.
+3. If Docker is unavailable, fail with an explicit prerequisite diagnostic; do not skip hostile
+   boundary tests silently.
+4. Run the Make target locally and inspect pristine output. Create a signed commit.
 
-- [ ] **Step 1: Add a failing Make target test**
-
-  Add a harness assertion that `make -n test-github-actions` resolves to the maintained test script
-  and does not silently skip actionlint or either helper's `bash -n` checks.
-
-- [ ] **Step 2: Run the target assertion and verify RED**
-
-  Run: `examples/github-actions/github-actions_test.sh repository-integration`
-
-  Expected: FAIL because the Make target is absent.
-
-- [ ] **Step 3: Add the Make target and CI step**
-
-  Add `test-github-actions` to `.PHONY` and help, with one recipe invoking
-  `examples/github-actions/github-actions_test.sh all`. In CI's Go 1.25 matrix entry, install
-  Terraform with the pinned setup action and `terraform_wrapper: false`, then run the Make target.
-  Keep the existing `update-branches_test.sh` step.
-
-- [ ] **Step 4: Run repository integration GREEN**
-
-  Run:
-
-  ```text
-  examples/github-actions/github-actions_test.sh repository-integration
-  make test-github-actions
-  actionlint
-  ```
-
-  Expected: PASS with only the exact documented queue diagnostic filtered inside the example
-  validator; repository workflows produce no actionlint output.
-
-- [ ] **Step 5: Create a signed checkpoint commit**
-
-  Commit message file content:
-
-  ```text
-  ci: validate GitHub Actions automation example
-  ```
-
-  Run:
-
-  ```text
-  /Users/dan/.codex/bin/codex-git add Makefile .github/workflows/ci.yml examples/github-actions/github-actions_test.sh
-  /Users/dan/.codex/bin/codex-git commit -F /tmp/tfvb-task-7-commit.md
-  /Users/dan/.codex/bin/codex-git log -1 --show-signature --format=fuller
-  ```
-
----
-
-### Task 8: Document Installation, Security, and Real-Service Acceptance
+### Task 14: Document installation, limits, and recovery
 
 **Files:**
+
 - Create: `examples/github-actions/README.md`
 - Modify: `examples/README.md`
 - Modify: `docs/ADVANCED-USAGE.md`
 - Modify: `README.md`
 
-**Interfaces:**
-- Documents the copy boundary: `examples/github-actions/.github/` to consumer `.github/`.
-- Documents fixed secrets:
-  - `TF_VERSION_BUMP_GITHUB_APP_PRIVATE_KEY`
-  - `TF_VERSION_BUMP_COMMIT_SIGNING_PRIVATE_KEY`
-- Documents the complete disposable-repository acceptance transcript required by the spec.
+Write the example guide specified by the design, including:
 
-- [ ] **Step 1: Write documentation acceptance checks before prose**
+- Copy paths, default-branch config ownership, single and newline-separated multiple roots.
+- `v1.0.0-rc.7` checksum/provenance prerequisite and digest-pinned Terraform image.
+- Literal allow-lists, manual narrowing, dry run, 256-branch limit, and exact schedules.
+- Protected publication environment, least privileges, fixed secret names, optional signing, and
+  no unsigned fallback after signing failure.
+- Command-scoped private-repository Git auth and why checkout persistence remains disabled.
+- Trusted data directories, provider/container boundary, timeouts, lock requirements, and valid
+  provider-free roots.
+- The honest security limit: the host authenticates process status, not semantic truth from a
+  malicious provider.
+- Current GitHub.com built-in-token recursion/approval behaviour and the need for GitHub Enterprise
+  Server consumers to verify their installed version. App mode is permitted only after the
+  documented downstream-workflow audit and acknowledgement; App event delivery is not itself a
+  security boundary.
+- Stable `update_<state-branch>` names, policy-scoped ownership, exact leases, best-effort Git/API
+  compensation, residual race, and manual recovery after a compensation lease conflict.
+- Run-attempt artefact identity, native one-running/one-latest-pending concurrency, and redispatching
+  a displaced manual dry run.
+- Failure classification and the manual, strongly marked orphan-cleanup procedure; automatic
+  destructive garbage collection remains out of scope.
+- The complete disposable private-repository acceptance procedure from the spec.
 
-  Extend the harness to require links and headings for installation, built-in token, App mode,
-  signing, single/multiple roots, dry run, lock files/provider-free roots, ownership/leases,
-  troubleshooting, orphan cleanup, GHES compatibility, and real-service acceptance.
+Link the detailed example from the existing examples, advanced-usage, and root documentation
+without duplicating the guide. Human prose receives direct review, not grep tests. Run link checks
+already present in the repository, if any, and create a signed docs commit.
 
-- [ ] **Step 2: Run documentation checks and verify RED**
+### Task 15: Cleanup, full verification, and disposable-service gate
 
-  Run: `examples/github-actions/github-actions_test.sh documentation`
+**Files:** Review all files changed by this plan.
 
-  Expected: FAIL because the example README and cross-links are absent.
+1. Run the `test-cleanup` skill in a separate subagent. Remove only duplicated or implementation-
+   shaped tests; retain every distinct security, race, lifecycle, and failure-class behaviour.
+2. Run `superpowers:requesting-code-review`, resolve every actionable finding through focused TDD,
+   and rerun cleanup if tests changed materially.
+3. Run the complete local gate with pristine output:
 
-- [ ] **Step 3: Write the consumer guide**
+   ```bash
+   bash -n scripts/run-actionlint.sh
+   bash -n examples/github-actions/.github/scripts/discover-state-branches.sh
+   bash -n examples/github-actions/.github/scripts/process-state-branch.sh
+   scripts/run-actionlint.sh examples/github-actions/.github/workflows/*.yml
+   examples/github-actions/test.sh
+   examples/update-branches_test.sh
+   make test-coverage
+   golangci-lint run --timeout=5m
+   go build ./...
+   ```
 
-  Include exact copy commands, files to customise, protected environment setup, default-branch
-  restrictions, trusted-dispatch assumptions, repository setting for Actions-created PRs, exact
-  version pins, and prefix/config separation.
-
-  Clearly distinguish:
-
-  - built-in mode: three write permissions, no App client ID, suppressed push workflows, and
-    approval-required PR checks;
-  - App mode: `contents: read` caller ceiling, client ID input, protected App key, and unattended PR
-    checks;
-  - unsigned mode versus explicit SSH signing with non-interactive key and registered public key;
-  - required lock for installed providers versus valid provider-free absence;
-  - GitHub.com support versus GHES queue and artefact-action compatibility checks.
-
-- [ ] **Step 4: Document deterministic recovery and deferred orphan cleanup**
-
-  Explain stable refs, ownership trailers/markers, state/base OIDs, update/deletion leases, unowned
-  collisions, stale-base failures, no-change cleanup, and the manual dry-run-first procedure for
-  orphaned refs/issues. Do not add automatic garbage collection.
-
-- [ ] **Step 5: Write the real-service acceptance procedure**
-
-  Provide exact steps for a disposable repository covering:
-
-  - matching/non-matching branches, provider and provider-free roots;
-  - default-branch-only protected publication environment;
-  - built-in and App permission summaries;
-  - alternate-ref rejection;
-  - hostile-provider candidate isolation;
-  - success, idempotence, validation failure/issue, recovery, and obsolete PR cleanup;
-  - three rapid queued dispatches;
-  - built-in approval-required checks versus App automatic checks;
-  - dry-run no-mutation comparison;
-  - unowned ref, lease races, and state-base movement;
-  - optional signed commit locally and GitHub-verified.
-
-  State explicitly that whoever executes acceptance must retain the terminal transcript and inspect
-  repository refs, PRs, issues, Actions permissions, and artefacts before claiming completion.
-
-- [ ] **Step 6: Add concise cross-links**
-
-  Add the GitHub Actions example to `examples/README.md`, distinguish it from local sequential
-  `update-branches.sh` in `docs/ADVANCED-USAGE.md`, and update the root README documentation table
-  without duplicating the consumer guide.
-
-- [ ] **Step 7: Run documentation checks GREEN**
-
-  Run:
-
-  ```text
-  examples/github-actions/github-actions_test.sh documentation
-  /Users/dan/.codex/bin/codex-git diff --check
-  ```
-
-  Expected: PASS; no placeholders, broken relative links, or trailing whitespace.
-
-- [ ] **Step 8: Create a signed checkpoint commit**
-
-  Commit message file content:
-
-  ```text
-  docs: explain state branch Actions automation
-  ```
-
-  Run:
-
-  ```text
-  /Users/dan/.codex/bin/codex-git add examples/github-actions/README.md examples/README.md docs/ADVANCED-USAGE.md README.md
-  /Users/dan/.codex/bin/codex-git commit -F /tmp/tfvb-task-8-commit.md
-  /Users/dan/.codex/bin/codex-git log -1 --show-signature --format=fuller
-  ```
-
----
-
-### Task 9: Cleanup, Full Verification, and Real-Service Gate
-
-**Files:**
-- Review all files changed by Tasks 1-8.
-- Modify only files required by findings from cleanup/review.
-
-**Interfaces:**
-- Produces the evidence required by the design completion criteria.
-
-- [ ] **Step 1: Run the mandatory independent test-cleanup pass**
-
-  Commit or stash a clean implementation checkpoint, then invoke the `test-cleanup` skill as a
-  fresh subagent. It must classify every Go and shell test changed on the branch, remove only
-  low-value duplication, rerun affected suites, and signed-commit any cleanup. Do not let an
-  implementation agent clean its own tests.
-
-- [ ] **Step 2: Request an adversarial implementation review**
-
-  Use `superpowers:requesting-code-review` after cleanup. Require the reviewer to compare the branch
-  against the design and concentrate on credential boundaries, artefact trust, hostile refs/paths,
-  provider execution, leases, ownership, dry-run mutations, and GitHub event behaviour. Resolve all
-  verified findings with TDD and signed commits.
-
-- [ ] **Step 3: Run the full local verification gate**
-
-  Run each command separately and inspect its complete output:
-
-  ```text
-  go mod download
-  go mod verify
-  go build ./...
-  make test-coverage
-  golangci-lint run --timeout=5m
-  examples/update-branches_test.sh
-  make test-github-actions
-  actionlint
-  /Users/dan/.codex/bin/codex-git diff --check main...HEAD
-  ```
-
-  Expected: every command exits zero, coverage remains at least 80%, and output contains no
-  warnings, ignored failures, uncaptured expected errors, or diagnostics other than the one exact
-  queue false positive filtered within the example validator.
-
-- [ ] **Step 4: Verify every branch commit signature**
-
-  List `main..HEAD`, inspect each with `--show-signature`, and stop if any Codex-created commit lacks
-  a good signature. Do not amend or rewrite with an unsigned fallback.
-
-- [ ] **Step 5: Obtain authority for disposable GitHub acceptance**
-
-  If Dan has not already authorised creation and deletion of the disposable repository and its App
-  installation/environment configuration, stop and request that authority. This gate must not be
-  replaced by mocks or claims based only on local tests.
-
-- [ ] **Step 6: Execute and retain the real-service transcript**
-
-  Follow `examples/github-actions/README.md` exactly. Verify every case enumerated in Task 8,
-  including three queued dispatches, App-mode read-only `GITHUB_TOKEN`, hostile-provider isolation,
-  built-in/App check triggering, dry-run no-mutation, leases, and optional signing. Save the
-  transcript outside the repository unless Dan explicitly requests a committed evidence file.
-
-- [ ] **Step 7: Run final repository-state checks**
-
-  Run:
-
-  ```text
-  /Users/dan/.codex/bin/codex-git status --short --branch
-  /Users/dan/.codex/bin/codex-git log --oneline --show-signature main..HEAD
-  ```
-
-  Expected: clean feature branch, no generated binaries/coverage artefacts staged, and every branch
-  commit signed.
-
-- [ ] **Step 8: Hand off with evidence**
-
-  Report the implementation commits, local verification results, coverage, cleanup/review outcome,
-  real-service acceptance repository/transcript location, and any operational setup Dan must retain.
-  Do not push or open a PR unless Dan requests it.
+4. With Dan's explicit approval for external mutations, run the documented acceptance in a
+   disposable private repository. It must cover authenticated discovery/push/delete, built-in and
+   audited App modes, alternate-ref environment denial, hostile-container and hostile-downstream
+   cases, provider/provider-free roots, run-attempt reruns, policy/unowned collisions, state and
+   deletion races, a real post-push PR-creation rejection with exact-lease rollback, dry run,
+   failure/recovery/cleanup, three rapid dispatches, and optional signed publication.
+5. Review the transcript against every completion criterion in the design. Do not claim completion
+   if any API, permissions, event, environment, queue, signing, compensation, or hostile-boundary
+   assertion was inferred rather than observed.
+6. Inspect the complete branch diff and worktree state with the Codex Git wrapper, ensure all
+   commits are signed, and create the final signed commit if verification or cleanup changed files.
+   Do not push without Dan's explicit instruction.

--- a/docs/superpowers/plans/2026-08-18-github-actions-branch-automation.md
+++ b/docs/superpowers/plans/2026-08-18-github-actions-branch-automation.md
@@ -104,8 +104,10 @@ phase.
 1. Add one harness assertion that the actionlint launcher exists and reports 1.7.12. Run it and
    observe RED because the launcher is absent.
 2. Add the smallest documented launcher using exactly
-   `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`. It accepts workflow paths, has
-   `--help`, and emits no output on success. Rerun GREEN.
+   `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12` plus only
+   `-ignore '^unexpected key "queue" for "concurrency" section\.'`. It accepts workflow paths, has
+   `--help`, explains that GitHub.com is authoritative for the newer property, and emits no output
+   on success. Rerun GREEN.
 3. Add one harness assertion that both runtime helpers support `--help`. Observe RED, then create
    only minimal executable help/usage scaffolds. Rerun GREEN.
 4. Add `branch-automation-test` and `actionlint` Make targets that delegate to these scripts. Do not
@@ -380,13 +382,15 @@ Add each workflow contract through a focused structural or actionlint RED/GREEN 
 7. Add App token creation pinned to the stated SHA and repository/permission limits. In App mode,
    the caller ceiling leaves the effective `GITHUB_TOKEN` read-only; it is never passed to a write
    child.
-8. Add policy-independent state-branch publication concurrency and supported caller concurrency
-   using only `group` and `cancel-in-progress`. Do not use a `queue` key.
+8. Add `queue: max` to caller concurrency and to policy-independent state-branch publication
+   concurrency, with no in-progress cancellation. Add the exact actionlint 1.7.12 suppression for
+   its stale `queue` parser diagnostic and no other warning.
 9. Verify every checkout has `persist-credentials: false`, every action pin matches the approved
    SHA, and no untrusted expression appears directly in `run:` source.
 
 Run the pinned actionlint launcher against the temporary consumer-style `.github` tree after every
-workflow increment. It must need no ignored diagnostics. Create a signed commit.
+workflow increment. Only the exact documented `queue` diagnostic may be ignored. Create a signed
+commit.
 
 ### Task 12: Add production and non-production callers
 
@@ -400,8 +404,8 @@ workflow increment. It must need no ignored diagnostics. Create a signed commit.
 
 1. Add the non-production caller with manual `branch_prefix`/`dry_run`, a 04:17 daily
    `Australia/Melbourne` schedule, policy `nonproduction`, the three documented prefixes, root `.`,
-   exact release/archive/image pins, and native last-pending-wins concurrency. Populate the archive
-   digest only from the completed `v1.0.0-rc.7` release acceptance record.
+   exact release/archive/image pins, and `queue: max` concurrency. Populate the archive digest only
+   from the completed `v1.0.0-rc.7` release acceptance record.
 2. Add the production caller with the same manual interface, a Sunday 04:43
    `Australia/Melbourne` schedule, policy `production`, and the two production prefixes.
 3. Make built-in-token mode the copyable default. Add commented/documented App inputs only with the
@@ -409,8 +413,8 @@ workflow increment. It must need no ignored diagnostics. Create a signed commit.
 4. Add representative separate config files and validate each with the released CLI against a
    trusted fixture before any matrix is created.
 5. Add tests for exact schedules, default-branch-only dispatch, permission ceilings, config paths,
-   prefix separation, and one-running/one-latest-pending semantics. Three rapid-run behaviour is a
-   real-service assertion, not an invented local scheduler.
+   prefix separation, and `queue: max`. All three rapid runs completing is a real-service assertion,
+   not an invented local scheduler.
 
 Run actionlint and the caller subset, then create a signed commit.
 
@@ -458,8 +462,8 @@ Write the example guide specified by the design, including:
   security boundary.
 - Stable `update_<state-branch>` names, policy-scoped ownership, exact leases, best-effort Git/API
   compensation, residual race, and manual recovery after a compensation lease conflict.
-- Run-attempt artefact identity, native one-running/one-latest-pending concurrency, and redispatching
-  a displaced manual dry run.
+- Run-attempt artefact identity, GitHub.com's `queue: max` behaviour and bound, and GitHub Enterprise
+  Server compatibility checks.
 - Failure classification and the manual, strongly marked orphan-cleanup procedure; automatic
   destructive garbage collection remains out of scope.
 - The complete disposable private-repository acceptance procedure from the spec.

--- a/docs/superpowers/plans/2026-08-18-github-actions-branch-automation.md
+++ b/docs/superpowers/plans/2026-08-18-github-actions-branch-automation.md
@@ -50,6 +50,13 @@ reopen the partial-publication defect.
   establish only its scaffold, not a batch of unrelated requirements.
 - Every checkout uses `persist-credentials: false`. Every untrusted Actions value enters shell via
   `env:`, never direct expression interpolation into `run:`.
+- Every `hashicorp/setup-terraform` use sets `terraform_wrapper: false`; the processing helper is
+  the only status, timeout, and log supervisor.
+- Only **Re-run all jobs** is supported. Every downstream matrix job rejects a discovery attempt
+  that differs from its current `github.run_attempt`, with a diagnostic explaining that partial
+  reruns cannot produce a complete current-attempt artefact lineage.
+- Preparation and validation each use one cumulative 20-minute deadline per state branch, not per
+  Terraform root, inside their 30-minute job limits.
 - Action pins:
   - `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1` (`v7.0.1`)
   - `actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e` (`v7.0.0`)
@@ -154,8 +161,8 @@ Finish by running the complete discovery subset plus `bash -n`, then create a si
 3. Implement a token-free `GIT_ASKPASS` helper plus mode-`0600` token file for the exact child Git
    command. Keep the token out of URLs and process arguments, disable prompts, and remove both files
    in unconditional cleanup. Rerun GREEN and inspect the service request.
-4. Repeat focused RED/GREEN tests for authenticated fetch, atomic update, and exact-lease deletion
-   through the processing helper.
+4. Repeat focused RED/GREEN tests for authenticated fetch, exact-lease update, and exact-lease
+   deletion through the processing helper.
 5. Add a failure-path test proving credential files are removed and no repository config or remote
    URL retains the token.
 
@@ -196,12 +203,15 @@ and create a signed commit.
    `*.tf` plus the control config in one real Terraform root. Implement only that download,
    verification, and update path.
 2. Add a RED test for `terraform init -upgrade -backend=false -input=false -no-color` using the
-   trusted data directory and a 20-minute command timeout. Implement and rerun GREEN.
+   trusted data directory and the state branch's cumulative 20-minute preparation deadline.
+   Implement and rerun GREEN.
 3. Add separate RED/GREEN cases for a provider root requiring a regular persisted lock, a
    provider-free root legitimately omitting one, and an ignored newly required lock failing without
    force-add.
 4. Add a RED test for two roots and deterministic failure attribution. Implement sequential root
-   handling and rerun GREEN.
+   handling with one shared deadline; the second root receives only the remaining budget. Use an
+   injectable short duration to prove cleanup and bundle upload retain the job-level reserve, then
+   rerun GREEN.
 5. Add one manifest field at a time with a focused assertion: schema version; run ID/attempt/policy;
    control/ref/base identity; config and exact tool/archive/image pins; classification; roots and
    provider dependency state; changed paths, modes, and SHA-256 hashes.
@@ -228,21 +238,27 @@ commit.
 2. Add a RED `validate` test that verifies the candidate manifest and applies its patch only to a
    disposable validation checkout. Implement that boundary.
 3. Add a RED test that starts the digest-pinned image with no Docker socket, dropped capabilities,
-   `no-new-privileges`, resource/process limits, runner UID/GID, and only the disposable checkout
-   plus trusted data directory mounted. Pass only explicit non-secret Terraform variables. Implement
-   the smallest container invocation and rerun GREEN.
+   `no-new-privileges`, `--pids-limit=256`, `--memory=4g`, `--memory-swap=4g`, `--cpus=2`, the runner
+   UID/GID, and only the disposable checkout plus trusted data directory mounted. Pass only explicit
+   non-secret Terraform variables. Implement the exact fixed limits and rerun GREEN.
 4. Add a RED test that checks `terraform version -json` in the image before target content is used.
    Reject a tag/digest/version mismatch.
-5. Add focused tests for provider and provider-free init/validate commands, including
-   `-lockfile=readonly` only when a lock exists.
-6. Add hostile delayed/background attempts against credentials, candidate, lock, control checkout,
+5. Add focused tests for provider and provider-free initialisation commands, including
+   `-lockfile=readonly` only when a lock exists. Run initialisation in a networked constrained
+   container, document that configured module/registry addresses can reach services visible to the
+   runner, and retain its trusted data directory for validation.
+6. Add a RED test that runs `terraform validate` in a separate container with the same fixed mounts
+   and limits plus `--network=none`. Prove that the provider cannot reach an outbound listener or a
+   host-gateway test service. Implement the split networked-init/offline-validation flow and rerun
+   GREEN.
+7. Add hostile delayed/background attempts against credentials, candidate, lock, control checkout,
    `GITHUB_ENV`, `GITHUB_PATH`, outcome path, and container socket. The constrained container mounts
    the reviewed test mirror and CLI config read-only only when the harness enables its internal test
    mode. The trusted host—not a mounted target process—must create the outcome from the observed
    container status after termination.
-7. Add a hanging-provider RED test. Enforce the 20-minute per-root timeout with injectable shorter
-   test duration and classify it as `branch-validation`.
-8. State in test names and assertions that a zero supervised exit is all this boundary authenticates;
+8. Add a hanging-provider RED test. Enforce the cumulative 20-minute branch-validation deadline
+   with an injectable shorter duration and classify it as `branch-validation`.
+9. State in test names and assertions that a zero supervised exit is all this boundary authenticates;
    it cannot prove an adversarial provider's semantic honesty.
 
 Run the tests on a host with Docker available and create a signed commit.
@@ -264,7 +280,9 @@ For each check, add a targeted corrupt bundle, observe RED, implement rejection,
 4. Contradictory or unknown result classifications.
 5. Independent `v1.0.0-rc.7` source reproduction against a fresh exact-base checkout, accepting only
    an exact source diff before applying declared lock bytes.
-6. Full-run and failed-job rerun fixtures whose run-attempt-specific artefacts cannot cross-consume.
+6. A complete rerun fixture whose run-attempt-specific artefacts cannot cross-consume, plus a
+   failed-job rerun fixture whose reused discovery attempt is rejected with instructions to use
+   **Re-run all jobs**.
 
 The resulting `verify` mode writes only a local verified-result file. Add a test proving no GitHub
 write token, App key, or signing key exists in its environment or temporary tree. Run the complete
@@ -296,7 +314,7 @@ subset and create a signed commit.
 Local tests cover parsers and real Git. Defer GitHub API assertions to the disposable-repository
 gate. Run the subset and create a signed commit.
 
-### Task 9: Sign and publish with atomic Git guards
+### Task 9: Sign and publish with exact leases and compensation
 
 **Files:**
 
@@ -308,21 +326,26 @@ gate. Run the subset and create a signed commit.
 2. Add a RED signed-commit test using a temporary SSH key. Configure signing only in the target
    repository, require explicit author identity, verify locally, and stop without unsigned fallback
    on signing failure. Add a separate unsigned case when no key is configured.
-3. Add a RED real-bare-remote test for one atomic push containing a no-op state ref guarded by the
-   exact validated-base lease and the create/update automation ref guarded by its expected OID.
-   Implement and rerun GREEN.
-4. Move the state ref at the push boundary and prove neither ref update is accepted. This test must
-   exercise the atomic push, not only an earlier comparison.
+3. Add a RED real-bare-remote test that rechecks the state OID immediately before pushing only the
+   create/update automation ref guarded by its exact expected-old-OID lease. Implement and rerun
+   GREEN.
+4. Move the state ref after advertisement but before the automation-ref update. Prove that Git may
+   accept the update because the unchanged state ref is not sent, then prove the post-push state
+   check exact-lease-deletes a newly created ref or restores the previous automation OID. Never
+   describe the two refs as one atomic transaction.
 5. Add exact-lease tests for automation-ref update and deletion races. Never retry unconditionally.
 6. Add post-push and post-PR state checks. On detected movement, roll back only the OID written by
    the current invocation with an exact lease.
 7. Add failpoints after ref create/update. A later PR failure exact-lease-deletes a newly created
    ref or restores the previous OID. An ambiguous response first re-reads markers. A compensation
-   lease mismatch reports manual recovery and preserves the unseen writer's change.
-8. For no-change cleanup, delete the marked ref atomically before closing the PR. Add recovery for
-   API failure after deletion.
+   lease mismatch reports manual recovery and preserves the unseen writer's change. A termination-
+   after-push failpoint must leave the documented recoverable managed pair or bounded manual-
+   recovery result for a new ref without a PR.
+8. For no-change cleanup, recheck state, exact-lease-delete the marked ref, recheck state again, and
+   restore the deleted OID with an exact absent-ref lease if movement is detected. Delete before
+   closing the PR and add recovery for API failure or runner termination after deletion.
 
-Run the atomic publication suite repeatedly to expose races, then create a signed commit.
+Run the publication-race and compensation suite repeatedly, then create a signed commit.
 
 ### Task 10: Reconcile PRs, issues, and safe Markdown
 
@@ -366,13 +389,18 @@ Add each workflow contract through a focused structural or actionlint RED/GREEN 
    environment secrets, semantic-version tag and digest validation, policy regex, paired
    App/signing inputs, and `unattended_checks_safe` gate.
 2. Add `discover` with `contents: read`, immutable control SHA, released CLI download/verification,
-   command-scoped authenticated discovery, and a 10-minute job timeout.
+   command-scoped authenticated discovery, a matrix-bound current run attempt, and a 10-minute job
+   timeout.
 3. Add `prepare` and `validate` matrices with `fail-fast: false`, `max-parallel`, `contents: read`,
    exact OID checkouts, no credentials/secrets, run-attempt artefact names, unconditional result
-   upload, 20-minute operation timeouts, and 30-minute job timeouts.
+   upload, cumulative 20-minute per-branch operation deadlines, and 30-minute job timeouts. Set
+   `terraform_wrapper: false` on every setup action. Validation uses separate networked-init and
+   `--network=none` validate containers with the exact fixed resource limits from Task 6.
 4. Add a separate `verify` matrix with `always()`, `contents: read`, no publication environment or
    protected secrets, exact artefact enumeration, a 15-minute operation limit, and a 20-minute job
-   timeout. It uploads one narrowly scoped verified-result artefact per current run attempt.
+   timeout. It uploads one narrowly scoped verified-result artefact per current run attempt. Every
+   matrix job rejects a reused discovery attempt before downloading an artefact, so partial failed-
+   job reruns instruct the operator to use **Re-run all jobs**.
 5. Add a dependent `publish` matrix on a fresh protected runner with a 10-minute operation limit and
    15-minute job timeout. It validates the verified-result identity without sourcing it, then uses
    App/built-in auth only for `prepublish` and exact child commands; the signing secret is
@@ -385,8 +413,9 @@ Add each workflow contract through a focused structural or actionlint RED/GREEN 
 8. Add `queue: max` to caller concurrency and to policy-independent state-branch publication
    concurrency, with no in-progress cancellation. Add the exact actionlint 1.7.12 suppression for
    its stale `queue` parser diagnostic and no other warning.
-9. Verify every checkout has `persist-credentials: false`, every action pin matches the approved
-   SHA, and no untrusted expression appears directly in `run:` source.
+9. Verify every checkout has `persist-credentials: false`, every Terraform setup disables the
+   wrapper, every action pin matches the approved SHA, every job enforces the discovery-attempt
+   contract, and no untrusted expression appears directly in `run:` source.
 
 Run the pinned actionlint launcher against the temporary consumer-style `.github` tree after every
 workflow increment. Only the exact documented `queue` diagnostic may be ignored. Create a signed
@@ -452,18 +481,20 @@ Write the example guide specified by the design, including:
 - Protected publication environment, least privileges, fixed secret names, optional signing, and
   no unsigned fallback after signing failure.
 - Command-scoped private-repository Git auth and why checkout persistence remains disabled.
-- Trusted data directories, provider/container boundary, timeouts, lock requirements, and valid
-  provider-free roots.
+- Trusted data directories, the disabled Actions wrapper, cumulative branch timeouts, fixed Docker
+  resource limits, the networked-init egress risk, offline provider validation, lock requirements,
+  and valid provider-free roots.
 - The honest security limit: the host authenticates process status, not semantic truth from a
   malicious provider.
 - Current GitHub.com built-in-token recursion/approval behaviour and the need for GitHub Enterprise
-  Server consumers to verify their installed version. App mode is permitted only after the
-  documented downstream-workflow audit and acknowledgement; App event delivery is not itself a
-  security boundary.
+  Server consumers to verify their installed version. App mode is permitted only after auditing
+  every generated `push`, `pull_request`, and `pull_request_target` workflow and acknowledging that
+  App event delivery is not itself a security boundary.
 - Stable `update_<state-branch>` names, policy-scoped ownership, exact leases, best-effort Git/API
-  compensation, residual race, and manual recovery after a compensation lease conflict.
-- Run-attempt artefact identity, GitHub.com's `queue: max` behaviour and bound, and GitHub Enterprise
-  Server compatibility checks.
+  compensation, the lack of cross-ref atomicity, crash windows, and manual recovery after a
+  compensation lease conflict or newly created ref without a PR.
+- Run-attempt artefact identity, the **Re-run all jobs** requirement and partial-rerun diagnostic,
+  GitHub.com's `queue: max` behaviour and bound, and GitHub Enterprise Server compatibility checks.
 - Failure classification and the manual, strongly marked orphan-cleanup procedure; automatic
   destructive garbage collection remains out of scope.
 - The complete disposable private-repository acceptance procedure from the spec.
@@ -497,7 +528,8 @@ already present in the repository, if any, and create a signed docs commit.
 4. With Dan's explicit approval for external mutations, run the documented acceptance in a
    disposable private repository. It must cover authenticated discovery/push/delete, built-in and
    audited App modes, alternate-ref environment denial, hostile-container and hostile-downstream
-   cases, provider/provider-free roots, run-attempt reruns, policy/unowned collisions, state and
+   push/PR cases, provider/provider-free roots, complete and rejected partial reruns,
+   policy/unowned collisions, advertisement-to-update state movement, termination after push,
    deletion races, a real post-push PR-creation rejection with exact-lease rollback, dry run,
    failure/recovery/cleanup, three rapid dispatches, and optional signed publication.
 5. Review the transcript against every completion criterion in the design. Do not claim completion

--- a/docs/superpowers/plans/2026-08-19-tf-version-bump-aggregate-failures.md
+++ b/docs/superpowers/plans/2026-08-19-tf-version-bump-aggregate-failures.md
@@ -88,27 +88,47 @@ failures`.
 - Modify: `integration_config_test.go`
 - Modify: `terraform_provider_test.go`
 
-**Step 1: Add and satisfy the Terraform-version behaviour**
+**Step 1: Add and satisfy the Terraform-version CLI behaviour**
 
 Add a test with a malformed Terraform file followed by a valid `required_version` file. Assert the
 valid file is updated and the runner reports failure. Run only that test to prove RED, change
-`processTerraformVersion` to return update and error counts, propagate the failure through both CLI
-and config modes, then rerun it GREEN.
+`processTerraformVersion` to return update and error counts, propagate the failure through CLI mode,
+then rerun it GREEN.
 
-**Step 2: Add and satisfy the provider-version behaviour**
+**Step 2: Add and satisfy the Terraform-version config behaviour**
+
+Add an independent `runConfigFileMode` test using a real config that selects the malformed and valid
+Terraform-version files. Prove RED because config mode still discards the aggregate error, propagate
+that error through config mode without changing continuation, then rerun GREEN.
+
+**Step 3: Add and satisfy the provider-version CLI behaviour**
 
 Repeat the focused RED/GREEN cycle for a malformed file followed by a valid `required_providers`
-file. Change `processProviderVersion` and its callers only as required.
+file through CLI mode. Change `processProviderVersion` and its CLI caller only as required.
 
-**Step 3: Add the all-success regression**
+**Step 4: Add and satisfy the provider-version config behaviour**
+
+Add a separate `runConfigFileMode` RED using a real provider config, then propagate the provider
+aggregate error through config mode and rerun GREEN. Do not treat the Terraform config test as
+evidence for this distinct path.
+
+**Step 5: Add mixed-config aggregation and continuation**
+
+Add a config containing module, Terraform, and provider operations where an earlier operation has a
+malformed selected file and later operations have valid updates. Assert every later operation still
+runs, every successful change is written, and the runner returns one aggregate failure after the
+final summary. Prove RED before changing the config-mode orchestration, then implement the smallest
+cross-operation aggregation and rerun GREEN.
+
+**Step 6: Add the all-success regressions**
 
 Add a focused test for each mode showing that multiple valid files retain a successful result and
 the existing summary. This guards against treating “no updates” as an error.
 
-**Step 4: Run the affected suite and commit**
+**Step 7: Run the affected suite and commit**
 
 ```bash
-go test -run 'TestRun.*(Terraform|Provider).*Failure|TestRun.*AllFilesSucceed' -count=1
+go test -run 'TestRun.*(Terraform|Provider|MixedConfig).*Failure|TestRun.*AllFilesSucceed' -count=1
 go test ./...
 ```
 
@@ -123,10 +143,11 @@ Commit with a signed commit such as `fix: propagate Terraform and provider file 
 
 **Step 1: Add an end-to-end main-path status test**
 
-Invoke `main` through the repository's existing `stubExit` and `withFlagArgs` harness against
-malformed and valid files. Assert exit code 1, the exact captured diagnostic, and that the later
-valid file changed. This tests the complete public command path rather than only helper return
-values, without adding a second test binary harness.
+Invoke `main` through the repository's existing `stubExit` and `withFlagArgs` harness with an
+explicit `-config` argument whose real config selects malformed and valid files. Assert exit code 1,
+the exact captured diagnostic, and that the later valid file changed. This tests the complete public
+config command path consumed by the automation rather than only helper return values, without adding
+a second test binary harness. A separate CLI-mode main test may remain for its distinct flag path.
 
 Run the focused test RED before the final `main` propagation, implement the smallest change from a
 runner error to the existing fatal exit mechanism, then rerun it GREEN.

--- a/docs/superpowers/plans/2026-08-19-tf-version-bump-aggregate-failures.md
+++ b/docs/superpowers/plans/2026-08-19-tf-version-bump-aggregate-failures.md
@@ -1,0 +1,195 @@
+# Aggregate CLI Failure and v1.0.0-rc.7 Release Plan
+
+> **For Codex:** Use `superpowers:executing-plans` to implement this plan. Follow
+> `superpowers:test-driven-development` one behaviour at a time. After implementation, run the
+> `test-cleanup` skill in a separate subagent, then use `superpowers:verification-before-completion`.
+
+**Goal:** Make every CLI mode finish processing selected files but return a non-zero process status
+when any selected file fails, document that contract, and publish the first immutable release that
+the GitHub Actions automation may consume.
+
+**Architecture:** The three processing paths return both their update count and aggregate error
+count. Mode runners print the existing summaries, then return an error when the aggregate count is
+non-zero; `main` converts that error to the existing fatal exit path. Successful output remains
+unchanged and later files continue after an earlier failure. Release publication is a separate,
+explicitly authorised gate after the code lands on `main`.
+
+**Tech stack:** Go 1.25+, standard `testing`, Markdown documentation, GoReleaser, GitHub Actions.
+
+---
+
+## Constraints
+
+- Work on a topic branch and use `/Users/dan/.codex/bin/codex-git` for every Git operation.
+- Every Codex-created commit and tag must be signed. Stop immediately if signing fails.
+- Do not push a branch or release tag without Dan's explicit approval at that step.
+- Preserve per-file continuation and existing successful output.
+- Do not introduce a compatibility flag for the old zero-exit behaviour; that would require Dan's
+  separate approval.
+- Add one focused failing test before each behaviour change. A missing helper is not sufficient
+  evidence for multiple behaviours.
+
+### Task 1: Aggregate module-update errors
+
+**Files:**
+
+- Modify: `main.go`
+- Modify: `main_integration_test.go`
+- Modify: `cli_functions_test.go`
+- Modify: `coverage_test.go`
+- Modify: `integration_config_test.go`
+
+**Step 1: Add one failing module-mode test**
+
+Add a focused test that processes two real files in deterministic order: malformed HCL first and
+a valid matching module second. Capture the real runner result and output. Assert that the valid
+file is updated, the malformed-file diagnostic is captured exactly, and the runner reports
+failure.
+
+Run:
+
+```bash
+go test -run TestRunCLIModeReportsModuleFileFailure -count=1
+```
+
+Expected: FAIL because module processing currently returns only an update count and the mode runner
+cannot report the earlier file error.
+
+**Step 2: Implement only module error aggregation**
+
+Change `processFiles` to return update and error counts. Increment the error count where the
+existing diagnostic is logged, continue processing, and have module CLI mode return an aggregate
+error after printing its existing summary.
+
+Run the focused test again and expect PASS.
+
+**Step 3: Cover module config mode separately**
+
+Add a focused config-mode test with the same malformed-then-valid ordering. Assert continuation and
+a failing result, run it RED, make the smallest config-runner change, and rerun it GREEN.
+
+**Step 4: Run the affected suite and commit**
+
+```bash
+go test -run 'TestRun(CLI|Config)ModeReportsModuleFileFailure' -count=1
+go test ./...
+```
+
+Commit the focused change with a signed commit such as `fix: report aggregate module update
+failures`.
+
+### Task 2: Aggregate Terraform and provider errors
+
+**Files:**
+
+- Modify: `main.go`
+- Modify: `main_integration_test.go`
+- Modify: `cli_functions_test.go`
+- Modify: `integration_config_test.go`
+- Modify: `terraform_provider_test.go`
+
+**Step 1: Add and satisfy the Terraform-version behaviour**
+
+Add a test with a malformed Terraform file followed by a valid `required_version` file. Assert the
+valid file is updated and the runner reports failure. Run only that test to prove RED, change
+`processTerraformVersion` to return update and error counts, propagate the failure through both CLI
+and config modes, then rerun it GREEN.
+
+**Step 2: Add and satisfy the provider-version behaviour**
+
+Repeat the focused RED/GREEN cycle for a malformed file followed by a valid `required_providers`
+file. Change `processProviderVersion` and its callers only as required.
+
+**Step 3: Add the all-success regression**
+
+Add a focused test for each mode showing that multiple valid files retain a successful result and
+the existing summary. This guards against treating “no updates” as an error.
+
+**Step 4: Run the affected suite and commit**
+
+```bash
+go test -run 'TestRun.*(Terraform|Provider).*Failure|TestRun.*AllFilesSucceed' -count=1
+go test ./...
+```
+
+Commit with a signed commit such as `fix: propagate Terraform and provider file failures`.
+
+### Task 3: Document and verify the process-status contract
+
+**Files:**
+
+- Modify: `docs/USAGE.md`
+- Modify: `main_coverage_test.go`
+
+**Step 1: Add an end-to-end main-path status test**
+
+Invoke `main` through the repository's existing `stubExit` and `withFlagArgs` harness against
+malformed and valid files. Assert exit code 1, the exact captured diagnostic, and that the later
+valid file changed. This tests the complete public command path rather than only helper return
+values, without adding a second test binary harness.
+
+Run the focused test RED before the final `main` propagation, implement the smallest change from a
+runner error to the existing fatal exit mechanism, then rerun it GREEN.
+
+**Step 2: Correct the usage documentation**
+
+Replace the statement that individual file errors leave a zero exit status. State that processing
+continues, every file-level diagnostic is written, and the command exits non-zero after the final
+summary when any selected operation failed.
+
+Human prose does not receive a grep-based test. Review the rendered section directly against the
+end-to-end test's observed contract.
+
+**Step 3: Verify and commit**
+
+```bash
+gofmt -w main.go main_integration_test.go cli_functions_test.go coverage_test.go \
+  integration_config_test.go terraform_provider_test.go main_coverage_test.go
+go test -run TestCommandReportsAggregateFileFailure -count=1
+go test -race ./...
+go build ./...
+golangci-lint run --timeout=5m
+```
+
+Run `test-cleanup` in a separate subagent. Apply only removals that preserve all distinct behaviour
+coverage, rerun the full commands above, inspect the complete diff, then create a signed commit such
+as `docs: define aggregate CLI failure status`.
+
+### Task 4: Merge and publish v1.0.0-rc.7
+
+This task changes remote state and begins only after review, branch integration, and Dan's explicit
+release approval.
+
+**Step 1: Verify the release commit on main**
+
+Confirm the approved commits are on current `main`, every PR-branch commit is signed, the worktree
+is clean, and the complete repository verification is fresh:
+
+```bash
+make test-coverage
+golangci-lint run --timeout=5m
+go build ./...
+```
+
+Run a local GoReleaser snapshot as described in `docs/RELEASING.md`, inspect its output, and confirm
+it did not leave unexpected source changes.
+
+**Step 2: Obtain explicit authorisation**
+
+Stop and ask Dan before creating or pushing `v1.0.0-rc.7`. Do not infer tag approval from approval
+to implement this plan.
+
+**Step 3: Create and push the signed annotated tag**
+
+Use `/Users/dan/.codex/bin/codex-git` for both operations. Verify the tag signature locally before
+pushing. If signing or verification fails, stop; do not create an unsigned replacement.
+
+**Step 4: Verify published distribution**
+
+Wait for the release and provenance workflows. Confirm all expected archives, packages, checksum
+manifest, and provenance exist. Download the Linux amd64 archive used by the automation, verify its
+SHA-256 checksum and SLSA provenance using the documented commands, then run its `-version` output
+and the aggregate-failure scenario against that independently downloaded binary.
+
+Record the release URL, archive checksum, provenance verification result, and acceptance transcript.
+Only then is the GitHub Actions implementation plan unblocked.

--- a/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
+++ b/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
@@ -192,14 +192,14 @@ timezone support:
 - Non-production: daily at 04:17 in `Australia/Melbourne`.
 - Production: Sunday at 04:43 in `Australia/Melbourne`.
 
-Each caller has its own concurrency group with `cancel-in-progress: false`. GitHub Actions permits
-one running and one pending run in a concurrency group; a newer run replaces the existing pending
-run. This last-pending-wins behaviour is acceptable because scheduled and normal manual runs are
-idempotent reconciliations of current branch state. A displaced manual dry run must be dispatched
-again if its output is still wanted. Production and non-production can run independently.
-Reconciliation additionally uses a policy-independent per-state-branch concurrency group derived
-from the repository ID and branch hash. Two policies can prepare concurrently but cannot publish
-the same `update_<state-branch>` ref concurrently.
+Each caller has its own concurrency group with `queue: max` and no in-progress cancellation.
+Current GitHub.com queues up to 100 pending runs in that group instead of replacing an existing
+pending run. Production and non-production can run independently. Publication additionally uses a
+policy-independent per-state-branch concurrency group with `queue: max`, derived from the repository
+ID and branch hash. Two policies can prepare concurrently but cannot publish the same
+`update_<state-branch>` ref concurrently, and neither policy's pending publication is silently
+replaced. GitHub Enterprise Server consumers must confirm that their installed version supports the
+`queue` property before copying the example.
 
 Manual runs are accepted only when `github.ref` is the repository's default branch. This catches
 accidental alternate-ref dispatches. The publication job also uses a required protected GitHub
@@ -745,13 +745,14 @@ covered by the real-service acceptance run.
 
 The project adds one repository-owned launcher that runs exactly
 `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`; the local harness, Make target, CI, and
-final verification all use that launcher for the three example workflow files. No parser warning
-is suppressed. Validation copies the example `.github` tree into a temporary consumer-style
-repository root first, so local reusable-workflow paths resolve exactly as they do after
-installation. It also runs `bash -n`, verifies that Docker is available for the container-boundary
-tests, and runs the integration tests for both helper scripts. Existing Go tests, race detection,
-branch-automation tests, linting, and build validation remain required and must produce pristine
-output.
+final verification all use that launcher for the three example workflow files. That parser predates
+GitHub.com's supported `queue` property, so the launcher applies only the exact
+`-ignore '^unexpected key "queue" for "concurrency" section\.'` suppression. It suppresses no other
+diagnostic. Validation copies the example `.github` tree into a temporary consumer-style repository
+root first, so local reusable-workflow paths resolve exactly as they do after installation. It also
+runs `bash -n`, verifies that Docker is available for the container-boundary tests, and runs the
+integration tests for both helper scripts. Existing Go tests, race detection, branch-automation
+tests, linting, and build validation remain required and must produce pristine output.
 
 Each behaviour is introduced through its own focused failing test and smallest implementation,
 followed by the focused test again. A missing script or mode is used only to establish the initial
@@ -789,8 +790,8 @@ The example README defines an acceptance procedure using a disposable GitHub rep
 - Private-repository discovery, fetch, update, and deletion using command-scoped authentication.
 - Successful update, repeated idempotent update, validation failure, issue update, recovery, and
   obsolete-PR cleanup.
-- Three rapid dispatches demonstrating the documented native behaviour: the first runs, the third
-  replaces the second pending run, and the third reconciles the latest repository state.
+- Three rapid dispatches demonstrating that `queue: max` preserves and eventually executes all
+  three runs rather than replacing either pending run.
 - A built-in-token PR whose `push` workflows remain absent and whose `pull_request` checks wait for
   writer approval, followed by an App-mode PR whose checks start without that approval gate.
 - A dry run that demonstrates no repository refs, content, PRs, or issues changed while diagnostic
@@ -840,8 +841,8 @@ The acceptance transcript is reviewed before completion is claimed.
   diagnostics, versus automation failures that never create issues.
 - Required provider lock files, valid provider-free roots without locks, and rejection of ignored
   required locks and symlinked Terraform/lock paths.
-- GitHub's one-running/one-latest-pending concurrency behaviour and the need to redispatch a
-  displaced manual dry run.
+- GitHub.com's `queue: max` behaviour, its 100-pending-run bound, and the need for GitHub Enterprise
+  Server consumers to confirm support before installation.
 - The 256-branch matrix ceiling and the controlled failure when an allow-list exceeds it.
 - Built-in-token event suppression and approval-required PR checks, including when App mode is
   required for unattended checks.
@@ -884,8 +885,9 @@ The feature is complete when:
   clear failure), provider-free directories may omit the file, disposable `.terraform/` data is
   excluded, and symlinked, escaping, non-regular, or otherwise unexpected paths are rejected before
   writing.
-- Concurrency uses only supported `group` and `cancel-in-progress` keys and documents GitHub's
-  one-running/one-latest-pending behaviour. The pinned actionlint launcher requires no suppression.
+- GitHub.com caller and publication concurrency use the supported `queue: max` behaviour so pending
+  runs are preserved. The pinned actionlint launcher suppresses only its exact stale-parser
+  diagnostic for that property.
 - Built-in-token documentation and acceptance distinguish suppressed `push` workflows from
   approval-required PR workflows, and require App mode for unattended required checks.
 - Every changed Terraform source file belongs directly to exactly one configured and validated

--- a/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
+++ b/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
@@ -24,12 +24,19 @@ lifecycle.
 - Persist `.terraform.lock.hcl` changes alongside Terraform source changes.
 - Return a non-zero CLI status after any per-file processing error so automation cannot publish a
   partial update as successful.
+- Install an immutable released CLI artefact that contains that aggregate failure-status contract;
+  the example must never validate a working-tree binary and publish with an older release.
 - Maintain stable update branches, pull requests, and validation-failure issues without creating
   duplicates on scheduled runs.
 - Support a dry run that still applies and validates proposed changes in a disposable checkout
   while suppressing repository refs and GitHub content mutations.
 - Support the built-in `GITHUB_TOKEN`, optional GitHub App authentication, and optional SSH commit
   signing.
+- Keep target-selected providers away from Actions workflow command files and capture their process
+  status through a trusted host supervisor, without claiming that an adversarial provider performs
+  semantically honest validation.
+- Prevent unattended downstream pull-request checks from silently escaping the same hostile-code
+  boundary.
 - Show how the same workflow can validate multiple Terraform root modules without complicating the
   root-directory example.
 
@@ -42,6 +49,11 @@ lifecycle.
 - Delete, reset, force-push, or otherwise modify a state branch.
 - Provide arbitrary regular-expression or shell-glob branch matching.
 - Add configurable post-update command hooks in the initial example.
+- Prove that an adversarial provider truthfully implements its own validation protocol. The
+  automation can authenticate Terraform's supervised process result, not the provider's intent.
+- Make Git ref updates and GitHub pull-request API mutations one distributed transaction. The
+  workflow instead uses atomic Git ref updates, exact leases, compensating rollback, and explicit
+  recovery rules.
 
 ## Example layout
 
@@ -69,7 +81,9 @@ copy the example's `.github` directory rather than invoke a workflow from its ex
 The shell scripts keep non-trivial orchestration out of YAML blocks. They have help output,
 validate their inputs, fail with stage-specific messages, and limit routine output while retaining
 failure logs for diagnosis. They expose separate preparation, validation, and reconciliation
-operations so the privileged job never executes target-branch Terraform.
+operations so the privileged job never executes target-branch Terraform. Reconciliation itself is
+split into credential-free verification/staging, authenticated ownership preflight, and publication
+operations so write credentials and signing material appear only when required.
 
 ## Workflow architecture
 
@@ -77,28 +91,43 @@ The production and non-production callers own policy. Each caller defines its al
 configuration path, pinned tool versions, schedule, and concurrency group, then invokes the local
 reusable workflow.
 
-The reusable workflow contains four job stages:
+The reusable workflow contains five job stages:
 
 1. `discover` checks out the exact caller commit, validates the shared configuration, and produces
    a sorted JSON matrix containing each matching state branch and its immutable tip OID.
 2. `prepare` runs once per matrix entry with `fail-fast: false`. It applies the update and runs
    Terraform initialisation on an unprivileged fresh runner, then uploads a preparation bundle
    before any provider plugin executes. A successful bundle contains the immutable candidate.
-3. `validate` runs once per successful candidate on another unprivileged fresh runner. It consumes
-   the candidate without changing its publishable payload, executes the target-selected providers,
-   and uploads only a candidate-bound outcome and captured logs.
-4. `reconcile` runs once per matrix entry on another fresh runner after the complete validation
-   matrix. It treats both artefacts as untrusted data, revalidates them, and either publishes the
-   pre-provider candidate, reports a deterministic branch failure, or records a workflow-level
-   failure.
+3. `validate` runs once per successful candidate on another unprivileged fresh runner. A trusted
+   host supervisor consumes the candidate without changing its publishable payload and runs
+   Terraform inside a pinned, constrained container that receives no Actions runtime variables,
+   workflow command-file paths, control checkout, candidate bundle, or host outcome path. The host
+   supervisor records the container exit status and uploads only a candidate-bound outcome and
+   captured logs.
+4. `verify` runs once per matrix entry on another fresh runner after the complete validation
+   matrix. With `contents: read` and no publication environment, it treats both artefacts as
+   untrusted data, revalidates and stages the pre-provider candidate, and emits a narrowly scoped
+   verified-result artefact. It executes neither Terraform nor target-supplied code.
+5. `publish` runs once per verified matrix entry on a fresh protected runner. It validates the
+   verified-result identity, mints the selected credential, checks ownership and remote refs,
+   materialises signing key data only immediately before commit creation, and publishes, reports a
+   deterministic branch failure, or records a workflow-level failure.
 
 Preparation captures update and initialisation status and uploads its bundle in unconditional
 cleanup steps before returning the recorded failure status. Validation does the same for its
-candidate-bound outcome and logs. Reconciliation uses an `always()` condition so one failed matrix
-entry does not suppress reporting for the others. It expects one preparation bundle for every
-entry, and a validation outcome only when preparation produced a successful candidate. A missing,
-duplicate, unexpected, or mismatched artefact is an automation failure and can never be interpreted
-as success.
+host-supervised, candidate-bound outcome and logs. Verification and publication use `always()` so
+one failed matrix entry does not suppress reporting for the others. Verification expects one
+preparation bundle for every entry, and a validation outcome only when preparation produced a
+successful candidate. Publication expects exactly one verified result for its current entry and
+attempt. A missing, duplicate, unexpected, wrong-attempt, or mismatched artefact is an automation
+failure and can never be interpreted as success.
+
+The verified-result artefact contains a versioned manifest and the already verified patch needed to
+recreate the staged tree. Its name and manifest bind the run ID, run attempt, policy, control OID,
+state ref, base OID, candidate digest, validation-outcome digest, changed paths, modes, and hashes.
+It contains no executable control logic or credentials. Publication validates those fields and
+applies the patch as data to a fresh exact-base checkout; it never sources files from the artefact or
+executes target content.
 
 The update matrix defaults to four concurrent branches. This bounds Terraform downloads and GitHub
 API writes while retaining useful parallelism. A caller can lower or raise the limit through the
@@ -114,22 +143,37 @@ uses two independent checkouts:
 
 Terraform can execute target-selected provider plugins during validation. Therefore checkout
 separation is not treated as a process-security boundary. Preparation uploads the immutable source
-and lock-file candidate before provider execution, and validation cannot replace that artefact. The
-fresh reconciliation job is the publication boundary: it does not execute Terraform or any
-target-supplied executable, and it materialises write credentials and signing material only after
-validating the candidate and outcome.
+and lock-file candidate before provider execution. Validation mounts only a disposable validation
+workspace and a trusted `TF_DATA_DIR` into the container; it never mounts the candidate bundle,
+control checkout, host outcome directory, Docker socket, Actions command files, or Actions runtime
+environment. The container receives only explicit Terraform configuration values. When it exits,
+the trusted host supervisor constructs the outcome from its observed status. A provider may still
+lie through its own protocol and make Terraform report success; that semantic limitation is stated
+explicitly. The fresh publication job is the mutation boundary and executes neither
+Terraform nor target-supplied executables.
 
 A successful preparation bundle contains a versioned JSON manifest, captured preparation logs, and
-a binary Git patch. The manifest records the control OID, state branch, validated base OID,
-preparation classification, configured Terraform directories, provider-dependency state, changed
-paths, file modes, and SHA-256 hashes. A failed preparation bundle contains its classification and
-logs but no publishable patch. The validation outcome records the candidate manifest digest,
-validation classification, and captured validation logs. Reconciliation rejects unknown manifest
-versions, mismatched refs, OIDs, or candidate digests, absolute or escaping paths, symlink or
-non-regular modes, unexpected file types, hash mismatches, and patch paths outside the declared set.
-It applies the patch only after a fresh exact-base checkout and independently reproduces the
-`tf-version-bump` source changes before accepting lock-file changes from the pre-provider candidate
-bundle.
+a binary Git patch. The manifest records the workflow run ID and attempt, stable automation policy
+ID, control OID, state branch, validated base OID, config path, exact tool versions, release archive
+digest, and validation image digest, preparation classification, configured Terraform directories,
+provider-dependency state, changed paths, file modes, and SHA-256 hashes. A failed preparation
+bundle contains its
+classification and logs but no publishable patch. Artefact names include the run ID, run attempt,
+policy ID, and branch hash. The validation outcome records those identities, the candidate manifest
+digest, the host-observed container result, validation classification, and captured logs.
+Reconciliation rejects unknown manifest versions, mismatched run identities, policies, refs, OIDs,
+or candidate digests, absolute or escaping paths, symlink or non-regular modes, unexpected file
+types, hash mismatches, and patch paths outside the declared set. It applies the patch only after a
+fresh exact-base checkout and independently reproduces the `tf-version-bump` source changes before
+accepting lock-file changes from the pre-provider candidate bundle.
+
+Every stage has a bounded inner operation timeout plus a larger job timeout so the workflow can
+capture logs and classifications before GitHub terminates the job. Discovery is limited to 10
+minutes. Preparation and validation commands are limited to 20 minutes per Terraform root and their
+jobs to 30 minutes. Verification is limited to 15 minutes and its job to 20 minutes; publication is
+limited to 10 minutes and its job to 15 minutes. A preparation initialisation timeout is
+`branch-init`; a validation timeout is `branch-validation`; all other job timeouts are automation
+failures.
 
 ## Triggers and schedules
 
@@ -148,14 +192,17 @@ timezone support:
 - Non-production: daily at 04:17 in `Australia/Melbourne`.
 - Production: Sunday at 04:43 in `Australia/Melbourne`.
 
-Each caller has its own concurrency group with `queue: max` and no in-progress cancellation. Up to
-100 runs wait behind the active run instead of replacing the existing pending run. Production and
-non-production can run independently. This is current GitHub.com syntax; GitHub Enterprise Server
-consumers must confirm that their installed version supports the `queue` property before copying
-the example.
+Each caller has its own concurrency group with `cancel-in-progress: false`. GitHub Actions permits
+one running and one pending run in a concurrency group; a newer run replaces the existing pending
+run. This last-pending-wins behaviour is acceptable because scheduled and normal manual runs are
+idempotent reconciliations of current branch state. A displaced manual dry run must be dispatched
+again if its output is still wanted. Production and non-production can run independently.
+Reconciliation additionally uses a policy-independent per-state-branch concurrency group derived
+from the repository ID and branch hash. Two policies can prepare concurrently but cannot publish
+the same `update_<state-branch>` ref concurrently.
 
 Manual runs are accepted only when `github.ref` is the repository's default branch. This catches
-accidental alternate-ref dispatches. The reconciliation job also uses a required protected GitHub
+accidental alternate-ref dispatches. The publication job also uses a required protected GitHub
 environment restricted to the default branch. App and signing private keys live only in that
 environment; they are not passed through `workflow_call`. Repository administrators must limit
 manual dispatch to trusted actors. Built-in-token mode additionally assumes repository write
@@ -163,33 +210,63 @@ access is trusted because a writer can submit modified workflow YAML even when n
 is exposed. App-mode callers cap the reusable workflow's `GITHUB_TOKEN` at `contents: read`; only
 the short-lived App token receives publication permissions.
 
+Built-in-token mode is the safe default for repositories whose downstream pull-request workflows
+have not been audited; generated checks remain approval-gated. App mode is accepted only when the
+caller explicitly sets `unattended_checks_safe: true`. That assertion means every downstream
+workflow applicable to the state branches uses reviewed workflow definitions, a read-only token,
+no repository or environment secrets, no privileged environment, and equivalent isolation before
+executing target-controlled code. The reusable workflow cannot enforce another workflow's runtime
+permissions, so it rejects App mode without this explicit policy assertion and the documentation
+requires a repository audit. App mode is not described as safe for generic unattended checks.
+
 ## Reusable workflow interface
 
 | Input | Type | Required/default | Purpose |
 |---|---|---|---|
+| `automation_policy_id` | string | Required | Stable lowercase identity such as `nonproduction` or `production` |
 | `allowed_branch_prefixes` | string | Required | Newline-separated literal prefix allow-list |
 | `branch_prefix` | string | `""` | Optional manual narrowing prefix |
 | `config_path` | string | Required | Config path in the default-branch control checkout |
 | `terraform_directories` | string | `.` | Newline-separated module directories processed independently |
 | `terraform_version` | string | Required | Exact Terraform version installed for the run |
-| `tf_version_bump_version` | string | Required | Exact `tf-version-bump` release tag used by `go install` |
-| `go_version` | string | Required | Exact Go version used by `go install` |
+| `terraform_image` | string | Required | Validation image pinned by tag and multi-platform digest |
+| `tf_version_bump_version` | string | Required | Exact `tf-version-bump` release tag used in the archive URL and version check |
+| `tf_version_bump_archive_sha256` | string | Required | Recorded SHA-256 of the Linux x86-64 release archive |
 | `dry_run` | boolean | `false` | Suppress repository refs and GitHub content mutations |
 | `max_parallel` | number | `4` | Maximum concurrent state-branch jobs |
 | `commit_author_name` | string | `""` | Explicit signed-commit identity; derive bot name when unsigned |
 | `commit_author_email` | string | `""` | Explicit signed-commit identity; derive bot email when unsigned |
 | `github_app_client_id` | string | `""` | Enable GitHub App authentication when paired with its key |
-| `publication_environment` | string | Required | Default-branch-restricted environment for reconciliation |
+| `unattended_checks_safe` | boolean | `false` | Required acknowledgement of the downstream-check contract for App mode |
+| `publication_environment` | string | Required | Default-branch-restricted environment for publication |
 
 Optional protected-environment secrets with fixed names are:
 
 - `TF_VERSION_BUMP_GITHUB_APP_PRIVATE_KEY`
 - `TF_VERSION_BUMP_COMMIT_SIGNING_PRIVATE_KEY`
 
-The workflow rejects partial authentication or signing configurations. A GitHub App client ID
-requires the App private key in the protected environment. When the signing key is present, the
-caller must explicitly supply both commit identity inputs rather than inherit a bot default.
-Environment secrets cannot be passed or selected by an untrusted caller.
+The workflow validates `automation_policy_id` against
+`^[a-z0-9][a-z0-9-]{0,31}$`, validates the release tag as a `v`-prefixed semantic version, requires
+the archive digest to be exactly 64 lowercase hexadecimal characters, and binds all three into every
+applicable artefact and manifest; the policy also binds every marker and ownership check.
+The required update branch name remains exactly `update_<state-branch>`; a different policy's marked
+ref is foreign and causes a safe failure rather than adoption. The workflow rejects partial
+authentication or signing configurations. A GitHub App client ID requires the App private key and
+`unattended_checks_safe: true`. When the signing key is present, the caller must explicitly supply
+both commit identity inputs rather than inherit a bot default. Environment secrets cannot be passed
+or selected by an untrusted caller.
+
+The example pins `tf_version_bump_version: v1.0.0-rc.7` and the Linux x86-64 archive's actual
+published SHA-256. Implementation of this workflow cannot start until the aggregate per-file
+failure change has been merged, released under that tag, and the published artefact has passed
+checksum/provenance verification. Each job downloads that exact archive, verifies it against the
+recorded digest before extraction, and verifies the binary's reported version. Tests execute the
+same downloaded binary; they do not substitute a binary built from the automation feature branch.
+
+The example pairs `terraform_version: 1.15.5` with
+`terraform_image: hashicorp/terraform:1.15.5@sha256:15bf5a08b1fb9c9747c8ff01098aeeefb4aec9a6c24eb13e7661bdf9447e4aee`.
+The validation supervisor verifies `terraform version -json` inside that image before applying
+target content and rejects a mismatch.
 
 Production and non-production callers demonstrate separate config paths, prefix lists, schedules,
 concurrency groups, and tool versions. Their illustrative allow-lists are:
@@ -209,14 +286,17 @@ aws-state/production/
 
 Discovery verifies that the caller ref is the default branch and records `github.sha` as the
 immutable control OID. It checks out that exact commit with persisted credentials disabled,
-installs the pinned CLI, and validates the shared configuration once against a trusted temporary
-Terraform fixture before creating any branch matrix. A malformed config is therefore one workflow
-failure rather than one issue per branch.
+downloads and verifies the pinned release archive, and validates the shared configuration once
+against a trusted temporary Terraform fixture before creating any branch matrix. A malformed
+config is therefore one workflow failure rather than one issue per branch.
 
 Discovery lists remote heads and OIDs from `origin`; it does not depend on whatever subset
-`actions/checkout` fetched. A state branch matches when its complete name begins with one of the
-configured literal prefixes. The remainder of the branch name is unrestricted except by Git's
-normal ref-name rules.
+`actions/checkout` fetched. Because persisted checkout credentials are disabled, the workflow
+supplies its read-only token to that exact Git subprocess through a temporary `GIT_ASKPASS` helper.
+The helper contains no token, the token is absent from the URL and process arguments, terminal
+prompts are disabled, and the helper is removed unconditionally. A state branch matches when its
+complete name begins with one of the configured literal prefixes. The remainder of the branch name
+is unrestricted except by Git's normal ref-name rules.
 
 The discovery script:
 
@@ -226,9 +306,12 @@ The discovery script:
 3. Selects remote branches using the allow-list plus optional narrowing prefix.
 4. Deduplicates branches selected by overlapping prefixes.
 5. Records each branch's exact remote tip OID and sorts names bytewise for deterministic output.
-6. Fails when no branches match so a configuration mistake cannot look successful.
-7. Encodes the control OID and final branch/OID pairs as JSON for the matrix without evaluating
-   branch names as shell code.
+6. Fails when no branches match and when more than GitHub's 256-job matrix limit match, with a
+   diagnostic instructing the caller to narrow or partition its prefix policy.
+7. Encodes the run ID, run attempt, automation policy ID, control OID, and final branch/OID/ref-hash
+   triples as JSON for the matrix without evaluating branch names as shell code. The ref hash is the
+   lowercase hexadecimal SHA-256 of the complete branch ref and is used for artefact and concurrency
+   keys; the branch name itself is never interpolated into those expressions.
 
 The manual prefix can narrow `state/nonproduction/` to `state/nonproduction/example-`, but a
 non-production caller rejects `state/production/`.
@@ -237,36 +320,43 @@ Every value originating in a workflow context, input, branch name, manifest, or 
 untrusted data. Shell steps receive those values through `env:` only; direct `${{ ... }}`
 interpolation into `run:` source is forbidden. Scripts double-quote expansions, use `--` and full
 refspecs for operands, consume NUL-delimited Git output, create JSON with `jq --arg`, and create PR
-and issue bodies through files. Branch names are never evaluated as code.
+and issue bodies through files. Branch names are never evaluated as code. Dynamic values rendered
+for GitHub Markdown are HTML-escaped, wrapped in safe `<code>` or `<pre>` elements, and have `@`
+neutralised before insertion so target-controlled values cannot create mentions, links, HTML, or
+misleading structure.
 
 All repository-relative paths are canonicalised beneath their checkout roots. The workflow rejects
 absolute paths, `..` traversal, missing config files, missing Terraform directories, duplicate
 canonical directories, and directories that resolve outside the target checkout. Nested module
 directories are allowed, but each directory processes only the `.tf` files directly within it.
 
-Before either preparation or reconciliation invokes `tf-version-bump`, the script enumerates that
+Before either preparation or verification invokes `tf-version-bump`, the script enumerates that
 directory's matching files, uses `lstat` to reject symlinks and non-regular files, and verifies each
 canonical path remains under the target checkout. Required lock files receive the same checks.
 Containment is repeated for every changed and untracked path before a preparation bundle or commit
-is created.
+is created. Repository `.terraform` paths are rejected. Every Terraform invocation uses a fresh,
+absolute `TF_DATA_DIR` created under a trusted runner temporary directory, never the target
+checkout, so a tracked `.terraform` symlink cannot redirect initialisation writes.
 
 ## Per-branch preparation and validation flow
 
 Each unprivileged preparation job performs the following sequence:
 
 1. Check out the control OID and discovered state-branch OID with persisted credentials disabled.
-2. Install the exact Go, `tf-version-bump`, and Terraform versions supplied by the caller.
+2. Install the exact released `tf-version-bump` and Terraform versions supplied by the caller and
+   verify their reported versions. The released CLI must be the same artefact exercised by tests.
 3. Validate directory containment and reject symlinked or non-regular candidate files before any
-   write.
+   write, including any repository `.terraform` path.
 4. For every configured Terraform directory, run `tf-version-bump` from that directory with the
    control config and the non-recursive pattern `*.tf`.
-5. For that same directory, run:
+5. Create a fresh absolute `TF_DATA_DIR` under the trusted runner temporary directory and, for that
+   same directory, run with a 20-minute command timeout:
 
    ```text
    terraform -chdir=<directory> init -upgrade -backend=false -input=false -no-color
    ```
 
-6. After successful initialisation, inspect the canonical `.terraform/providers` package tree
+6. After successful initialisation, inspect the trusted data directory's provider package tree
    before removing it. If initialisation installed any provider package, require a regular
    `.terraform.lock.hcl`, including a newly created untracked file. If it installed none, record the
    directory as provider-free and allow the lock file to be absent. If a new required lock file is
@@ -275,13 +365,19 @@ Each unprivileged preparation job performs the following sequence:
    confirm that every changed `.tf` file is directly inside exactly one configured directory and
    every other change is that directory's lock file. Any other path fails the safety check.
 8. Produce the versioned manifest and patch, verify their hashes locally, upload the immutable
-   candidate bundle with a collision-resistant branch hash in its artefact name, and remove the
-   checkouts. Terraform initialisation downloads provider packages but does not execute provider
-   validation RPCs, so this captures the publishable candidate before any provider plugin executes.
+   candidate bundle under a name containing the run ID, run attempt, policy ID, and
+   collision-resistant branch hash, and remove the checkouts and trusted data directories.
+   Terraform initialisation downloads provider packages but does not execute provider validation
+   RPCs, so this captures the publishable candidate before any provider plugin executes.
 
-A fresh unprivileged validation job downloads only its expected candidate, validates the manifest,
-paths, modes, hashes, refs, and OIDs, and applies the patch to a fresh exact-base checkout. For each
-directory with provider selections it runs:
+A fresh unprivileged validation job downloads only its exact run-attempt candidate, validates the
+manifest, paths, modes, hashes, refs, OIDs, policy, and run identity, and applies the patch to a
+fresh exact-base validation checkout. The host creates a trusted data directory and starts the
+pinned Terraform image with `--rm`, no Docker socket, all capabilities dropped,
+`no-new-privileges`, bounded processes/memory/CPU, the runner UID/GID, and only the disposable
+validation checkout and trusted data directory mounted. It passes no host environment variables
+except explicit non-secret Terraform settings. For each directory with provider selections, the
+container runs under a 20-minute host timeout:
 
 ```text
 terraform -chdir=<directory> init -backend=false -input=false -no-color -lockfile=readonly
@@ -289,9 +385,16 @@ terraform -chdir=<directory> validate -no-color
 ```
 
 For a manifest-declared provider-free directory it omits `-lockfile=readonly` because no lock file
-exists, then runs the same validation command. The validation job never uploads source or lock-file
-bytes and discards its checkout after uploading only its candidate-bound outcome and logs. Provider
-execution therefore cannot alter the immutable candidate later considered for publication.
+exists, then runs the same validation command. Neither the candidate bundle nor the host outcome
+directory is mounted into the container. After the container stops, the trusted host supervisor
+creates the outcome from the observed exit status, then uploads only that candidate-bound outcome
+and captured logs. A timeout is `branch-validation`. The validation job never uploads source or
+lock-file bytes and discards its checkout and data directory. Provider execution therefore cannot
+alter the immutable candidate, host outcome, or Actions control plane later used for publication.
+
+This boundary authenticates that the supervised Terraform process returned zero; it does not prove
+that an adversarial provider truthfully implemented schema or configuration validation. That
+semantic limitation appears in the PR body and consumer documentation.
 
 `tf-version-bump` continues processing later files after a per-file parse, stat, read, or write
 error, but accumulates those errors and exits non-zero after processing completes. Its output ends
@@ -303,40 +406,75 @@ ensures every changed source file is loaded by the immediately following init/va
 Consumers list nested modules explicitly. Duplicate directories are rejected, so a changed source
 belongs to exactly one unit.
 
-## Privileged reconciliation flow
+## Verification and privileged publication flow
 
-A non-dry run starts a fresh reconciliation matrix after all preparation and validation jobs have
-uploaded their artefacts. For each branch, reconciliation:
+A non-dry run starts fresh verification and publication matrices after all preparation and
+validation jobs have uploaded their artefacts. Reconciliation has three explicit phases across two
+job boundaries:
 
-1. Downloads only that run's expected preparation bundle and, when applicable, validation outcome,
-   then validates their manifests, paths, modes, hashes, control OID, branch name, validated base
-   OID, and candidate binding before using any payload.
-2. For a successful result, checks out the exact control and base OIDs with persisted credentials
-   disabled, repeats path/symlink preflight, independently reruns `tf-version-bump` for each
-   configured directory, and requires its `.tf` diff to match the manifest.
-3. Applies only the lock-file portion from the pre-provider candidate bundle, verifies the complete
-   resulting diff and hashes, and stages only declared regular `.tf` and lock files.
-4. Fetches the state ref immediately before publication and requires its remote OID still to equal
-   the validated base OID. Movement fails without publication; a later run processes the new tip.
-5. Verifies ownership of any existing automation ref and PR, then creates the signed or unsigned
-   commit, updates the ref with an explicit expected-OID lease, and creates or refreshes the PR.
-6. Reconciles the branch's marked failure issue and returns the result status so the overall
-   workflow fails whenever validation or reconciliation failed.
+1. **Verify and stage in a credential-free job.** With `contents: read`, no publication environment,
+   and no write token or protected secret, download only the exact run-attempt
+   preparation bundle and applicable validation outcome; validate their manifests, paths, modes,
+   hashes, run identity, policy, control OID, branch, validated base OID, and candidate binding.
+   Check out the exact control and base OIDs with persisted credentials disabled, repeat
+   path/symlink preflight, independently rerun the released `tf-version-bump` for each configured
+   directory, require its `.tf` diff to match, apply only declared lock-file bytes, verify the full
+   result, and upload a run-attempt-bound verified-result artefact that contains no token or key
+   material.
+2. **Authenticated prepublication in a protected job.** On a fresh runner, download and validate
+   the verified-result identity without executing or sourcing it, then mint the App token when
+   configured or select the built-in token. Supply the selected token only to exact Git/GitHub
+   commands through a temporary credential file and command-scoped environment. Fetch the current
+   state and automation refs and query exact PR/issue records. Verify the state OID, policy-scoped
+   ownership, PR marker, issue author identity, and expected automation-ref OID. No signing key is
+   materialised.
+3. **Publish in the same protected job.** Materialise the signing key only after prepublication
+   succeeds, create and locally verify the commit, then use one authenticated atomic Git push
+   containing a no-op state-ref refspec guarded by an exact state-ref lease and the automation-ref
+   create/update guarded by its own exact lease. This makes the state/base comparison atomic with
+   the update-ref transaction. Create or refresh the PR, reconcile the marked issue, remove every
+   credential/key helper in unconditional cleanup, and return the result status.
 
 For example, `state/nonproduction/example-thing` maps to
 `update_state/nonproduction/example-thing`. State branches are read-only bases. The `update_`
 namespace is reserved for this automation, but naming alone never grants ownership.
 
 An automation commit carries exact machine-readable trailers identifying the workflow, state
-branch, validated base OID, and control OID. A managed PR carries a corresponding hidden marker.
-Before rewriting or deleting an existing automation ref, reconciliation requires both its tip
-commit marker and the corresponding marked PR to agree. An unmarked or mismatched existing ref is
-an automation failure and is never adopted.
+branch, automation policy ID, validated base OID, control OID, run ID, and run attempt. A managed PR
+carries a corresponding policy-scoped hidden marker. Before rewriting or deleting an existing
+automation ref, reconciliation requires both its tip commit marker and the corresponding marked PR,
+open or closed, to agree. An unmarked, different-policy, or mismatched existing ref is an automation
+failure and is never adopted. A marked issue is edited or closed only when its immutable author
+login equals the selected built-in/App bot identity.
+
+Git authentication never relies on checkout persistence or on Git interpreting `GH_TOKEN`.
+Discovery and publication create a token-free `GIT_ASKPASS` helper and a mode-`0600` token file only
+for their exact Git commands; the token is absent from remotes and command arguments, prompts are
+disabled, and both files are removed unconditionally. GitHub CLI commands receive `GH_TOKEN` only
+in their own child environment.
+
+The Git ref transaction guarantees that the state ref equalled the validated base at the instant
+the automation ref was created or updated. GitHub PR API calls are not part of that transaction.
+Reconciliation rechecks the state ref after the push and after PR mutation; detected movement causes
+an exact-lease rollback of the automation ref written by the current invocation and closes or
+restores the managed PR as applicable. State movement after the final check is normal concurrent
+repository activity and is corrected by the next queued run; the documentation does not claim
+strict atomicity across Git and GitHub APIs.
+
+Every mutation boundary has compensation. If initial PR creation fails after creating the ref, the
+workflow exact-lease-deletes that ref. If refreshing an existing PR fails after updating its ref, it
+exact-lease-restores the previous ref OID. Ambiguous API responses are reconciled by re-reading exact
+markers before compensation. A compensation lease failure never triggers an unconditional retry;
+it produces an automation error with explicit manual recovery details. Failpoint integration tests
+cover ref create/update, PR create/edit/close, and ref deletion.
 
 When a successful non-dry run produces no changes, the workflow closes the marked automation PR as
-obsolete and deletes only its verified automation branch using an expected-old-OID lease. A lease
-mismatch fails without an unconditional retry. It also closes any open marked validation-failure
-issue because the branch completed the update and validation flow.
+obsolete and deletes only its verified automation branch using an atomic no-op state ref plus an
+expected-old-OID deletion lease. A lease mismatch fails without an unconditional retry. Deletion is
+performed before PR closure so a failed delete leaves the recoverable marked PR/branch pair intact;
+an API failure after deletion is recovered by locating and closing the marked PR on the next run.
+It also closes any open marked validation-failure issue because the branch completed the update and
+validation flow.
 
 ## Dry-run semantics
 
@@ -351,7 +489,7 @@ workflow still:
 - Uploads diagnostic preparation and outcome artefacts and reports proposed changes and failures in
   workflow output.
 
-It never enters the protected reconciliation environment and never commits, pushes, changes GitHub
+It never enters the protected publication environment and never commits, pushes, changes GitHub
 repository content, creates or edits a pull request, creates or edits an issue, closes an issue or
 pull request, or deletes an automation branch. GitHub's unavoidable workflow run, logs, summaries,
 and explicitly uploaded diagnostic artefacts are permitted. This validates the proposed result
@@ -368,39 +506,49 @@ chore: apply tf-version-bump config
 The pull request identifies the state branch and is looked up by exact base and head refs rather
 than title alone. Its body is refreshed on every run with:
 
+- Automation policy ID.
 - State-branch base revision.
 - Immutable control revision.
+- Workflow run ID and attempt.
 - Config path.
-- Go, `tf-version-bump`, and Terraform versions.
+- Released `tf-version-bump`, release archive digest, Terraform version, and validation image
+  digest.
 - Changed files.
 - Initialised and validated Terraform directories.
 - Workflow-run link.
 - A statement that the branch is automation-owned and may be regenerated.
+- A statement that success records Terraform's supervised exit status and cannot prove that a
+  malicious provider truthfully implemented validation.
+
+Every dynamic value uses the shared Markdown encoder: escape `&`, `<`, and `>`, neutralise `@` with
+a zero-width separator, and render scalar values in `<code>` and log tails in bounded `<pre>`
+blocks. Machine markers contain only fixed syntax plus validated policy IDs and hexadecimal hashes.
 
 The workflow recreates the automation commit from the latest state-branch tip instead of
-accumulating obsolete generated commits or rebasing them indefinitely. The force-with-lease applies
-only to the stable automation ref after its ownership markers pass. A lease mismatch or state-base
-movement fails as an automation error and does not retry with an unconditional force. Branch
-deletion uses the same expected-old-OID protection.
+accumulating obsolete generated commits or rebasing them indefinitely. One atomic push guards the
+unchanged state ref and stable automation ref with their exact expected OIDs after ownership markers
+pass. A lease mismatch or detected state-base movement fails as an automation error and does not
+retry with an unconditional force. Branch deletion uses the same atomic state guard and
+expected-old-OID protection. GitHub API failures use the compensation rules above.
 
 ## Failure classification and issues
 
-Failures from these stages are deterministic state-branch failures:
+Failures from these stages are state-branch failures eligible for one reconciled issue:
 
 - `tf-version-bump`
+- `terraform init`
 - `terraform validate`
 
 The control config is validated before matrix creation, so a shared config failure stops discovery
-without branch issues. All `terraform init` failures are workflow-level failures because its exit
-status does not reliably distinguish branch configuration defects from registry outages,
-authentication failures, rate limits, or other transient dependencies. Init failures retain logs
-and fail the workflow but do not create branch issues. Missing/ignored locks, unsafe paths,
-manifest failures, ref movement, and ownership or lease failures are likewise automation or
-repository-policy failures rather than update/validation issues.
+without branch issues. An init issue states that the cause may be branch configuration or a
+transient registry, authentication, rate-limit, network, or other external dependency; a later
+successful non-dry-run closes it through the normal recovery lifecycle. Missing/ignored locks,
+unsafe paths, manifest failures, ref movement, and ownership or lease failures are automation or
+repository-policy failures rather than update/init/validation issues.
 
-A non-dry run creates or updates one open issue per deterministic failing state branch. The issue
-is identified by an exact stable title and a machine-readable marker, not a fuzzy title search. Its
-body is replaced with the latest:
+A non-dry run creates or updates one open issue per update/init/validation failing state branch. The
+issue is identified by an exact stable title and a machine-readable marker, not a fuzzy title
+search. Its body is replaced with the latest:
 
 - State branch and base revision.
 - Failing stage and Terraform directory, when applicable.
@@ -409,22 +557,26 @@ body is replaced with the latest:
 - Workflow-run and uploaded-log links.
 
 Full captured logs are uploaded as a workflow artefact with a collision-resistant name derived
-from a hash of the complete branch ref. The issue body is bounded so recurring scheduled failures
-do not grow without limit. A successful later non-dry run closes the issue with a recovery comment.
+from the run ID, run attempt, policy ID, and hash of the complete branch ref. The issue body uses the
+shared Markdown encoder and is bounded so recurring scheduled failures do not grow without limit. A
+successful later non-dry run closes the issue with a recovery comment, but only after verifying the
+marker, policy, and immutable bot author login.
 
-When a newer control or base revision produces a deterministic update/validation failure,
+When a newer control or base revision produces an update/init/validation failure,
 reconciliation closes the previous marked PR as obsolete, deletes its verified automation branch
 with an expected-OID lease, and then creates or updates the failure issue. A stale previously
-successful PR is never left open and apparently mergeable after a newer deterministic failure.
-Workflow-level init or transient failures leave the prior PR unchanged because they do not establish
-that its validated proposal is defective.
+successful PR is never left open and apparently mergeable after a newer branch failure.
+The init issue makes any possible transient cause explicit rather than leaving an older proposal
+open as though the latest run had validated it.
 
 Authentication, GitHub API, invalid input, unsafe diff, signing, commit, push, lease, PR, issue
 reconciliation, and workflow configuration failures are automation failures. They fail the matrix
 job without creating a misleading state-validation issue. The candidate manifest and its bound
 validation outcome together carry an explicit result class with precedence `automation`,
-`shared/init`, `branch-update`, `branch-validation`, then `success`; reconciliation rejects unknown,
-mismatched, or contradictory classes. `fail-fast: false` ensures other state branches continue.
+`branch-update`, `branch-init`, `branch-validation`, then `success`; reconciliation rejects unknown,
+mismatched, or contradictory classes. A supervised validation command timeout is
+`branch-validation`; a job-level timeout or container-supervisor failure is `automation`.
+`fail-fast: false` ensures other state branches continue.
 
 ## Authentication and permissions
 
@@ -436,30 +588,37 @@ The caller sets the reusable workflow's permission ceiling according to its auth
 Reusable workflows can only maintain or reduce the caller's permission ceiling. The reusable
 workflow declares narrower permissions per job:
 
-- Discovery, preparation, and validation: `contents: read` only.
-- Reconciliation: `contents: write`, `pull-requests: write`, and `issues: write`.
+- Discovery, preparation, validation, and verification: `contents: read` only.
+- Publication: `contents: write`, `pull-requests: write`, and `issues: write`.
 
-The reconciliation declaration supports built-in-token callers, but an App caller's read-only
-ceiling keeps the effective reconciliation `GITHUB_TOKEN` read-only. Every checkout sets
-`persist-credentials: false`. The built-in publication path injects `GITHUB_TOKEN` only into the
-exact Git/GitHub CLI steps that need it. The App publication path never passes `GITHUB_TOKEN` to a
-write operation; it uses only the short-lived App token. Consumers using the built-in token must
-enable the repository setting that permits GitHub Actions to create pull requests.
+The publication declaration supports built-in-token callers, but an App caller's read-only ceiling
+keeps the effective publication `GITHUB_TOKEN` read-only. Every checkout sets
+`persist-credentials: false`. The built-in publication path makes `GITHUB_TOKEN` available only to
+authenticated prepublication/publication steps and their exact Git/GitHub CLI children. It is not
+present during candidate verification or source reproduction. The App publication path never
+passes `GITHUB_TOKEN` to a write operation; it uses only the short-lived App token. Consumers using
+the built-in token must enable the repository setting that permits GitHub Actions to create pull
+requests.
 
-GitHub recursion protection distinguishes the events created with the built-in token. Resulting
-`push` events do not create workflow runs. Pull-request `opened`, `synchronize`, and `reopened`
-events do create workflow runs, but those runs wait for approval from a repository writer. Other
-pull-request activity types do not create runs. Built-in-token mode is therefore suitable only when
-manual approval of generated PR checks is acceptable. Consumers whose required checks must run
-unattended use App mode; an explicit consumer-managed `workflow_dispatch` is the documented manual
-fallback rather than an assumed automatic check run.
+Current GitHub.com recursion protection distinguishes the events created with the built-in token.
+Resulting `push` events do not create workflow runs. Pull-request `opened`, `synchronize`, and
+`reopened` events do create workflow runs, but those runs wait for approval from a repository
+writer. Other pull-request activity types do not create runs. GitHub Enterprise Server versions
+can retain the older rule that suppresses these pull-request runs as well, so consumers must verify
+their installed version rather than assume GitHub.com behaviour. Built-in-token mode is therefore
+suitable only when manual approval of generated PR checks is acceptable on the target platform.
+Consumers whose required checks must run unattended may use App mode only after satisfying and
+acknowledging the downstream-check contract; otherwise they retain approval or use an explicit
+consumer-managed `workflow_dispatch` after review. App authentication changes event delivery, not
+the trustworthiness of downstream workflow code.
 
-When the App client ID and protected-environment private key are supplied, reconciliation uses the
+When the App client ID and protected-environment private key are supplied, publication uses the
 GitHub-maintained App-token action to mint a short-lived installation token limited to the current
 repository and the same three explicit permissions. It obtains the App bot's user ID through the
 GitHub API and constructs the correct bot name and noreply address for commit attribution.
-App-authenticated PR activity allows future PR checks to run without the built-in token's approval
-gate. The App key never exists in discovery, preparation, or validation.
+App-authenticated PR activity allows audited PR checks to run without the built-in token's approval
+gate. The App key is not referenced, passed, or materialised in discovery, preparation, validation,
+or verification.
 
 Every referenced action is pinned to an immutable commit SHA with a version comment, matching the
 repository's existing workflow convention.
@@ -517,6 +676,7 @@ A maintained shell test creates temporary real Git repositories and bare remotes
 - Prefix allow-lists and manual narrowing.
 - Rejection of manual widening.
 - Overlapping-prefix deduplication and deterministic ordering.
+- Controlled discovery at 256 matches and a clear pre-matrix failure at 257 matches.
 - Branch names containing slashes.
 - Valid hostile ref names containing shell metacharacters, quotes, leading dashes, Unicode, and
   percent signs without evaluating them as commands.
@@ -524,9 +684,8 @@ A maintained shell test creates temporary real Git repositories and bare remotes
 - Rejection of manual dispatch from a non-default ref.
 - One immutable control OID across a default-branch movement.
 - Exact discovered base OIDs and rejection when a state ref advances before publication.
-- Successful update, initialisation, and validation with the real `tf-version-bump` binary and a
-  pinned real Terraform CLI.
-- Aggregate non-zero CLI status after a real per-file failure while later files still run.
+- Successful update, initialisation, and validation with the independently downloaded
+  `v1.0.0-rc.7` release artefact and the digest-pinned Terraform image used by the workflows.
 - One-to-one mapping of directly changed source files to configured Terraform directories,
   including rejection of omitted, duplicate, and ambiguous roots.
 - Terraform source and lock-file staging into an immutable candidate before provider execution.
@@ -537,21 +696,42 @@ A maintained shell test creates temporary real Git repositories and bare remotes
   bundles are rejected by fresh reconciliation.
 - Dry-run isolation.
 - Rejection of unexpected changed files.
-- Pre-write rejection of Terraform/lock symlinks into the control checkout and outside both
-  checkouts.
+- Pre-write rejection of Terraform/lock symlinks and repository `.terraform` paths, including
+  symlinks at each ancestor that could escape into the control checkout or elsewhere on the
+  runner. Terraform uses a fresh absolute trusted `TF_DATA_DIR` for every root.
 - Stable automation-branch regeneration, ownership-marker validation, unowned-ref refusal, and
-  explicit leases for updates and deletion races.
+  explicit leases for updates and deletion races. A branch marked for a different policy is
+  foreign and fails safely even though the required ref name remains `update_<state-branch>`.
+- Atomic publication tests move the state ref at the push boundary and prove that a no-op state-ref
+  update with an exact lease prevents stale update-ref publication.
+- Failpoint tests after ref creation or update, PR creation or edit, PR close, and ref deletion
+  prove the documented exact-lease compensation and retry behaviour.
 - Malformed shared-config failure before matrix creation.
-- Workflow-level classification of a real deterministic init/download failure without branch
-  issues.
+- Branch-issue classification of a real init/download failure with bounded diagnostics.
 - Success followed by a new deterministic failure closes the stale marked PR and safely removes
   its owned update branch.
 - Signed commits, local signature verification, cleanup of key material, and signing failure.
-- A hostile purpose-built Terraform provider fixture that attempts to find credentials, alter
-  control files and the validation checkout's lock file, poison later validation steps, and
-  construct a malicious outcome. Local coverage verifies that it cannot replace the pre-provider
-  candidate and that reconciliation treats every resulting payload as untrusted data; the actual
-  runner and protected-secret boundary is verified by real-service acceptance.
+- A hostile purpose-built Terraform provider fixture runs in the same constrained container
+  boundary as production. It attempts delayed writes after parent exit, credential discovery,
+  candidate and lock-file replacement, workflow-command poisoning, outcome forgery, and container
+  escape. Host-side tests verify that it cannot alter the immutable candidate or trusted outcome
+  and that the host records the observed process status. These tests do not claim that a malicious
+  provider must report truthful semantic validation diagnostics. The repository test harness builds
+  the reviewed Linux fixture, places it in a trusted read-only filesystem mirror, and supplies a
+  host-created Terraform CLI configuration only in test mode; neither the mirror nor this test-only
+  configuration is selectable from state-branch content or reusable-workflow inputs.
+- A hanging provider is terminated at the configured timeout and produces the validation-timeout
+  classification without unbounded runner use.
+- Artefact names and manifests bind run ID, run attempt, policy ID, control OID, state ref, and base
+  OID. Full-run and failed-job re-run cases cannot consume another attempt's artefacts.
+- The command-scoped Git authentication helper works against a real authenticated bare HTTP test
+  service without storing a token in a remote URL or process argument and removes its temporary
+  files after each command.
+- Dynamic PR and issue text neutralises mentions and HTML/Markdown control, and renders bounded
+  diagnostics without allowing attacker-controlled presentation.
+- The credential-free verification job reaches a complete verified result without an App token or
+  signing key. The protected publication job refuses to mutate when either selected credential is
+  unavailable.
 - Unsigned operation when no signing key is configured.
 - Obsolete no-change branch and PR payload generation.
 - Clear failure when a newly required provider lock file is ignored; the workflow never force-adds
@@ -563,16 +743,19 @@ covered by the real-service acceptance run.
 
 ### Workflow validation
 
-The project adds a pinned `actionlint` invocation for all three example workflow files. GitHub.com
-supports `concurrency.queue`, but actionlint 1.7.12 predates that syntax and reports `queue` as an
-unexpected concurrency key. Until a pinned actionlint release supports it, the invocation includes
-the exact `-ignore '^unexpected key "queue" for "concurrency" section\.'` filter for that known false
-positive; it does not disable other syntax checks. The real-service queue acceptance remains
-mandatory. Validation copies the example `.github` tree into a temporary consumer-style repository
-root first, so local reusable-workflow paths resolve exactly as they do after installation. It also
-runs `bash -n` and the integration test for both helper scripts. Existing Go tests, race detection,
+The project adds one repository-owned launcher that runs exactly
+`go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`; the local harness, Make target, CI, and
+final verification all use that launcher for the three example workflow files. No parser warning
+is suppressed. Validation copies the example `.github` tree into a temporary consumer-style
+repository root first, so local reusable-workflow paths resolve exactly as they do after
+installation. It also runs `bash -n`, verifies that Docker is available for the container-boundary
+tests, and runs the integration tests for both helper scripts. Existing Go tests, race detection,
 branch-automation tests, linting, and build validation remain required and must produce pristine
 output.
+
+Each behaviour is introduced through its own focused failing test and smallest implementation,
+followed by the focused test again. A missing script or mode is used only to establish the initial
+scaffold, not as the failing reason for a batch of unrelated assertions.
 
 After implementation and TDD finish, a separate test-cleanup pass reviews new tests for duplicated
 or low-value coverage.
@@ -586,20 +769,28 @@ The example README defines an acceptance procedure using a disposable GitHub rep
 - A provider-using root with a committed lock file, a provider-free root without one, and a
   default-branch config covering both.
 - A default-branch-restricted publication environment.
-- Built-in-token and GitHub App runs.
+- A built-in-token run and an App-mode run made only after the repository's downstream workflows
+  satisfy the documented unattended-check contract.
 - An App-mode run whose job permission summary shows `contents: read` and no write scopes, and whose
   publication succeeds with the short-lived App token, proving `GITHUB_TOKEN` is not the write
   credential.
 - An alternate-ref manual dispatch that cannot enter the protected publication job or read its
   secrets.
-- A state branch using the hostile provider fixture. The provider attempts to read write/App/signing
-  credentials, alter the control checkout and validation lock file, poison `GITHUB_ENV` and
-  `GITHUB_PATH`, and submit a malicious outcome. The validation job exposes no protected or write
-  credentials, cannot replace the pre-provider candidate, the fresh reconciliation runner rejects
-  the tampered outcome, and no repository ref, content, PR, or issue mutation occurs.
+- The actual GitHub-hosted validation runner executes the hostile fixture in the digest-pinned
+  container through the repository harness's reviewed read-only filesystem mirror and records its
+  mount, environment, permission, delayed-write, and timeout results. This is a CI boundary test,
+  not a state-branch-selectable production input. The fixture has no write/App/signing credentials,
+  workflow-command files, control checkout, immutable candidate, trusted outcome path, or container
+  socket available to it.
+- App mode is rejected unless `unattended_checks_safe: true`. The accepted App case uses reviewed
+  default-branch workflows with a read-only token, no secrets or privileged environments, and an
+  isolated target-code step. A hostile downstream test cannot mutate repository content or read a
+  secret sentinel.
+- Private-repository discovery, fetch, update, and deletion using command-scoped authentication.
 - Successful update, repeated idempotent update, validation failure, issue update, recovery, and
   obsolete-PR cleanup.
-- Three rapid dispatches demonstrating `queue: max` rather than pending-run replacement.
+- Three rapid dispatches demonstrating the documented native behaviour: the first runs, the third
+  replaces the second pending run, and the third reconciles the latest repository state.
 - A built-in-token PR whose `push` workflows remain absent and whose `pull_request` checks wait for
   writer approval, followed by an App-mode PR whose checks start without that approval gate.
 - A dry run that demonstrates no repository refs, content, PRs, or issues changed while diagnostic
@@ -607,6 +798,12 @@ The example README defines an acceptance procedure using a disposable GitHub rep
 - An unowned update-ref collision and concurrent update/deletion races that preserve the remote
   ref.
 - A state-base movement that prevents stale publication.
+- Full-workflow and failed-job re-runs whose artefacts remain isolated by run attempt.
+- A policy collision that refuses to adopt or overwrite the foreign marked ref and PR.
+- A built-in-token run with repository PR creation temporarily disabled, demonstrating that a real
+  post-push PR-creation rejection triggers exact-lease rollback without deleting an unseen remote
+  update. The remaining mutation-boundary compensation paths are covered by the local state-machine
+  and real-Git failpoint tests rather than an invented GitHub API mock.
 - An optional signed run whose pushed commit is locally verified and shown as verified by GitHub
   when the signing identity is configured correctly.
 
@@ -621,20 +818,31 @@ The acceptance transcript is reviewed before completion is claimed.
 - Protected publication-environment setup, default-branch restrictions, trusted-dispatch
   assumptions, and fixed optional secret names.
 - Exact tool-version pinning.
+- The prerequisite `v1.0.0-rc.7` release, its aggregate-failure contract, and verification of the
+  downloaded artefact's checksum and provenance before use.
 - Production and non-production prefix/config separation.
 - Manual narrowing and dry-run behaviour.
 - Built-in-token limitations and optional GitHub App configuration.
+- The `automation_policy_id` ownership boundary and the explicit `unattended_checks_safe`
+  downstream-workflow contract required for App mode.
 - Unsigned and signed commit setup.
 - Stable branch, PR, issue, and cleanup lifecycles.
 - Reserved namespace, ownership markers, immutable control/base OIDs, and lease failure recovery.
+- Run-ID and run-attempt artefact provenance, command-scoped private-repository Git authentication,
+  publication compensation, and the remaining non-transactional GitHub-API race.
 - Single-root and multi-root configurations.
 - Direct-file-per-module processing and the requirement to list every nested module explicitly.
 - Backend-disabled Terraform initialisation.
-- Workflow-level init failures versus deterministic branch update/validation issues.
+- Digest-pinned constrained Terraform execution, trusted `TF_DATA_DIR`, command and job timeouts,
+  host-observed process status, and the limit that a malicious provider can lie about semantic
+  validation results even though it cannot alter the publishable candidate or obtain credentials.
+- Branch-scoped update, init, and validation issues, including possible transient causes in init
+  diagnostics, versus automation failures that never create issues.
 - Required provider lock files, valid provider-free roots without locks, and rejection of ignored
   required locks and symlinked Terraform/lock paths.
-- GitHub.com `queue: max` semantics, the temporary actionlint 1.7.12 false-positive ignore, and the
-  need to confirm queue support before using the example on GitHub Enterprise Server.
+- GitHub's one-running/one-latest-pending concurrency behaviour and the need to redispatch a
+  displaced manual dry run.
+- The 256-branch matrix ceiling and the controlled failure when an allow-list exceeds it.
 - Built-in-token event suppression and approval-required PR checks, including when App mode is
   required for unattended checks.
 - Manual identification and cleanup of strongly marked orphaned automation refs and issues when a
@@ -655,9 +863,10 @@ The feature is complete when:
 - Dry runs perform real local updates and validation without repository or GitHub content mutation;
   workflow logs and diagnostic artefacts are retained.
 - Terraform executes only in credential-free jobs with `contents: read`, the immutable publishable
-  candidate is uploaded before provider execution, and privileged reconciliation runs on a fresh
-  protected runner without executing target-supplied code.
-- App-mode reconciliation has an effective read-only `GITHUB_TOKEN`; only its short-lived App token
+  candidate is uploaded before provider execution, credential-free verification runs in a separate
+  read-only job, and privileged publication runs on a fresh protected runner without executing
+  target-supplied code.
+- App-mode publication has an effective read-only `GITHUB_TOKEN`; only its short-lived App token
   can publish repository content, refs, PRs, or issues.
 - Untrusted refs and inputs remain data across Actions, shell, Git, JSON, Markdown, and artefact
   boundaries.
@@ -667,14 +876,16 @@ The feature is complete when:
   publication.
 - Existing update refs require verifiable ownership, and every rewrite or deletion uses an exact
   expected remote OID.
-- The CLI reports aggregate per-file failure with a non-zero status.
+- The independently downloaded `v1.0.0-rc.7` CLI reports aggregate per-file failure with a non-zero
+  status, and the workflow downloads and verifies the recorded SHA-256 of that exact released
+  archive before use.
 - Every configured Terraform module directory with installed provider packages has a lock file
   after initialisation; new and changed required lock files are staged unless ignored (which is a
   clear failure), provider-free directories may omit the file, disposable `.terraform/` data is
   excluded, and symlinked, escaping, non-regular, or otherwise unexpected paths are rejected before
   writing.
-- GitHub.com runs use the supported bounded `queue: max` concurrency behaviour; actionlint ignores
-  only its pinned version's exact known false positive until parser support is released.
+- Concurrency uses only supported `group` and `cancel-in-progress` keys and documents GitHub's
+  one-running/one-latest-pending behaviour. The pinned actionlint launcher requires no suppression.
 - Built-in-token documentation and acceptance distinguish suppressed `push` workflows from
   approval-required PR workflows, and require App mode for unattended required checks.
 - Every changed Terraform source file belongs directly to exactly one configured and validated

--- a/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
+++ b/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
@@ -68,8 +68,8 @@ copy the example's `.github` directory rather than invoke a workflow from its ex
 
 The shell scripts keep non-trivial orchestration out of YAML blocks. They have help output,
 validate their inputs, fail with stage-specific messages, and limit routine output while retaining
-failure logs for diagnosis. They expose separate validation and reconciliation operations so the
-privileged job never executes target-branch Terraform.
+failure logs for diagnosis. They expose separate preparation, validation, and reconciliation
+operations so the privileged job never executes target-branch Terraform.
 
 ## Workflow architecture
 
@@ -104,9 +104,9 @@ The update matrix defaults to four concurrent branches. This bounds Terraform do
 API writes while retaining useful parallelism. A caller can lower or raise the limit through the
 reusable workflow's `max_parallel` input.
 
-The validation jobs have `contents: read`, use `persist-credentials: false` for every checkout, and
-never receive a write token, GitHub App private key, or commit-signing key. Each validation job uses
-two independent checkouts:
+The preparation and validation jobs have `contents: read`, use `persist-credentials: false` for
+every checkout, and never receive a write token, GitHub App private key, or commit-signing key. Each
+uses two independent checkouts:
 
 - A control checkout of the immutable caller SHA supplies the reviewed scripts and
   `tf-version-bump` configuration.
@@ -244,7 +244,7 @@ absolute paths, `..` traversal, missing config files, missing Terraform director
 canonical directories, and directories that resolve outside the target checkout. Nested module
 directories are allowed, but each directory processes only the `.tf` files directly within it.
 
-Before either validation or reconciliation invokes `tf-version-bump`, the script enumerates that
+Before either preparation or reconciliation invokes `tf-version-bump`, the script enumerates that
 directory's matching files, uses `lstat` to reject symlinks and non-regular files, and verifies each
 canonical path remains under the target checkout. Required lock files receive the same checks.
 Containment is repeated for every changed and untracked path before a preparation bundle or commit
@@ -305,11 +305,12 @@ belongs to exactly one unit.
 
 ## Privileged reconciliation flow
 
-A non-dry run starts a fresh reconciliation matrix after all validation jobs have uploaded their
-bundles. For each branch, reconciliation:
+A non-dry run starts a fresh reconciliation matrix after all preparation and validation jobs have
+uploaded their artefacts. For each branch, reconciliation:
 
-1. Downloads only that run's expected artefact and validates its manifest, paths, modes, hashes,
-   control OID, branch name, and validated base OID before using any payload.
+1. Downloads only that run's expected preparation bundle and, when applicable, validation outcome,
+   then validates their manifests, paths, modes, hashes, control OID, branch name, validated base
+   OID, and candidate binding before using any payload.
 2. For a successful result, checks out the exact control and base OIDs with persisted credentials
    disabled, repeats path/symlink preflight, independently reruns `tf-version-bump` for each
    configured directory, and requires its `.tf` diff to match the manifest.
@@ -435,7 +436,7 @@ The caller sets the reusable workflow's permission ceiling according to its auth
 Reusable workflows can only maintain or reduce the caller's permission ceiling. The reusable
 workflow declares narrower permissions per job:
 
-- Discovery and validation: `contents: read` only.
+- Discovery, preparation, and validation: `contents: read` only.
 - Reconciliation: `contents: write`, `pull-requests: write`, and `issues: write`.
 
 The reconciliation declaration supports built-in-token callers, but an App caller's read-only
@@ -458,7 +459,7 @@ GitHub-maintained App-token action to mint a short-lived installation token limi
 repository and the same three explicit permissions. It obtains the App bot's user ID through the
 GitHub API and constructs the correct bot name and noreply address for commit attribution.
 App-authenticated PR activity allows future PR checks to run without the built-in token's approval
-gate. The App key never exists in discovery or validation.
+gate. The App key never exists in discovery, preparation, or validation.
 
 Every referenced action is pinned to an immutable commit SHA with a version comment, matching the
 repository's existing workflow convention.

--- a/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
+++ b/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
@@ -35,8 +35,8 @@ lifecycle.
 - Keep target-selected providers away from Actions workflow command files and capture their process
   status through a trusted host supervisor, without claiming that an adversarial provider performs
   semantically honest validation.
-- Prevent unattended downstream pull-request checks from silently escaping the same hostile-code
-  boundary.
+- Prevent unattended downstream push and pull-request workflows from silently escaping the same
+  hostile-code boundary.
 - Show how the same workflow can validate multiple Terraform root modules without complicating the
   root-directory example.
 
@@ -51,9 +51,10 @@ lifecycle.
 - Add configurable post-update command hooks in the initial example.
 - Prove that an adversarial provider truthfully implements its own validation protocol. The
   automation can authenticate Terraform's supervised process result, not the provider's intent.
-- Make Git ref updates and GitHub pull-request API mutations one distributed transaction. The
-  workflow instead uses atomic Git ref updates, exact leases, compensating rollback, and explicit
-  recovery rules.
+- Make state-ref observation, automation-ref mutation, and GitHub pull-request API mutations one
+  distributed transaction. Git omits unchanged refs from a push, so the workflow instead uses
+  pre-push and post-push state checks, exact automation-ref leases, compensating rollback, and
+  explicit crash-recovery rules.
 
 ## Example layout
 
@@ -122,6 +123,12 @@ successful candidate. Publication expects exactly one verified result for its cu
 attempt. A missing, duplicate, unexpected, wrong-attempt, or mismatched artefact is an automation
 failure and can never be interpreted as success.
 
+Only **Re-run all jobs** is supported. Every downstream matrix job compares the discovery matrix's
+run attempt with its current `github.run_attempt`; a mismatch identifies a partial failed-job rerun
+and fails with a diagnostic instructing the operator to rerun the complete workflow. A complete
+rerun creates a new, self-contained artefact lineage for the new attempt. Artefacts from prior
+attempts are never consumed by the new attempt.
+
 The verified-result artefact contains a versioned manifest and the already verified patch needed to
 recreate the staged tree. Its name and manifest bind the run ID, run attempt, policy, control OID,
 state ref, base OID, candidate digest, validation-outcome digest, changed paths, modes, and hashes.
@@ -140,6 +147,10 @@ uses two independent checkouts:
 - A control checkout of the immutable caller SHA supplies the reviewed scripts and
   `tf-version-bump` configuration.
 - A target checkout of the immutable discovered state-branch OID receives the proposed changes.
+
+Every `hashicorp/setup-terraform` step sets `terraform_wrapper: false`. The trusted shell
+supervisor invokes the Terraform executable directly and is solely responsible for timeouts, log
+capture, and status classification; no Actions output wrapper sits between it and Terraform.
 
 Terraform can execute target-selected provider plugins during validation. Therefore checkout
 separation is not treated as a process-security boundary. Preparation uploads the immutable source
@@ -169,11 +180,14 @@ accepting lock-file changes from the pre-provider candidate bundle.
 
 Every stage has a bounded inner operation timeout plus a larger job timeout so the workflow can
 capture logs and classifications before GitHub terminates the job. Discovery is limited to 10
-minutes. Preparation and validation commands are limited to 20 minutes per Terraform root and their
-jobs to 30 minutes. Verification is limited to 15 minutes and its job to 20 minutes; publication is
-limited to 10 minutes and its job to 15 minutes. A preparation initialisation timeout is
-`branch-init`; a validation timeout is `branch-validation`; all other job timeouts are automation
-failures.
+minutes. All update and initialisation work for one state branch shares one cumulative 20-minute
+preparation deadline, and all validation work for that branch shares a separate cumulative
+20-minute validation deadline; neither deadline is renewed for each Terraform root. Their jobs are
+limited to 30 minutes, leaving 10 minutes for bundle creation, log upload, and cleanup.
+Verification is limited to 15 minutes and its job to 20 minutes; publication is limited to 10
+minutes and its job to 15 minutes. A preparation timeout is classified according to the command
+that exhausted the budget (`branch-update` or `branch-init`), and a validation timeout is
+`branch-validation`; all job-level timeouts are automation failures.
 
 ## Triggers and schedules
 
@@ -210,14 +224,16 @@ access is trusted because a writer can submit modified workflow YAML even when n
 is exposed. App-mode callers cap the reusable workflow's `GITHUB_TOKEN` at `contents: read`; only
 the short-lived App token receives publication permissions.
 
-Built-in-token mode is the safe default for repositories whose downstream pull-request workflows
-have not been audited; generated checks remain approval-gated. App mode is accepted only when the
-caller explicitly sets `unattended_checks_safe: true`. That assertion means every downstream
-workflow applicable to the state branches uses reviewed workflow definitions, a read-only token,
-no repository or environment secrets, no privileged environment, and equivalent isolation before
+Built-in-token mode is the safe default for repositories whose downstream workflows have not been
+audited; generated pull-request checks remain approval-gated and push workflows are suppressed.
+App mode is accepted only when the caller explicitly sets `unattended_checks_safe: true`. That
+assertion covers every workflow event caused by App publication, including `push` workflows for
+`update_*` refs and `pull_request` or `pull_request_target` workflows for generated pull requests.
+Each applicable workflow must use reviewed default-branch definitions, a read-only token, no
+repository or environment secrets, no privileged environment, and equivalent isolation before
 executing target-controlled code. The reusable workflow cannot enforce another workflow's runtime
 permissions, so it rejects App mode without this explicit policy assertion and the documentation
-requires a repository audit. App mode is not described as safe for generic unattended checks.
+requires a repository audit. App mode is not described as safe for generic unattended workflows.
 
 ## Reusable workflow interface
 
@@ -347,10 +363,11 @@ Each unprivileged preparation job performs the following sequence:
    verify their reported versions. The released CLI must be the same artefact exercised by tests.
 3. Validate directory containment and reject symlinked or non-regular candidate files before any
    write, including any repository `.terraform` path.
-4. For every configured Terraform directory, run `tf-version-bump` from that directory with the
-   control config and the non-recursive pattern `*.tf`.
+4. Start one cumulative 20-minute preparation deadline for the state branch. For every configured
+   Terraform directory, run `tf-version-bump` from that directory with the control config and the
+   non-recursive pattern `*.tf`; each command receives only the deadline's remaining time.
 5. Create a fresh absolute `TF_DATA_DIR` under the trusted runner temporary directory and, for that
-   same directory, run with a 20-minute command timeout:
+   same directory, run within the same remaining preparation deadline:
 
    ```text
    terraform -chdir=<directory> init -upgrade -backend=false -input=false -no-color
@@ -374,23 +391,40 @@ A fresh unprivileged validation job downloads only its exact run-attempt candida
 manifest, paths, modes, hashes, refs, OIDs, policy, and run identity, and applies the patch to a
 fresh exact-base validation checkout. The host creates a trusted data directory and starts the
 pinned Terraform image with `--rm`, no Docker socket, all capabilities dropped,
-`no-new-privileges`, bounded processes/memory/CPU, the runner UID/GID, and only the disposable
-validation checkout and trusted data directory mounted. It passes no host environment variables
-except explicit non-secret Terraform settings. For each directory with provider selections, the
-container runs under a 20-minute host timeout:
+`no-new-privileges`, `--pids-limit=256`, `--memory=4g`, `--memory-swap=4g`, `--cpus=2`, the runner
+UID/GID, and only the disposable validation checkout and trusted data directory mounted. These
+fixed limits are part of the example contract; consumers with smaller self-hosted runners must
+adjust and retest them before installation. The container receives no host environment variables
+except explicit non-secret Terraform settings.
+
+All roots share one cumulative 20-minute validation deadline. For each directory with provider
+selections, the host first runs a networked initialisation container within the remaining deadline:
 
 ```text
 terraform -chdir=<directory> init -backend=false -input=false -no-color -lockfile=readonly
+```
+
+Initialisation requires registry and module downloads and therefore retains outbound network
+access. Target-controlled source addresses can cause requests to services reachable from the
+runner; consumers that require restricted egress must supply an appropriate runner/network policy.
+Provider executables are installed but not invoked during this phase.
+
+The host then starts a separate container with the same mounts and resource limits plus
+`--network=none`, and runs within the remaining branch deadline:
+
+```text
 terraform -chdir=<directory> validate -no-color
 ```
 
 For a manifest-declared provider-free directory it omits `-lockfile=readonly` because no lock file
-exists, then runs the same validation command. Neither the candidate bundle nor the host outcome
-directory is mounted into the container. After the container stops, the trusted host supervisor
-creates the outcome from the observed exit status, then uploads only that candidate-bound outcome
-and captured logs. A timeout is `branch-validation`. The validation job never uploads source or
-lock-file bytes and discards its checkout and data directory. Provider execution therefore cannot
-alter the immutable candidate, host outcome, or Actions control plane later used for publication.
+exists during the networked initialisation phase, then runs validation with `--network=none` in the
+same way. Neither the candidate bundle nor the host outcome directory is mounted into either
+container. After each container stops, the trusted host supervisor records its observed status; it
+creates the final outcome and uploads only that candidate-bound outcome and captured logs. A
+timeout is `branch-validation`. The validation job never uploads source or lock-file bytes and
+discards its checkout and data directory. Provider execution therefore cannot alter the immutable
+candidate, host outcome, or Actions control plane later used for publication, and it cannot make
+outbound connections during validation.
 
 This boundary authenticates that the supervised Terraform process returned zero; it does not prove
 that an adversarial provider truthfully implemented schema or configuration validation. That
@@ -429,11 +463,12 @@ job boundaries:
    ownership, PR marker, issue author identity, and expected automation-ref OID. No signing key is
    materialised.
 3. **Publish in the same protected job.** Materialise the signing key only after prepublication
-   succeeds, create and locally verify the commit, then use one authenticated atomic Git push
-   containing a no-op state-ref refspec guarded by an exact state-ref lease and the automation-ref
-   create/update guarded by its own exact lease. This makes the state/base comparison atomic with
-   the update-ref transaction. Create or refresh the PR, reconcile the marked issue, remove every
-   credential/key helper in unconditional cleanup, and return the result status.
+   succeeds, create and locally verify the commit, recheck the state ref, then push only the
+   automation-ref create/update guarded by its exact expected-old-OID lease. Recheck the state ref
+   immediately after the push and again after PR mutation. Detected movement triggers exact-lease
+   compensation of only the automation ref written by this invocation. Create or refresh the PR,
+   reconcile the marked issue, remove every credential/key helper in unconditional cleanup, and
+   return the result status.
 
 For example, `state/nonproduction/example-thing` maps to
 `update_state/nonproduction/example-thing`. State branches are read-only bases. The `update_`
@@ -453,28 +488,34 @@ for their exact Git commands; the token is absent from remotes and command argum
 disabled, and both files are removed unconditionally. GitHub CLI commands receive `GH_TOKEN` only
 in their own child environment.
 
-The Git ref transaction guarantees that the state ref equalled the validated base at the instant
-the automation ref was created or updated. GitHub PR API calls are not part of that transaction.
-Reconciliation rechecks the state ref after the push and after PR mutation; detected movement causes
-an exact-lease rollback of the automation ref written by the current invocation and closes or
-restores the managed PR as applicable. State movement after the final check is normal concurrent
-repository activity and is corrected by the next queued run; the documentation does not claim
-strict atomicity across Git and GitHub APIs.
+Git omits an equal old/new ref from its push command list, so an unchanged state ref cannot act as a
+compare-and-swap guard on an automation-ref update. Publication consequently provides best-effort
+consistency rather than cross-ref atomicity: it checks the state OID before the push, pushes the
+automation ref with its own exact lease, and rechecks the state after the push and after PR
+mutation. Detected movement causes an exact-lease rollback of the automation ref written by the
+current invocation and closes or restores the managed PR as applicable. State movement after the
+final check is normal concurrent repository activity and is corrected by the next queued run.
 
 Every mutation boundary has compensation. If initial PR creation fails after creating the ref, the
 workflow exact-lease-deletes that ref. If refreshing an existing PR fails after updating its ref, it
 exact-lease-restores the previous ref OID. Ambiguous API responses are reconciled by re-reading exact
 markers before compensation. A compensation lease failure never triggers an unconditional retry;
 it produces an automation error with explicit manual recovery details. Failpoint integration tests
-cover ref create/update, PR create/edit/close, and ref deletion.
+cover ref create/update, PR create/edit/close, ref deletion, state movement between advertisement
+and update, and termination immediately after push. An abrupt runner loss can leave a transient or
+stale marked ref because no later check can execute. A subsequent run repairs an existing managed
+PR/ref pair normally; a newly created marked ref with no corresponding PR remains unowned under the
+two-marker rule and produces bounded manual-recovery instructions rather than being adopted or
+deleted automatically.
 
-When a successful non-dry run produces no changes, the workflow closes the marked automation PR as
-obsolete and deletes only its verified automation branch using an atomic no-op state ref plus an
-expected-old-OID deletion lease. A lease mismatch fails without an unconditional retry. Deletion is
-performed before PR closure so a failed delete leaves the recoverable marked PR/branch pair intact;
-an API failure after deletion is recovered by locating and closing the marked PR on the next run.
-It also closes any open marked validation-failure issue because the branch completed the update and
-validation flow.
+When a successful non-dry run produces no changes, the workflow prechecks the current state, deletes
+only its verified automation branch using an expected-old-OID deletion lease, and then closes the
+marked automation PR as obsolete. It rechecks the state after deletion; detected movement restores
+the deleted OID only when the ref is still absent, using an exact create lease. A lease mismatch
+fails without an unconditional retry. Deletion is performed before PR closure so a failed delete
+leaves the recoverable marked PR/branch pair intact; an API failure or runner loss after deletion is
+recovered by locating and closing the marked PR on the next run. It also closes any open marked
+validation-failure issue because the branch completed the update and validation flow.
 
 ## Dry-run semantics
 
@@ -524,12 +565,12 @@ Every dynamic value uses the shared Markdown encoder: escape `&`, `<`, and `>`, 
 a zero-width separator, and render scalar values in `<code>` and log tails in bounded `<pre>`
 blocks. Machine markers contain only fixed syntax plus validated policy IDs and hexadecimal hashes.
 
-The workflow recreates the automation commit from the latest state-branch tip instead of
-accumulating obsolete generated commits or rebasing them indefinitely. One atomic push guards the
-unchanged state ref and stable automation ref with their exact expected OIDs after ownership markers
-pass. A lease mismatch or detected state-base movement fails as an automation error and does not
-retry with an unconditional force. Branch deletion uses the same atomic state guard and
-expected-old-OID protection. GitHub API failures use the compensation rules above.
+The workflow recreates the automation commit from the latest observed state-branch tip instead of
+accumulating obsolete generated commits or rebasing them indefinitely. After ownership markers
+pass, the automation ref is pushed with its exact expected OID and the state ref is checked before
+and after the push. A lease mismatch or detected state-base movement fails as an automation error
+and does not retry with an unconditional force. Branch deletion uses the same state pre/post checks
+and expected-old-OID protection. GitHub API failures use the compensation rules above.
 
 ## Failure classification and issues
 
@@ -702,8 +743,11 @@ A maintained shell test creates temporary real Git repositories and bare remotes
 - Stable automation-branch regeneration, ownership-marker validation, unowned-ref refusal, and
   explicit leases for updates and deletion races. A branch marked for a different policy is
   foreign and fails safely even though the required ref name remains `update_<state-branch>`.
-- Atomic publication tests move the state ref at the push boundary and prove that a no-op state-ref
-  update with an exact lease prevents stale update-ref publication.
+- Publication-race tests move the state ref after advertisement but before the automation-ref
+  update, prove that the update may be accepted, and then prove that the post-push check performs
+  exact-lease compensation without touching an unseen writer's ref.
+- A termination-after-push failpoint proves the documented residual stale-ref state and the next
+  run's automatic or bounded manual-recovery path, depending on whether a managed PR already exists.
 - Failpoint tests after ref creation or update, PR creation or edit, PR close, and ref deletion
   prove the documented exact-lease compensation and retry behaviour.
 - Malformed shared-config failure before matrix creation.
@@ -714,16 +758,24 @@ A maintained shell test creates temporary real Git repositories and bare remotes
 - A hostile purpose-built Terraform provider fixture runs in the same constrained container
   boundary as production. It attempts delayed writes after parent exit, credential discovery,
   candidate and lock-file replacement, workflow-command poisoning, outcome forgery, and container
-  escape. Host-side tests verify that it cannot alter the immutable candidate or trusted outcome
-  and that the host records the observed process status. These tests do not claim that a malicious
-  provider must report truthful semantic validation diagnostics. The repository test harness builds
-  the reviewed Linux fixture, places it in a trusted read-only filesystem mirror, and supplies a
-  host-created Terraform CLI configuration only in test mode; neither the mirror nor this test-only
-  configuration is selectable from state-branch content or reusable-workflow inputs.
+  escape, outbound access, and host-service access. Host-side tests verify the exact CPU, memory,
+  swap, and PID limits, prove that validation runs with `--network=none`, verify that the provider
+  cannot alter the immutable candidate or trusted outcome, and confirm that the host records the
+  observed process status. These tests do not claim that a malicious provider must report truthful
+  semantic validation diagnostics. The repository test harness builds the reviewed Linux fixture,
+  places it in a trusted read-only filesystem mirror, and supplies a host-created Terraform CLI
+  configuration only in test mode; neither the mirror nor this test-only configuration is
+  selectable from state-branch content or reusable-workflow inputs.
+- Networked initialisation and offline validation run as separate constrained container commands
+  against the same disposable data directory; only the initialisation command can reach configured
+  registries and module sources.
 - A hanging provider is terminated at the configured timeout and produces the validation-timeout
   classification without unbounded runner use.
 - Artefact names and manifests bind run ID, run attempt, policy ID, control OID, state ref, and base
-  OID. Full-run and failed-job re-run cases cannot consume another attempt's artefacts.
+  OID. A complete rerun creates and consumes only its own attempt's lineage; a failed-job rerun is
+  rejected because its reused discovery output identifies a prior attempt.
+- Two roots sharing an injectable shortened cumulative deadline prove that the second root receives
+  only the remaining budget and that cleanup/artefact upload completes before the job deadline.
 - The command-scoped Git authentication helper works against a real authenticated bare HTTP test
   service without storing a token in a remote URL or process argument and removes its temporary
   files after each command.
@@ -779,14 +831,14 @@ The example README defines an acceptance procedure using a disposable GitHub rep
   secrets.
 - The actual GitHub-hosted validation runner executes the hostile fixture in the digest-pinned
   container through the repository harness's reviewed read-only filesystem mirror and records its
-  mount, environment, permission, delayed-write, and timeout results. This is a CI boundary test,
-  not a state-branch-selectable production input. The fixture has no write/App/signing credentials,
-  workflow-command files, control checkout, immutable candidate, trusted outcome path, or container
-  socket available to it.
+  mount, environment, permission, resource, offline-network, delayed-write, and timeout results.
+  This is a CI boundary test, not a state-branch-selectable production input. The fixture has no
+  write/App/signing credentials, workflow-command files, control checkout, immutable candidate,
+  trusted outcome path, container socket, or outbound network available to it during validation.
 - App mode is rejected unless `unattended_checks_safe: true`. The accepted App case uses reviewed
-  default-branch workflows with a read-only token, no secrets or privileged environments, and an
-  isolated target-code step. A hostile downstream test cannot mutate repository content or read a
-  secret sentinel.
+  default-branch push, `pull_request`, and `pull_request_target` workflows with a read-only token, no
+  secrets or privileged environments, and an isolated target-code step. Hostile downstream push
+  and pull-request tests cannot mutate repository content or read a secret sentinel.
 - Private-repository discovery, fetch, update, and deletion using command-scoped authentication.
 - Successful update, repeated idempotent update, validation failure, issue update, recovery, and
   obsolete-PR cleanup.
@@ -798,8 +850,11 @@ The example README defines an acceptance procedure using a disposable GitHub rep
   logs and artefacts remain available.
 - An unowned update-ref collision and concurrent update/deletion races that preserve the remote
   ref.
-- A state-base movement that prevents stale publication.
-- Full-workflow and failed-job re-runs whose artefacts remain isolated by run attempt.
+- A state-base movement between advertisement and automation-ref update whose accepted update is
+  exact-lease-compensated by the post-push check, plus termination immediately after push and the
+  documented next-run/manual recovery result.
+- A complete workflow rerun whose artefacts remain isolated by run attempt, followed by a failed-job
+  rerun that is rejected with instructions to use **Re-run all jobs**.
 - A policy collision that refuses to adopt or overwrite the foreign marked ref and PR.
 - A built-in-token run with repository PR creation temporarily disabled, demonstrating that a real
   post-push PR-creation rejection triggers exact-lease rollback without deleting an unseen remote
@@ -829,12 +884,14 @@ The acceptance transcript is reviewed before completion is claimed.
 - Unsigned and signed commit setup.
 - Stable branch, PR, issue, and cleanup lifecycles.
 - Reserved namespace, ownership markers, immutable control/base OIDs, and lease failure recovery.
-- Run-ID and run-attempt artefact provenance, command-scoped private-repository Git authentication,
-  publication compensation, and the remaining non-transactional GitHub-API race.
+- Run-ID and run-attempt artefact provenance, the **Re-run all jobs** requirement,
+  command-scoped private-repository Git authentication, best-effort state-ref consistency,
+  publication compensation, crash recovery, and the remaining Git/GitHub races.
 - Single-root and multi-root configurations.
 - Direct-file-per-module processing and the requirement to list every nested module explicitly.
 - Backend-disabled Terraform initialisation.
-- Digest-pinned constrained Terraform execution, trusted `TF_DATA_DIR`, command and job timeouts,
+- Digest-pinned constrained Terraform execution, trusted `TF_DATA_DIR`, cumulative branch and job
+  timeouts, fixed container resource limits, networked-init residual risk, offline validation,
   host-observed process status, and the limit that a malicious provider can lie about semantic
   validation results even though it cannot alter the publishable candidate or obtain credentials.
 - Branch-scoped update, init, and validation issues, including possible transient causes in init
@@ -845,7 +902,8 @@ The acceptance transcript is reviewed before completion is claimed.
   Server consumers to confirm support before installation.
 - The 256-branch matrix ceiling and the controlled failure when an allow-list exceeds it.
 - Built-in-token event suppression and approval-required PR checks, including when App mode is
-  required for unattended checks.
+  required and the push, `pull_request`, and `pull_request_target` workflows its publication can
+  trigger must be audited.
 - Manual identification and cleanup of strongly marked orphaned automation refs and issues when a
   state branch is deleted, renamed, or removed from the allow-list. Automatic orphan garbage
   collection is intentionally deferred until operational need justifies a separate destructive
@@ -873,10 +931,13 @@ The feature is complete when:
   boundaries.
 - Normal runs safely reconcile signed or unsigned commits, stable automation branches, PRs, and
   failure issues.
-- Every run pins one control OID and one validated base OID per state branch; ref movement blocks
-  publication.
+- Every run pins one control OID and one validated base OID per state branch; detected ref movement
+  triggers exact-lease compensation, while abrupt termination and movement after the final check
+  follow the documented recovery rules rather than an impossible cross-ref atomicity guarantee.
 - Existing update refs require verifiable ownership, and every rewrite or deletion uses an exact
   expected remote OID.
+- Complete reruns create a new attempt-bound artefact lineage, and partial failed-job reruns fail
+  safely with instructions to use **Re-run all jobs**.
 - The independently downloaded `v1.0.0-rc.7` CLI reports aggregate per-file failure with a non-zero
   status, and the workflow downloads and verifies the recorded SHA-256 of that exact released
   archive before use.
@@ -885,6 +946,10 @@ The feature is complete when:
   clear failure), provider-free directories may omit the file, disposable `.terraform/` data is
   excluded, and symlinked, escaping, non-regular, or otherwise unexpected paths are rejected before
   writing.
+- Preparation and validation each use one cumulative 20-minute branch deadline inside a 30-minute
+  job, so multiple sequential roots cannot individually consume the entire cleanup reserve.
+- Terraform's Actions wrapper is disabled; validation runs with the documented fixed resource
+  limits and no network after a separate networked initialisation phase.
 - GitHub.com caller and publication concurrency use the supported `queue: max` behaviour so pending
   runs are preserved. The pinned actionlint launcher suppresses only its exact stale-parser
   diagnostic for that property.

--- a/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
+++ b/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
@@ -22,10 +22,12 @@ lifecycle.
 - Apply updates, run `terraform init -upgrade -backend=false`, and run `terraform validate` before
   publishing a branch.
 - Persist `.terraform.lock.hcl` changes alongside Terraform source changes.
+- Return a non-zero CLI status after any per-file processing error so automation cannot publish a
+  partial update as successful.
 - Maintain stable update branches, pull requests, and validation-failure issues without creating
   duplicates on scheduled runs.
-- Support a side-effect-free dry run that still applies and validates the proposed changes in the
-  disposable runner checkout.
+- Support a dry run that still applies and validates proposed changes in a disposable checkout
+  while suppressing repository refs and GitHub content mutations.
 - Support the built-in `GITHUB_TOKEN`, optional GitHub App authentication, and optional SSH commit
   signing.
 - Show how the same workflow can validate multiple Terraform root modules without complicating the
@@ -33,7 +35,7 @@ lifecycle.
 
 ## Non-goals
 
-- Change the `tf-version-bump` CLI or its YAML configuration format.
+- Change the `tf-version-bump` YAML configuration format.
 - Turn `examples/update-branches.sh` into a GitHub API orchestration tool.
 - Initialise or access Terraform state backends.
 - Merge or approve generated pull requests.
@@ -66,7 +68,8 @@ copy the example's `.github` directory rather than invoke a workflow from its ex
 
 The shell scripts keep non-trivial orchestration out of YAML blocks. They have help output,
 validate their inputs, fail with stage-specific messages, and limit routine output while retaining
-failure logs for diagnosis.
+failure logs for diagnosis. They expose separate validation and reconciliation operations so the
+privileged job never executes target-branch Terraform.
 
 ## Workflow architecture
 
@@ -74,25 +77,45 @@ The production and non-production callers own policy. Each caller defines its al
 configuration path, pinned tool versions, schedule, and concurrency group, then invokes the local
 reusable workflow.
 
-The reusable workflow contains two jobs:
+The reusable workflow contains three job stages:
 
-1. `discover` validates the configuration and produces a sorted JSON matrix of matching remote
-   state branches.
-2. `update` runs once per matrix entry with `fail-fast: false`, so every discovered state branch is
-   processed even if another branch fails.
+1. `discover` checks out the exact caller commit, validates the shared configuration, and produces
+   a sorted JSON matrix containing each matching state branch and its immutable tip OID.
+2. `validate` runs once per matrix entry with `fail-fast: false`. It applies the update and runs
+   Terraform on an unprivileged fresh runner, then uploads a data-only result bundle.
+3. `reconcile` runs once per matrix entry on another fresh runner after the complete validation
+   matrix. It treats the result bundle as untrusted data, revalidates it, and either publishes the
+   proposal, reports a deterministic branch failure, or records a workflow-level failure.
+
+Validation captures command status, builds and uploads its result bundle in unconditional cleanup
+steps, and then returns the recorded failure status. Reconciliation uses an `always()` condition so
+one failed matrix entry does not suppress reporting for the others. A missing or duplicate expected
+bundle is an automation failure and can never be interpreted as success.
 
 The update matrix defaults to four concurrent branches. This bounds Terraform downloads and GitHub
 API writes while retaining useful parallelism. A caller can lower or raise the limit through the
 reusable workflow's `max_parallel` input.
 
-Each update job uses two independent checkouts:
+The validation jobs have `contents: read`, use `persist-credentials: false` for every checkout, and
+never receive a write token, GitHub App private key, or commit-signing key. Each validation job uses
+two independent checkouts:
 
-- A control checkout of `github.event.repository.default_branch` supplies the reviewed workflow,
-  scripts, and `tf-version-bump` configuration.
-- A target checkout of the selected remote state branch receives the proposed changes.
+- A control checkout of the immutable caller SHA supplies the reviewed scripts and
+  `tf-version-bump` configuration.
+- A target checkout of the immutable discovered state-branch OID receives the proposed changes.
 
-The separation ensures that a state branch cannot replace the automation or configuration that is
-processing it.
+Terraform can execute target-selected provider plugins during validation. Therefore checkout
+separation is not treated as a process-security boundary. The fresh reconciliation job is the
+boundary: it does not execute Terraform or any target-supplied executable, and it materialises
+write credentials and signing material only after validating the result bundle.
+
+The result bundle contains a versioned JSON manifest, captured logs, and a binary Git patch. The
+manifest records the control OID, state branch, validated base OID, result classification,
+configured Terraform directories, changed paths, file modes, and SHA-256 hashes. Reconciliation
+rejects unknown manifest versions, mismatched refs or OIDs, absolute or escaping paths, symlink or
+non-regular modes, unexpected file types, hash mismatches, and patch paths outside the declared
+set. It applies the patch only after a fresh exact-base checkout and independently reproduces the
+`tf-version-bump` source changes before accepting lock-file changes from the validated bundle.
 
 ## Triggers and schedules
 
@@ -111,9 +134,17 @@ timezone support:
 - Non-production: daily at 04:17 in `Australia/Melbourne`.
 - Production: Sunday at 04:43 in `Australia/Melbourne`.
 
-Each caller has its own concurrency group with cancellation disabled. A new run queues behind an
-active run for the same environment rather than interrupting branch, PR, or issue reconciliation.
-Production and non-production can run independently.
+Each caller has its own concurrency group with `queue: max` and no in-progress cancellation. Up to
+GitHub's concurrency-group queue limit waits behind the active run instead of replacing the
+existing pending run. Production and non-production can run independently.
+
+Manual runs are accepted only when `github.ref` is the repository's default branch. This catches
+accidental alternate-ref dispatches. The reconciliation job also uses a required protected GitHub
+environment restricted to the default branch. App and signing private keys live only in that
+environment; they are not passed through `workflow_call`. Repository administrators must limit
+manual dispatch to trusted actors. Built-in-token mode additionally assumes repository write
+access is trusted because a writer can submit modified workflow YAML even when no optional secret
+is exposed.
 
 ## Reusable workflow interface
 
@@ -122,24 +153,26 @@ Production and non-production can run independently.
 | `allowed_branch_prefixes` | string | Required | Newline-separated literal prefix allow-list |
 | `branch_prefix` | string | `""` | Optional manual narrowing prefix |
 | `config_path` | string | Required | Config path in the default-branch control checkout |
-| `file_pattern` | string | `**/*.tf` | Terraform files passed to `tf-version-bump` |
-| `terraform_directories` | string | `.` | Newline-separated root-module directories |
+| `terraform_directories` | string | `.` | Newline-separated module directories processed independently |
 | `terraform_version` | string | Required | Exact Terraform version installed for the run |
 | `tf_version_bump_version` | string | Required | Exact `tf-version-bump` release tag used by `go install` |
 | `go_version` | string | Required | Exact Go version used by `go install` |
-| `dry_run` | boolean | `false` | Suppress every remote mutation |
+| `dry_run` | boolean | `false` | Suppress repository refs and GitHub content mutations |
 | `max_parallel` | number | `4` | Maximum concurrent state-branch jobs |
-| `commit_author_name` | string | Bot identity | Commit author and committer name |
-| `commit_author_email` | string | Bot identity | Commit author and committer email |
+| `commit_author_name` | string | `""` | Explicit signed-commit identity; derive bot name when unsigned |
+| `commit_author_email` | string | `""` | Explicit signed-commit identity; derive bot email when unsigned |
 | `github_app_client_id` | string | `""` | Enable GitHub App authentication when paired with its key |
+| `publication_environment` | string | Required | Default-branch-restricted environment for reconciliation |
 
-Optional reusable-workflow secrets are:
+Optional protected-environment secrets with fixed names are:
 
-- `github_app_private_key`
-- `commit_signing_private_key`
+- `TF_VERSION_BUMP_GITHUB_APP_PRIVATE_KEY`
+- `TF_VERSION_BUMP_COMMIT_SIGNING_PRIVATE_KEY`
 
-The workflow rejects partial authentication or signing configurations. When signing is enabled,
-the caller must explicitly supply both commit identity inputs rather than inherit a bot default.
+The workflow rejects partial authentication or signing configurations. A GitHub App client ID
+requires the App private key in the protected environment. When the signing key is present, the
+caller must explicitly supply both commit identity inputs rather than inherit a bot default.
+Environment secrets cannot be passed or selected by an untrusted caller.
 
 Production and non-production callers demonstrate separate config paths, prefix lists, schedules,
 concurrency groups, and tool versions. Their illustrative allow-lists are:
@@ -157,7 +190,13 @@ aws-state/production/
 
 ## Branch discovery and validation
 
-Discovery lists remote heads from `origin`; it does not depend on whatever subset
+Discovery verifies that the caller ref is the default branch and records `github.sha` as the
+immutable control OID. It checks out that exact commit with persisted credentials disabled,
+installs the pinned CLI, and validates the shared configuration once against a trusted temporary
+Terraform fixture before creating any branch matrix. A malformed config is therefore one workflow
+failure rather than one issue per branch.
+
+Discovery lists remote heads and OIDs from `origin`; it does not depend on whatever subset
 `actions/checkout` fetched. A state branch matches when its complete name begins with one of the
 configured literal prefixes. The remainder of the branch name is unrestricted except by Git's
 normal ref-name rules.
@@ -169,67 +208,117 @@ The discovery script:
 2. If `branch_prefix` is supplied, verifies that it begins with at least one allowed prefix.
 3. Selects remote branches using the allow-list plus optional narrowing prefix.
 4. Deduplicates branches selected by overlapping prefixes.
-5. Sorts names bytewise for deterministic output.
+5. Records each branch's exact remote tip OID and sorts names bytewise for deterministic output.
 6. Fails when no branches match so a configuration mistake cannot look successful.
-7. Encodes the final list as JSON for the matrix without evaluating branch names as shell code.
+7. Encodes the control OID and final branch/OID pairs as JSON for the matrix without evaluating
+   branch names as shell code.
 
 The manual prefix can narrow `state/nonproduction/` to `state/nonproduction/example-`, but a
 non-production caller rejects `state/production/`.
 
-All repository-relative paths are resolved beneath their checkout roots. The workflow rejects
-absolute paths, `..` traversal, missing config files, missing Terraform directories, and
-directories that resolve outside the target checkout.
+Every value originating in a workflow context, input, branch name, manifest, or target checkout is
+untrusted data. Shell steps receive those values through `env:` only; direct `${{ ... }}`
+interpolation into `run:` source is forbidden. Scripts double-quote expansions, use `--` and full
+refspecs for operands, consume NUL-delimited Git output, create JSON with `jq --arg`, and create PR
+and issue bodies through files. Branch names are never evaluated as code.
 
-## Per-branch update flow
+All repository-relative paths are canonicalised beneath their checkout roots. The workflow rejects
+absolute paths, `..` traversal, missing config files, missing Terraform directories, duplicate
+canonical directories, and directories that resolve outside the target checkout. Nested module
+directories are allowed, but each directory processes only the `.tf` files directly within it.
 
-Each matrix job performs the following sequence:
+Before either validation or reconciliation invokes `tf-version-bump`, the script enumerates that
+directory's matching files, uses `lstat` to reject symlinks and non-regular files, and verifies each
+canonical path remains under the target checkout. Required lock files receive the same checks.
+Containment is repeated for every changed and untracked path before a result bundle or commit is
+created.
 
-1. Create the control and target checkouts.
+## Per-branch validation flow
+
+Each unprivileged validation job performs the following sequence:
+
+1. Check out the control OID and discovered state-branch OID with persisted credentials disabled.
 2. Install the exact Go, `tf-version-bump`, and Terraform versions supplied by the caller.
-3. Apply `tf-version-bump` once across the target checkout with the config from the control
-   checkout and the configured file pattern.
-4. For every configured Terraform directory, run sequentially:
+3. Validate directory containment and reject symlinked or non-regular candidate files before any
+   write.
+4. For every configured Terraform directory, run `tf-version-bump` from that directory with the
+   control config and the non-recursive pattern `*.tf`.
+5. For that same directory, run sequentially:
 
    ```text
    terraform -chdir=<directory> init -upgrade -backend=false -input=false -no-color
    terraform -chdir=<directory> validate -no-color
    ```
 
-5. Require a `.terraform.lock.hcl` file in every configured Terraform directory after
-   initialisation, including a newly created untracked lock file.
-6. Remove or ignore disposable `.terraform/` working data, then confirm that only Terraform source
-   files and `.terraform.lock.hcl` files changed. Any other unexpected path fails the safety check.
-7. If the run is a dry run, report the proposed file changes and stop without remote side effects.
-8. If no allowed files changed, reconcile obsolete automation state and stop without an empty
-   commit.
-9. Stage only allowed changed files.
-10. Create a commit from the latest state-branch tip on `update_<state-branch>`.
-11. Fetch any existing automation branch and update it using an explicit force-with-lease that
-    protects against an unseen concurrent writer.
-12. Create or update the single pull request from the automation branch to the state branch.
-13. Close any open validation-failure issue for the state branch.
+6. Require a regular `.terraform.lock.hcl` file in every configured directory after
+   initialisation, including a newly created untracked lock file. If a new required lock file is
+   ignored, fail with a repository-configuration error; never force-add it.
+7. Remove disposable `.terraform/` working data, then consume NUL-delimited Git status output and
+   confirm that every changed `.tf` file is directly inside exactly one configured directory and
+   every other change is that directory's lock file. Any other path fails the safety check.
+8. Produce the versioned manifest and patch, verify their hashes locally, upload the result bundle
+   with a collision-resistant branch hash in its artefact name, and remove the checkouts.
+
+`tf-version-bump` continues processing later files after a per-file parse, stat, read, or write
+error, but accumulates those errors and exits non-zero after processing completes. Its output ends
+with a deterministic aggregate failure count. This intentionally changes the prior unsafe exit
+status contract; automation never parses human prose to infer success.
+
+Each configured directory is a Terraform module validation unit. Running the bump with `*.tf`
+ensures every changed source file is loaded by the immediately following init/validate commands.
+Consumers list nested modules explicitly. Duplicate directories are rejected, so a changed source
+belongs to exactly one unit.
+
+## Privileged reconciliation flow
+
+A non-dry run starts a fresh reconciliation matrix after all validation jobs have uploaded their
+bundles. For each branch, reconciliation:
+
+1. Downloads only that run's expected artefact and validates its manifest, paths, modes, hashes,
+   control OID, branch name, and validated base OID before using any payload.
+2. For a successful result, checks out the exact control and base OIDs with persisted credentials
+   disabled, repeats path/symlink preflight, independently reruns `tf-version-bump` for each
+   configured directory, and requires its `.tf` diff to match the manifest.
+3. Applies only the validated lock-file portion from the bundle, verifies the complete resulting
+   diff and hashes, and stages only declared regular `.tf` and lock files.
+4. Fetches the state ref immediately before publication and requires its remote OID still to equal
+   the validated base OID. Movement fails without publication; a later run processes the new tip.
+5. Verifies ownership of any existing automation ref and PR, then creates the signed or unsigned
+   commit, updates the ref with an explicit expected-OID lease, and creates or refreshes the PR.
+6. Reconciles the branch's marked failure issue and returns the result status so the overall
+   workflow fails whenever validation or reconciliation failed.
 
 For example, `state/nonproduction/example-thing` maps to
-`update_state/nonproduction/example-thing`. Only branches beginning with `update_` are regenerated
-or deleted by this workflow. State branches are read-only bases.
+`update_state/nonproduction/example-thing`. State branches are read-only bases. The `update_`
+namespace is reserved for this automation, but naming alone never grants ownership.
 
-When a successful non-dry run produces no changes, the workflow closes an existing automation PR
-as obsolete and deletes only the corresponding `update_<state-branch>` branch. It also closes any
-open validation-failure issue because the branch completed the update and validation flow.
+An automation commit carries exact machine-readable trailers identifying the workflow, state
+branch, validated base OID, and control OID. A managed PR carries a corresponding hidden marker.
+Before rewriting or deleting an existing automation ref, reconciliation requires both its tip
+commit marker and the corresponding marked PR to agree. An unmarked or mismatched existing ref is
+an automation failure and is never adopted.
+
+When a successful non-dry run produces no changes, the workflow closes the marked automation PR as
+obsolete and deletes only its verified automation branch using an expected-old-OID lease. A lease
+mismatch fails without an unconditional retry. It also closes any open marked validation-failure
+issue because the branch completed the update and validation flow.
 
 ## Dry-run semantics
 
-Dry-run mode is a remote side-effect boundary, not a read-only filesystem mode. The workflow still:
+Dry-run mode is a repository/API side-effect boundary, not a read-only filesystem mode. The
+workflow still:
 
 - Runs `tf-version-bump` without the CLI's `-dry-run` flag.
 - Runs real Terraform initialisation and validation.
 - Creates or updates the required lock files in the disposable checkout.
 - Performs the allowed-path safety check.
-- Reports the proposed changes and failures in workflow output.
+- Uploads diagnostic result bundles and reports proposed changes and failures in workflow output.
 
-It never commits, pushes, creates or edits a pull request, creates or edits an issue, closes an
-issue or pull request, or deletes an automation branch. This validates the proposed result rather
-than the branch's old contents.
+It never enters the protected reconciliation environment and never commits, pushes, changes GitHub
+repository content, creates or edits a pull request, creates or edits an issue, closes an issue or
+pull request, or deletes an automation branch. GitHub's unavoidable workflow run, logs, summaries,
+and explicitly uploaded diagnostic artefacts are permitted. This validates the proposed result
+rather than the branch's old contents.
 
 ## Commit and pull-request lifecycle
 
@@ -243,6 +332,7 @@ The pull request identifies the state branch and is looked up by exact base and 
 than title alone. Its body is refreshed on every run with:
 
 - State-branch base revision.
+- Immutable control revision.
 - Config path.
 - Go, `tf-version-bump`, and Terraform versions.
 - Changed files.
@@ -252,20 +342,28 @@ than title alone. Its body is refreshed on every run with:
 
 The workflow recreates the automation commit from the latest state-branch tip instead of
 accumulating obsolete generated commits or rebasing them indefinitely. The force-with-lease applies
-only to the stable automation ref. A lease mismatch fails as an automation error and does not retry
-with an unconditional force.
+only to the stable automation ref after its ownership markers pass. A lease mismatch or state-base
+movement fails as an automation error and does not retry with an unconditional force. Branch
+deletion uses the same expected-old-OID protection.
 
 ## Failure classification and issues
 
-Failures from these stages are state-branch failures:
+Failures from these stages are deterministic state-branch failures:
 
 - `tf-version-bump`
-- `terraform init -upgrade -backend=false`
 - `terraform validate`
 
-A non-dry run creates or updates one open issue per failing state branch. The issue is identified
-by an exact stable title and a machine-readable marker, not a fuzzy title search. Its body is
-replaced with the latest:
+The control config is validated before matrix creation, so a shared config failure stops discovery
+without branch issues. All `terraform init` failures are workflow-level failures because its exit
+status does not reliably distinguish branch configuration defects from registry outages,
+authentication failures, rate limits, or other transient dependencies. Init failures retain logs
+and fail the workflow but do not create branch issues. Missing/ignored locks, unsafe paths,
+manifest failures, ref movement, and ownership or lease failures are likewise automation or
+repository-policy failures rather than update/validation issues.
+
+A non-dry run creates or updates one open issue per deterministic failing state branch. The issue
+is identified by an exact stable title and a machine-readable marker, not a fuzzy title search. Its
+body is replaced with the latest:
 
 - State branch and base revision.
 - Failing stage and Terraform directory, when applicable.
@@ -273,40 +371,52 @@ replaced with the latest:
 - Concise tail of captured standard output and standard error.
 - Workflow-run and uploaded-log links.
 
-Full captured logs are uploaded as a workflow artefact with a branch-safe name. The issue body is
-bounded so recurring scheduled failures do not grow without limit. A successful later non-dry run
-closes the issue with a recovery comment.
+Full captured logs are uploaded as a workflow artefact with a collision-resistant name derived
+from a hash of the complete branch ref. The issue body is bounded so recurring scheduled failures
+do not grow without limit. A successful later non-dry run closes the issue with a recovery comment.
+
+When a newer control or base revision produces a deterministic update/validation failure,
+reconciliation closes the previous marked PR as obsolete, deletes its verified automation branch
+with an expected-OID lease, and then creates or updates the failure issue. A stale previously
+successful PR is never left open and apparently mergeable after a newer deterministic failure.
+Workflow-level init or transient failures leave the prior PR unchanged because they do not establish
+that its validated proposal is defective.
 
 Authentication, GitHub API, invalid input, unsafe diff, signing, commit, push, lease, PR, issue
 reconciliation, and workflow configuration failures are automation failures. They fail the matrix
-job without creating a misleading state-validation issue. `fail-fast: false` ensures other state
-branches continue.
+job without creating a misleading state-validation issue. The manifest carries an explicit result
+class with precedence `automation`, `shared/init`, `branch-update`, `branch-validation`, then
+`success`; reconciliation rejects unknown or contradictory classes. `fail-fast: false` ensures
+other state branches continue.
 
 ## Authentication and permissions
 
-The caller job grants only:
+The caller grants the reusable workflow the write scopes needed by reconciliation as an upper
+bound. The reusable workflow then declares narrower permissions per job:
 
-- `contents: write`
-- `pull-requests: write`
-- `issues: write`
+- Discovery and validation: `contents: read` only.
+- Reconciliation: `contents: write`, `pull-requests: write`, and `issues: write`.
 
-The default path uses the job's `GITHUB_TOKEN`. Consumers must enable the repository setting that
-permits GitHub Actions to create pull requests. Pull-request workflows generated with this token
-may require manual approval under GitHub's current recursion protection.
+Every checkout sets `persist-credentials: false`. The default publication path injects the
+reconciliation job's `GITHUB_TOKEN` only into the exact Git/GitHub CLI steps that need it.
+Consumers must enable the repository setting that permits GitHub Actions to create pull requests.
+Pull-request workflows generated with this token may require manual approval under GitHub's current
+recursion protection.
 
-When both GitHub App inputs are supplied, the workflow uses the GitHub-maintained App-token action
-to mint a short-lived installation token limited to the current repository and the same three
-explicit permissions. It obtains the App bot's user ID through the GitHub API and constructs the
-correct bot name and noreply address for commit attribution. App-authenticated PR activity allows
-future PR checks to run without the built-in token's approval gate.
+When the App client ID and protected-environment private key are supplied, reconciliation uses the
+GitHub-maintained App-token action to mint a short-lived installation token limited to the current
+repository and the same three explicit permissions. It obtains the App bot's user ID through the
+GitHub API and constructs the correct bot name and noreply address for commit attribution.
+App-authenticated PR activity allows future PR checks to run without the built-in token's approval
+gate. The App key never exists in discovery or validation.
 
 Every referenced action is pinned to an immutable commit SHA with a version comment, matching the
 repository's existing workflow convention.
 
 ## Optional SSH commit signing
 
-When `commit_signing_private_key` is absent, the workflow creates the correctly attributed unsigned
-bot or App commit.
+When `TF_VERSION_BUMP_COMMIT_SIGNING_PRIVATE_KEY` is absent from the protected publication
+environment, the workflow creates the correctly attributed unsigned bot or App commit.
 
 When it is present, the workflow:
 
@@ -320,10 +430,11 @@ When it is present, the workflow:
 5. Creates the commit with an explicit signature and verifies it locally before pushing.
 6. Removes the private key and allowed-signers file in an unconditional cleanup step.
 
-Signing and verification failure stops the job. There is no unsigned fallback. The documentation
-states that the signing key must work non-interactively and that its public key must be registered
-as a signing key on the GitHub account associated with the author email for GitHub to show the
-commit as verified.
+Signing and verification failure stops reconciliation. There is no unsigned fallback. The key is
+materialised only after the manifest, ownership, base OID, source diff, and lock-file payload pass
+validation. The documentation states that the signing key must work non-interactively and that its
+public key must be registered as a signing key on the GitHub account associated with the author
+email for GitHub to show the commit as verified.
 
 ## Multiple Terraform root modules
 
@@ -335,9 +446,10 @@ environments/network
 environments/platform
 ```
 
-`tf-version-bump` still runs once for the configured repository file pattern. Terraform
-initialisation and validation then run sequentially in each root module. All roots must pass before
-the workflow publishes any commit. A failure issue names the affected root.
+`tf-version-bump` runs separately in each configured directory with the direct-file pattern
+`*.tf`. Terraform initialisation and validation immediately follow in that same directory. All
+modules must pass before the workflow publishes any commit. A deterministic failure issue names
+the affected module.
 
 The initial example does not run root modules in parallel within a state-branch job. Branch-level
 matrix parallelism already provides concurrency, while sequential roots keep output and failure
@@ -355,17 +467,39 @@ A maintained shell test creates temporary real Git repositories and bare remotes
 - Rejection of manual widening.
 - Overlapping-prefix deduplication and deterministic ordering.
 - Branch names containing slashes.
+- Valid hostile ref names containing shell metacharacters, quotes, leading dashes, Unicode, and
+  percent signs without evaluating them as commands.
 - No-match and invalid-path failures.
+- Rejection of manual dispatch from a non-default ref.
+- One immutable control OID across a default-branch movement.
+- Exact discovered base OIDs and rejection when a state ref advances before publication.
 - Successful update, initialisation, and validation with the real `tf-version-bump` binary and a
   pinned real Terraform CLI.
+- Aggregate non-zero CLI status after a real per-file failure while later files still run.
+- One-to-one mapping of directly changed source files to configured Terraform directories,
+  including rejection of omitted, duplicate, and ambiguous roots.
 - Terraform source and lock-file staging.
 - Multi-directory success and failure attribution.
+- Missing, duplicate, path-traversing, symlink-mode, hash-mismatched, and ref-mismatched result
+  bundles are rejected by fresh reconciliation.
 - Dry-run isolation.
 - Rejection of unexpected changed files.
-- Stable automation-branch regeneration and explicit lease protection.
+- Pre-write rejection of Terraform/lock symlinks into the control checkout and outside both
+  checkouts.
+- Stable automation-branch regeneration, ownership-marker validation, unowned-ref refusal, and
+  explicit leases for updates and deletion races.
+- Malformed shared-config failure before matrix creation.
+- Workflow-level classification of a real deterministic init/download failure without branch
+  issues.
+- Success followed by a new deterministic failure closes the stale marked PR and safely removes
+  its owned update branch.
 - Signed commits, local signature verification, cleanup of key material, and signing failure.
+- A hostile purpose-built Terraform provider that attempts to find credentials, alter control
+  files, and poison later-step state, proving validation cannot influence the fresh reconciliation
+  runner or protected secrets.
 - Unsigned operation when no signing key is configured.
 - Obsolete no-change branch and PR payload generation.
+- Clear failure when a newly required lock file is ignored; the workflow never force-adds it.
 
 The tests do not mock `gh` or assert against invented GitHub API behaviour. Deterministic PR and
 issue payload construction is tested locally. Actual PR, issue, token, and permissions behaviour is
@@ -373,10 +507,11 @@ covered by the real-service acceptance run.
 
 ### Workflow validation
 
-The project adds a pinned `actionlint` invocation for all three example workflow files. It also
-runs `bash -n` and the integration test for both helper scripts. Existing Go tests, race detection,
-branch-automation tests, linting, and build validation remain required and must produce pristine
-output.
+The project adds a pinned `actionlint` invocation for all three example workflow files. Validation
+copies the example `.github` tree into a temporary consumer-style repository root first, so local
+reusable-workflow paths resolve exactly as they do after installation. It also runs `bash -n` and
+the integration test for both helper scripts. Existing Go tests, race detection, branch-automation
+tests, linting, and build validation remain required and must produce pristine output.
 
 After implementation and TDD finish, a separate test-cleanup pass reviews new tests for duplicated
 or low-value coverage.
@@ -388,10 +523,18 @@ The example README defines an acceptance procedure using a disposable GitHub rep
 - One matching non-production state branch.
 - One non-matching production branch.
 - A committed lock file and default-branch config.
+- A default-branch-restricted publication environment.
 - Built-in-token and GitHub App runs.
+- An alternate-ref manual dispatch that cannot enter the protected publication job or read its
+  secrets.
 - Successful update, repeated idempotent update, validation failure, issue update, recovery, and
   obsolete-PR cleanup.
-- A dry run that demonstrates no remote refs, PRs, or issues changed.
+- Three rapid dispatches demonstrating `queue: max` rather than pending-run replacement.
+- A dry run that demonstrates no repository refs, content, PRs, or issues changed while diagnostic
+  logs and artefacts remain available.
+- An unowned update-ref collision and concurrent update/deletion races that preserve the remote
+  ref.
+- A state-base movement that prevents stale publication.
 - An optional signed run whose pushed commit is locally verified and shown as verified by GitHub
   when the signing identity is configured correctly.
 
@@ -403,14 +546,24 @@ The acceptance transcript is reviewed before completion is claimed.
 
 - Files to copy and paths to customise.
 - Repository settings and least-privilege permissions.
+- Protected publication-environment setup, default-branch restrictions, trusted-dispatch
+  assumptions, and fixed optional secret names.
 - Exact tool-version pinning.
 - Production and non-production prefix/config separation.
 - Manual narrowing and dry-run behaviour.
 - Built-in-token limitations and optional GitHub App configuration.
 - Unsigned and signed commit setup.
 - Stable branch, PR, issue, and cleanup lifecycles.
+- Reserved namespace, ownership markers, immutable control/base OIDs, and lease failure recovery.
 - Single-root and multi-root configurations.
+- Direct-file-per-module processing and the requirement to list every nested module explicitly.
 - Backend-disabled Terraform initialisation.
+- Workflow-level init failures versus deterministic branch update/validation issues.
+- Rejection of ignored required lock files and symlinked Terraform/lock paths.
+- Manual identification and cleanup of strongly marked orphaned automation refs and issues when a
+  state branch is deleted, renamed, or removed from the allow-list. Automatic orphan garbage
+  collection is intentionally deferred until operational need justifies a separate destructive
+  workflow; a future cleanup workflow must default to dry run.
 - Troubleshooting and real-service acceptance.
 
 `examples/README.md` and `docs/ADVANCED-USAGE.md` link to the GitHub Actions example and distinguish
@@ -422,11 +575,25 @@ The feature is complete when:
 
 - The three copyable workflows and two documented scripts implement this design.
 - Non-production and production examples have manual and timezone-aware scheduled triggers.
-- Dry runs perform real local updates and validation without any remote mutation.
+- Dry runs perform real local updates and validation without repository or GitHub content mutation;
+  workflow logs and diagnostic artefacts are retained.
+- Terraform executes only in credential-free read-only jobs, and privileged reconciliation runs on
+  a fresh protected runner without executing target-supplied code.
+- Untrusted refs and inputs remain data across Actions, shell, Git, JSON, Markdown, and artefact
+  boundaries.
 - Normal runs safely reconcile signed or unsigned commits, stable automation branches, PRs, and
   failure issues.
-- Every configured Terraform root has a lock file after initialisation; new and changed lock files
-  are staged, disposable `.terraform/` data is excluded, and unexpected paths are rejected.
+- Every run pins one control OID and one validated base OID per state branch; ref movement blocks
+  publication.
+- Existing update refs require verifiable ownership, and every rewrite or deletion uses an exact
+  expected remote OID.
+- The CLI reports aggregate per-file failure with a non-zero status.
+- Every configured Terraform module directory has a lock file after initialisation; new and changed
+  lock files are staged unless ignored (which is a clear failure), disposable `.terraform/` data is
+  excluded, and symlinked, escaping, non-regular, or otherwise unexpected paths are rejected before
+  writing.
+- Every changed Terraform source file belongs directly to exactly one configured and validated
+  module directory.
 - Local integration tests, pinned `actionlint`, the repository's full validation suite, and the
   disposable-repository acceptance procedure all pass with pristine output.
 - User-facing documentation describes configuration, permissions, security boundaries, and

--- a/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
+++ b/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
@@ -77,20 +77,28 @@ The production and non-production callers own policy. Each caller defines its al
 configuration path, pinned tool versions, schedule, and concurrency group, then invokes the local
 reusable workflow.
 
-The reusable workflow contains three job stages:
+The reusable workflow contains four job stages:
 
 1. `discover` checks out the exact caller commit, validates the shared configuration, and produces
    a sorted JSON matrix containing each matching state branch and its immutable tip OID.
-2. `validate` runs once per matrix entry with `fail-fast: false`. It applies the update and runs
-   Terraform on an unprivileged fresh runner, then uploads a data-only result bundle.
-3. `reconcile` runs once per matrix entry on another fresh runner after the complete validation
-   matrix. It treats the result bundle as untrusted data, revalidates it, and either publishes the
-   proposal, reports a deterministic branch failure, or records a workflow-level failure.
+2. `prepare` runs once per matrix entry with `fail-fast: false`. It applies the update and runs
+   Terraform initialisation on an unprivileged fresh runner, then uploads a preparation bundle
+   before any provider plugin executes. A successful bundle contains the immutable candidate.
+3. `validate` runs once per successful candidate on another unprivileged fresh runner. It consumes
+   the candidate without changing its publishable payload, executes the target-selected providers,
+   and uploads only a candidate-bound outcome and captured logs.
+4. `reconcile` runs once per matrix entry on another fresh runner after the complete validation
+   matrix. It treats both artefacts as untrusted data, revalidates them, and either publishes the
+   pre-provider candidate, reports a deterministic branch failure, or records a workflow-level
+   failure.
 
-Validation captures command status, builds and uploads its result bundle in unconditional cleanup
-steps, and then returns the recorded failure status. Reconciliation uses an `always()` condition so
-one failed matrix entry does not suppress reporting for the others. A missing or duplicate expected
-bundle is an automation failure and can never be interpreted as success.
+Preparation captures update and initialisation status and uploads its bundle in unconditional
+cleanup steps before returning the recorded failure status. Validation does the same for its
+candidate-bound outcome and logs. Reconciliation uses an `always()` condition so one failed matrix
+entry does not suppress reporting for the others. It expects one preparation bundle for every
+entry, and a validation outcome only when preparation produced a successful candidate. A missing,
+duplicate, unexpected, or mismatched artefact is an automation failure and can never be interpreted
+as success.
 
 The update matrix defaults to four concurrent branches. This bounds Terraform downloads and GitHub
 API writes while retaining useful parallelism. A caller can lower or raise the limit through the
@@ -105,17 +113,23 @@ two independent checkouts:
 - A target checkout of the immutable discovered state-branch OID receives the proposed changes.
 
 Terraform can execute target-selected provider plugins during validation. Therefore checkout
-separation is not treated as a process-security boundary. The fresh reconciliation job is the
-boundary: it does not execute Terraform or any target-supplied executable, and it materialises
-write credentials and signing material only after validating the result bundle.
+separation is not treated as a process-security boundary. Preparation uploads the immutable source
+and lock-file candidate before provider execution, and validation cannot replace that artefact. The
+fresh reconciliation job is the publication boundary: it does not execute Terraform or any
+target-supplied executable, and it materialises write credentials and signing material only after
+validating the candidate and outcome.
 
-The result bundle contains a versioned JSON manifest, captured logs, and a binary Git patch. The
-manifest records the control OID, state branch, validated base OID, result classification,
-configured Terraform directories, changed paths, file modes, and SHA-256 hashes. Reconciliation
-rejects unknown manifest versions, mismatched refs or OIDs, absolute or escaping paths, symlink or
-non-regular modes, unexpected file types, hash mismatches, and patch paths outside the declared
-set. It applies the patch only after a fresh exact-base checkout and independently reproduces the
-`tf-version-bump` source changes before accepting lock-file changes from the validated bundle.
+A successful preparation bundle contains a versioned JSON manifest, captured preparation logs, and
+a binary Git patch. The manifest records the control OID, state branch, validated base OID,
+preparation classification, configured Terraform directories, provider-dependency state, changed
+paths, file modes, and SHA-256 hashes. A failed preparation bundle contains its classification and
+logs but no publishable patch. The validation outcome records the candidate manifest digest,
+validation classification, and captured validation logs. Reconciliation rejects unknown manifest
+versions, mismatched refs, OIDs, or candidate digests, absolute or escaping paths, symlink or
+non-regular modes, unexpected file types, hash mismatches, and patch paths outside the declared set.
+It applies the patch only after a fresh exact-base checkout and independently reproduces the
+`tf-version-bump` source changes before accepting lock-file changes from the pre-provider candidate
+bundle.
 
 ## Triggers and schedules
 
@@ -135,8 +149,10 @@ timezone support:
 - Production: Sunday at 04:43 in `Australia/Melbourne`.
 
 Each caller has its own concurrency group with `queue: max` and no in-progress cancellation. Up to
-GitHub's concurrency-group queue limit waits behind the active run instead of replacing the
-existing pending run. Production and non-production can run independently.
+100 runs wait behind the active run instead of replacing the existing pending run. Production and
+non-production can run independently. This is current GitHub.com syntax; GitHub Enterprise Server
+consumers must confirm that their installed version supports the `queue` property before copying
+the example.
 
 Manual runs are accepted only when `github.ref` is the repository's default branch. This catches
 accidental alternate-ref dispatches. The reconciliation job also uses a required protected GitHub
@@ -231,12 +247,12 @@ directories are allowed, but each directory processes only the `.tf` files direc
 Before either validation or reconciliation invokes `tf-version-bump`, the script enumerates that
 directory's matching files, uses `lstat` to reject symlinks and non-regular files, and verifies each
 canonical path remains under the target checkout. Required lock files receive the same checks.
-Containment is repeated for every changed and untracked path before a result bundle or commit is
-created.
+Containment is repeated for every changed and untracked path before a preparation bundle or commit
+is created.
 
-## Per-branch validation flow
+## Per-branch preparation and validation flow
 
-Each unprivileged validation job performs the following sequence:
+Each unprivileged preparation job performs the following sequence:
 
 1. Check out the control OID and discovered state-branch OID with persisted credentials disabled.
 2. Install the exact Go, `tf-version-bump`, and Terraform versions supplied by the caller.
@@ -244,21 +260,38 @@ Each unprivileged validation job performs the following sequence:
    write.
 4. For every configured Terraform directory, run `tf-version-bump` from that directory with the
    control config and the non-recursive pattern `*.tf`.
-5. For that same directory, run sequentially:
+5. For that same directory, run:
 
    ```text
    terraform -chdir=<directory> init -upgrade -backend=false -input=false -no-color
-   terraform -chdir=<directory> validate -no-color
    ```
 
-6. Require a regular `.terraform.lock.hcl` file in every configured directory after
-   initialisation, including a newly created untracked lock file. If a new required lock file is
+6. After successful initialisation, inspect the canonical `.terraform/providers` package tree
+   before removing it. If initialisation installed any provider package, require a regular
+   `.terraform.lock.hcl`, including a newly created untracked file. If it installed none, record the
+   directory as provider-free and allow the lock file to be absent. If a new required lock file is
    ignored, fail with a repository-configuration error; never force-add it.
 7. Remove disposable `.terraform/` working data, then consume NUL-delimited Git status output and
    confirm that every changed `.tf` file is directly inside exactly one configured directory and
    every other change is that directory's lock file. Any other path fails the safety check.
-8. Produce the versioned manifest and patch, verify their hashes locally, upload the result bundle
-   with a collision-resistant branch hash in its artefact name, and remove the checkouts.
+8. Produce the versioned manifest and patch, verify their hashes locally, upload the immutable
+   candidate bundle with a collision-resistant branch hash in its artefact name, and remove the
+   checkouts. Terraform initialisation downloads provider packages but does not execute provider
+   validation RPCs, so this captures the publishable candidate before any provider plugin executes.
+
+A fresh unprivileged validation job downloads only its expected candidate, validates the manifest,
+paths, modes, hashes, refs, and OIDs, and applies the patch to a fresh exact-base checkout. For each
+directory with provider selections it runs:
+
+```text
+terraform -chdir=<directory> init -backend=false -input=false -no-color -lockfile=readonly
+terraform -chdir=<directory> validate -no-color
+```
+
+For a manifest-declared provider-free directory it omits `-lockfile=readonly` because no lock file
+exists, then runs the same validation command. The validation job never uploads source or lock-file
+bytes and discards its checkout after uploading only its candidate-bound outcome and logs. Provider
+execution therefore cannot alter the immutable candidate later considered for publication.
 
 `tf-version-bump` continues processing later files after a per-file parse, stat, read, or write
 error, but accumulates those errors and exits non-zero after processing completes. Its output ends
@@ -280,8 +313,8 @@ bundles. For each branch, reconciliation:
 2. For a successful result, checks out the exact control and base OIDs with persisted credentials
    disabled, repeats path/symlink preflight, independently reruns `tf-version-bump` for each
    configured directory, and requires its `.tf` diff to match the manifest.
-3. Applies only the validated lock-file portion from the bundle, verifies the complete resulting
-   diff and hashes, and stages only declared regular `.tf` and lock files.
+3. Applies only the lock-file portion from the pre-provider candidate bundle, verifies the complete
+   resulting diff and hashes, and stages only declared regular `.tf` and lock files.
 4. Fetches the state ref immediately before publication and requires its remote OID still to equal
    the validated base OID. Movement fails without publication; a later run processes the new tip.
 5. Verifies ownership of any existing automation ref and PR, then creates the signed or unsigned
@@ -311,9 +344,11 @@ workflow still:
 
 - Runs `tf-version-bump` without the CLI's `-dry-run` flag.
 - Runs real Terraform initialisation and validation.
-- Creates or updates the required lock files in the disposable checkout.
+- Creates or updates dependency lock files for roots with provider selections in the disposable
+  checkout; provider-free roots may remain without one.
 - Performs the allowed-path safety check.
-- Uploads diagnostic result bundles and reports proposed changes and failures in workflow output.
+- Uploads diagnostic preparation and outcome artefacts and reports proposed changes and failures in
+  workflow output.
 
 It never enters the protected reconciliation environment and never commits, pushes, changes GitHub
 repository content, creates or edits a pull request, creates or edits an issue, closes an issue or
@@ -385,10 +420,10 @@ that its validated proposal is defective.
 
 Authentication, GitHub API, invalid input, unsafe diff, signing, commit, push, lease, PR, issue
 reconciliation, and workflow configuration failures are automation failures. They fail the matrix
-job without creating a misleading state-validation issue. The manifest carries an explicit result
-class with precedence `automation`, `shared/init`, `branch-update`, `branch-validation`, then
-`success`; reconciliation rejects unknown or contradictory classes. `fail-fast: false` ensures
-other state branches continue.
+job without creating a misleading state-validation issue. The candidate manifest and its bound
+validation outcome together carry an explicit result class with precedence `automation`,
+`shared/init`, `branch-update`, `branch-validation`, then `success`; reconciliation rejects unknown,
+mismatched, or contradictory classes. `fail-fast: false` ensures other state branches continue.
 
 ## Authentication and permissions
 
@@ -408,9 +443,15 @@ ceiling keeps the effective reconciliation `GITHUB_TOKEN` read-only. Every check
 `persist-credentials: false`. The built-in publication path injects `GITHUB_TOKEN` only into the
 exact Git/GitHub CLI steps that need it. The App publication path never passes `GITHUB_TOKEN` to a
 write operation; it uses only the short-lived App token. Consumers using the built-in token must
-enable the repository setting that permits GitHub Actions to create pull requests. Pull-request
-workflows generated with this token may require manual approval under GitHub's current recursion
-protection.
+enable the repository setting that permits GitHub Actions to create pull requests.
+
+GitHub recursion protection distinguishes the events created with the built-in token. Resulting
+`push` events do not create workflow runs. Pull-request `opened`, `synchronize`, and `reopened`
+events do create workflow runs, but those runs wait for approval from a repository writer. Other
+pull-request activity types do not create runs. Built-in-token mode is therefore suitable only when
+manual approval of generated PR checks is acceptable. Consumers whose required checks must run
+unattended use App mode; an explicit consumer-managed `workflow_dispatch` is the documented manual
+fallback rather than an assumed automatic check run.
 
 When the App client ID and protected-environment private key are supplied, reconciliation uses the
 GitHub-maintained App-token action to mint a short-lived installation token limited to the current
@@ -487,7 +528,9 @@ A maintained shell test creates temporary real Git repositories and bare remotes
 - Aggregate non-zero CLI status after a real per-file failure while later files still run.
 - One-to-one mapping of directly changed source files to configured Terraform directories,
   including rejection of omitted, duplicate, and ambiguous roots.
-- Terraform source and lock-file staging.
+- Terraform source and lock-file staging into an immutable candidate before provider execution.
+- Provider-free root success without `.terraform.lock.hcl`, alongside rejection of a missing lock
+  when initialisation installs a provider package.
 - Multi-directory success and failure attribution.
 - Missing, duplicate, path-traversing, symlink-mode, hash-mismatched, and ref-mismatched result
   bundles are rejected by fresh reconciliation.
@@ -504,12 +547,14 @@ A maintained shell test creates temporary real Git repositories and bare remotes
   its owned update branch.
 - Signed commits, local signature verification, cleanup of key material, and signing failure.
 - A hostile purpose-built Terraform provider fixture that attempts to find credentials, alter
-  control files, poison later validation steps, and construct a malicious result bundle. Local
-  coverage verifies that reconciliation treats every resulting payload as untrusted data; the
-  actual runner and protected-secret boundary is verified by real-service acceptance.
+  control files and the validation checkout's lock file, poison later validation steps, and
+  construct a malicious outcome. Local coverage verifies that it cannot replace the pre-provider
+  candidate and that reconciliation treats every resulting payload as untrusted data; the actual
+  runner and protected-secret boundary is verified by real-service acceptance.
 - Unsigned operation when no signing key is configured.
 - Obsolete no-change branch and PR payload generation.
-- Clear failure when a newly required lock file is ignored; the workflow never force-adds it.
+- Clear failure when a newly required provider lock file is ignored; the workflow never force-adds
+  it.
 
 The tests do not mock `gh` or assert against invented GitHub API behaviour. Deterministic PR and
 issue payload construction is tested locally. Actual PR, issue, token, and permissions behaviour is
@@ -517,11 +562,16 @@ covered by the real-service acceptance run.
 
 ### Workflow validation
 
-The project adds a pinned `actionlint` invocation for all three example workflow files. Validation
-copies the example `.github` tree into a temporary consumer-style repository root first, so local
-reusable-workflow paths resolve exactly as they do after installation. It also runs `bash -n` and
-the integration test for both helper scripts. Existing Go tests, race detection, branch-automation
-tests, linting, and build validation remain required and must produce pristine output.
+The project adds a pinned `actionlint` invocation for all three example workflow files. GitHub.com
+supports `concurrency.queue`, but actionlint 1.7.12 predates that syntax and reports `queue` as an
+unexpected concurrency key. Until a pinned actionlint release supports it, the invocation includes
+the exact `-ignore '^unexpected key "queue" for "concurrency" section\.'` filter for that known false
+positive; it does not disable other syntax checks. The real-service queue acceptance remains
+mandatory. Validation copies the example `.github` tree into a temporary consumer-style repository
+root first, so local reusable-workflow paths resolve exactly as they do after installation. It also
+runs `bash -n` and the integration test for both helper scripts. Existing Go tests, race detection,
+branch-automation tests, linting, and build validation remain required and must produce pristine
+output.
 
 After implementation and TDD finish, a separate test-cleanup pass reviews new tests for duplicated
 or low-value coverage.
@@ -532,7 +582,8 @@ The example README defines an acceptance procedure using a disposable GitHub rep
 
 - One matching non-production state branch.
 - One non-matching production branch.
-- A committed lock file and default-branch config.
+- A provider-using root with a committed lock file, a provider-free root without one, and a
+  default-branch config covering both.
 - A default-branch-restricted publication environment.
 - Built-in-token and GitHub App runs.
 - An App-mode run whose job permission summary shows `contents: read` and no write scopes, and whose
@@ -541,13 +592,15 @@ The example README defines an acceptance procedure using a disposable GitHub rep
 - An alternate-ref manual dispatch that cannot enter the protected publication job or read its
   secrets.
 - A state branch using the hostile provider fixture. The provider attempts to read write/App/signing
-  credentials, alter the control checkout, poison `GITHUB_ENV` and `GITHUB_PATH`, and submit a
-  malicious result bundle. The validation job exposes no protected or write credentials, the fresh
-  reconciliation runner rejects the tampered bundle, and no repository ref, content, PR, or issue
-  mutation occurs.
+  credentials, alter the control checkout and validation lock file, poison `GITHUB_ENV` and
+  `GITHUB_PATH`, and submit a malicious outcome. The validation job exposes no protected or write
+  credentials, cannot replace the pre-provider candidate, the fresh reconciliation runner rejects
+  the tampered outcome, and no repository ref, content, PR, or issue mutation occurs.
 - Successful update, repeated idempotent update, validation failure, issue update, recovery, and
   obsolete-PR cleanup.
 - Three rapid dispatches demonstrating `queue: max` rather than pending-run replacement.
+- A built-in-token PR whose `push` workflows remain absent and whose `pull_request` checks wait for
+  writer approval, followed by an App-mode PR whose checks start without that approval gate.
 - A dry run that demonstrates no repository refs, content, PRs, or issues changed while diagnostic
   logs and artefacts remain available.
 - An unowned update-ref collision and concurrent update/deletion races that preserve the remote
@@ -577,7 +630,12 @@ The acceptance transcript is reviewed before completion is claimed.
 - Direct-file-per-module processing and the requirement to list every nested module explicitly.
 - Backend-disabled Terraform initialisation.
 - Workflow-level init failures versus deterministic branch update/validation issues.
-- Rejection of ignored required lock files and symlinked Terraform/lock paths.
+- Required provider lock files, valid provider-free roots without locks, and rejection of ignored
+  required locks and symlinked Terraform/lock paths.
+- GitHub.com `queue: max` semantics, the temporary actionlint 1.7.12 false-positive ignore, and the
+  need to confirm queue support before using the example on GitHub Enterprise Server.
+- Built-in-token event suppression and approval-required PR checks, including when App mode is
+  required for unattended checks.
 - Manual identification and cleanup of strongly marked orphaned automation refs and issues when a
   state branch is deleted, renamed, or removed from the allow-list. Automatic orphan garbage
   collection is intentionally deferred until operational need justifies a separate destructive
@@ -595,8 +653,9 @@ The feature is complete when:
 - Non-production and production examples have manual and timezone-aware scheduled triggers.
 - Dry runs perform real local updates and validation without repository or GitHub content mutation;
   workflow logs and diagnostic artefacts are retained.
-- Terraform executes only in credential-free read-only jobs, and privileged reconciliation runs on
-  a fresh protected runner without executing target-supplied code.
+- Terraform executes only in credential-free jobs with `contents: read`, the immutable publishable
+  candidate is uploaded before provider execution, and privileged reconciliation runs on a fresh
+  protected runner without executing target-supplied code.
 - App-mode reconciliation has an effective read-only `GITHUB_TOKEN`; only its short-lived App token
   can publish repository content, refs, PRs, or issues.
 - Untrusted refs and inputs remain data across Actions, shell, Git, JSON, Markdown, and artefact
@@ -608,10 +667,15 @@ The feature is complete when:
 - Existing update refs require verifiable ownership, and every rewrite or deletion uses an exact
   expected remote OID.
 - The CLI reports aggregate per-file failure with a non-zero status.
-- Every configured Terraform module directory has a lock file after initialisation; new and changed
-  lock files are staged unless ignored (which is a clear failure), disposable `.terraform/` data is
+- Every configured Terraform module directory with installed provider packages has a lock file
+  after initialisation; new and changed required lock files are staged unless ignored (which is a
+  clear failure), provider-free directories may omit the file, disposable `.terraform/` data is
   excluded, and symlinked, escaping, non-regular, or otherwise unexpected paths are rejected before
   writing.
+- GitHub.com runs use the supported bounded `queue: max` concurrency behaviour; actionlint ignores
+  only its pinned version's exact known false positive until parser support is released.
+- Built-in-token documentation and acceptance distinguish suppressed `push` workflows from
+  approval-required PR workflows, and require App mode for unattended required checks.
 - Every changed Terraform source file belongs directly to exactly one configured and validated
   module directory.
 - Local integration tests, pinned `actionlint`, the repository's full validation suite, and the

--- a/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
+++ b/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
@@ -144,7 +144,8 @@ environment restricted to the default branch. App and signing private keys live 
 environment; they are not passed through `workflow_call`. Repository administrators must limit
 manual dispatch to trusted actors. Built-in-token mode additionally assumes repository write
 access is trusted because a writer can submit modified workflow YAML even when no optional secret
-is exposed.
+is exposed. App-mode callers cap the reusable workflow's `GITHUB_TOKEN` at `contents: read`; only
+the short-lived App token receives publication permissions.
 
 ## Reusable workflow interface
 
@@ -391,17 +392,25 @@ other state branches continue.
 
 ## Authentication and permissions
 
-The caller grants the reusable workflow the write scopes needed by reconciliation as an upper
-bound. The reusable workflow then declares narrower permissions per job:
+The caller sets the reusable workflow's permission ceiling according to its authentication mode:
+
+- Built-in-token callers grant `contents: write`, `pull-requests: write`, and `issues: write`.
+- GitHub App callers grant only `contents: read`; unspecified scopes remain `none`.
+
+Reusable workflows can only maintain or reduce the caller's permission ceiling. The reusable
+workflow declares narrower permissions per job:
 
 - Discovery and validation: `contents: read` only.
 - Reconciliation: `contents: write`, `pull-requests: write`, and `issues: write`.
 
-Every checkout sets `persist-credentials: false`. The default publication path injects the
-reconciliation job's `GITHUB_TOKEN` only into the exact Git/GitHub CLI steps that need it.
-Consumers must enable the repository setting that permits GitHub Actions to create pull requests.
-Pull-request workflows generated with this token may require manual approval under GitHub's current
-recursion protection.
+The reconciliation declaration supports built-in-token callers, but an App caller's read-only
+ceiling keeps the effective reconciliation `GITHUB_TOKEN` read-only. Every checkout sets
+`persist-credentials: false`. The built-in publication path injects `GITHUB_TOKEN` only into the
+exact Git/GitHub CLI steps that need it. The App publication path never passes `GITHUB_TOKEN` to a
+write operation; it uses only the short-lived App token. Consumers using the built-in token must
+enable the repository setting that permits GitHub Actions to create pull requests. Pull-request
+workflows generated with this token may require manual approval under GitHub's current recursion
+protection.
 
 When the App client ID and protected-environment private key are supplied, reconciliation uses the
 GitHub-maintained App-token action to mint a short-lived installation token limited to the current
@@ -494,9 +503,10 @@ A maintained shell test creates temporary real Git repositories and bare remotes
 - Success followed by a new deterministic failure closes the stale marked PR and safely removes
   its owned update branch.
 - Signed commits, local signature verification, cleanup of key material, and signing failure.
-- A hostile purpose-built Terraform provider that attempts to find credentials, alter control
-  files, and poison later-step state, proving validation cannot influence the fresh reconciliation
-  runner or protected secrets.
+- A hostile purpose-built Terraform provider fixture that attempts to find credentials, alter
+  control files, poison later validation steps, and construct a malicious result bundle. Local
+  coverage verifies that reconciliation treats every resulting payload as untrusted data; the
+  actual runner and protected-secret boundary is verified by real-service acceptance.
 - Unsigned operation when no signing key is configured.
 - Obsolete no-change branch and PR payload generation.
 - Clear failure when a newly required lock file is ignored; the workflow never force-adds it.
@@ -525,8 +535,16 @@ The example README defines an acceptance procedure using a disposable GitHub rep
 - A committed lock file and default-branch config.
 - A default-branch-restricted publication environment.
 - Built-in-token and GitHub App runs.
+- An App-mode run whose job permission summary shows `contents: read` and no write scopes, and whose
+  publication succeeds with the short-lived App token, proving `GITHUB_TOKEN` is not the write
+  credential.
 - An alternate-ref manual dispatch that cannot enter the protected publication job or read its
   secrets.
+- A state branch using the hostile provider fixture. The provider attempts to read write/App/signing
+  credentials, alter the control checkout, poison `GITHUB_ENV` and `GITHUB_PATH`, and submit a
+  malicious result bundle. The validation job exposes no protected or write credentials, the fresh
+  reconciliation runner rejects the tampered bundle, and no repository ref, content, PR, or issue
+  mutation occurs.
 - Successful update, repeated idempotent update, validation failure, issue update, recovery, and
   obsolete-PR cleanup.
 - Three rapid dispatches demonstrating `queue: max` rather than pending-run replacement.
@@ -579,6 +597,8 @@ The feature is complete when:
   workflow logs and diagnostic artefacts are retained.
 - Terraform executes only in credential-free read-only jobs, and privileged reconciliation runs on
   a fresh protected runner without executing target-supplied code.
+- App-mode reconciliation has an effective read-only `GITHUB_TOKEN`; only its short-lived App token
+  can publish repository content, refs, PRs, or issues.
 - Untrusted refs and inputs remain data across Actions, shell, Git, JSON, Markdown, and artefact
   boundaries.
 - Normal runs safely reconcile signed or unsigned commits, stable automation branches, PRs, and

--- a/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
+++ b/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
@@ -179,11 +179,20 @@ fresh exact-base checkout and independently reproduces the `tf-version-bump` sou
 accepting lock-file changes from the pre-provider candidate bundle.
 
 Every stage has a bounded inner operation timeout plus a larger job timeout so the workflow can
-capture logs and classifications before GitHub terminates the job. Discovery is limited to 10
-minutes. All update and initialisation work for one state branch shares one cumulative 20-minute
-preparation deadline, and all validation work for that branch shares a separate cumulative
-20-minute validation deadline; neither deadline is renewed for each Terraform root. Their jobs are
-limited to 30 minutes, leaving 10 minutes for bundle creation, log upload, and cleanup.
+normally capture logs and classifications before GitHub terminates the job. Discovery is limited
+to 10 minutes. The first executable step of each preparation and validation job records an
+absolute 20-minute deadline before checkout, tool installation, path preflight, candidate setup,
+or image setup. Every later workflow-controlled step checks that deadline, and all update,
+initialisation, and validation commands receive only its remaining time; the deadline is not
+renewed for each Terraform root. Those jobs are limited to 30 minutes, giving at most ten minutes
+of nominal headroom after the absolute deadline for bundle creation, log upload, and cleanup.
+Every third-party `uses:` step in those jobs has `timeout-minutes: 10`. That integer per-step cap
+prevents one action from consuming the entire job, but it does not align the step with the remaining
+absolute budget or preserve aggregate headroom across several action steps. A third-party action
+that returns or times out after the absolute deadline can therefore consume some or all of the
+nominal headroom. That is a job-level automation failure without a cleanup/upload guarantee; the
+inner deadline precisely bounds only workflow-controlled work.
+
 Verification is limited to 15 minutes and its job to 20 minutes; publication is limited to 10
 minutes and its job to 15 minutes. A preparation timeout is classified according to the command
 that exhausted the budget (`branch-update` or `branch-init`), and a validation timeout is
@@ -358,38 +367,42 @@ checkout, so a tracked `.terraform` symlink cannot redirect initialisation write
 
 Each unprivileged preparation job performs the following sequence:
 
-1. Check out the control OID and discovered state-branch OID with persisted credentials disabled.
-2. Install the exact released `tf-version-bump` and Terraform versions supplied by the caller and
+1. As the first executable step, record the absolute preparation deadline 20 minutes in the
+   future. Every subsequent workflow-controlled step checks it before starting new work.
+2. Check out the control OID and discovered state-branch OID with persisted credentials disabled.
+3. Install the exact released `tf-version-bump` and Terraform versions supplied by the caller and
    verify their reported versions. The released CLI must be the same artefact exercised by tests.
-3. Validate directory containment and reject symlinked or non-regular candidate files before any
+4. Validate directory containment and reject symlinked or non-regular candidate files before any
    write, including any repository `.terraform` path.
-4. Start one cumulative 20-minute preparation deadline for the state branch. For every configured
-   Terraform directory, run `tf-version-bump` from that directory with the control config and the
-   non-recursive pattern `*.tf`; each command receives only the deadline's remaining time.
-5. Create a fresh absolute `TF_DATA_DIR` under the trusted runner temporary directory and, for that
+5. For every configured Terraform directory, run `tf-version-bump` from that directory with the
+   control config and non-recursive pattern `*.tf`; each command receives only the deadline's
+   remaining time.
+6. Create a fresh absolute `TF_DATA_DIR` under the trusted runner temporary directory and, for that
    same directory, run within the same remaining preparation deadline:
 
    ```text
    terraform -chdir=<directory> init -upgrade -backend=false -input=false -no-color
    ```
 
-6. After successful initialisation, inspect the trusted data directory's provider package tree
+7. After successful initialisation, inspect the trusted data directory's provider package tree
    before removing it. If initialisation installed any provider package, require a regular
    `.terraform.lock.hcl`, including a newly created untracked file. If it installed none, record the
    directory as provider-free and allow the lock file to be absent. If a new required lock file is
    ignored, fail with a repository-configuration error; never force-add it.
-7. Remove disposable `.terraform/` working data, then consume NUL-delimited Git status output and
+8. Remove disposable `.terraform/` working data, then consume NUL-delimited Git status output and
    confirm that every changed `.tf` file is directly inside exactly one configured directory and
    every other change is that directory's lock file. Any other path fails the safety check.
-8. Produce the versioned manifest and patch, verify their hashes locally, upload the immutable
+9. Produce the versioned manifest and patch, verify their hashes locally, upload the immutable
    candidate bundle under a name containing the run ID, run attempt, policy ID, and
    collision-resistant branch hash, and remove the checkouts and trusted data directories.
    Terraform initialisation downloads provider packages but does not execute provider validation
    RPCs, so this captures the publishable candidate before any provider plugin executes.
 
-A fresh unprivileged validation job downloads only its exact run-attempt candidate, validates the
-manifest, paths, modes, hashes, refs, OIDs, policy, and run identity, and applies the patch to a
-fresh exact-base validation checkout. The host creates a trusted data directory and starts the
+A fresh unprivileged validation job records its absolute 20-minute deadline as its first executable
+step, before downloading the exact run-attempt candidate or performing checkout and image setup.
+It validates the manifest, paths, modes, hashes, refs, OIDs, policy, and run identity, and applies
+the patch to a fresh exact-base validation checkout. Every later workflow-controlled step checks
+the deadline before starting new work. The host creates a trusted data directory and starts the
 pinned Terraform image with `--rm`, no Docker socket, all capabilities dropped,
 `no-new-privileges`, `--pids-limit=256`, `--memory=4g`, `--memory-swap=4g`, `--cpus=2`, the runner
 UID/GID, and only the disposable validation checkout and trusted data directory mounted. These
@@ -503,10 +516,12 @@ markers before compensation. A compensation lease failure never triggers an unco
 it produces an automation error with explicit manual recovery details. Failpoint integration tests
 cover ref create/update, PR create/edit/close, ref deletion, state movement between advertisement
 and update, and termination immediately after push. An abrupt runner loss can leave a transient or
-stale marked ref because no later check can execute. A subsequent run repairs an existing managed
-PR/ref pair normally; a newly created marked ref with no corresponding PR remains unowned under the
-two-marker rule and produces bounded manual-recovery instructions rather than being adopted or
-deleted automatically.
+stale marked ref because no later check can execute. If termination occurs after creating or
+updating the ref but before the corresponding PR mutation completes, the PR marker is absent or no
+longer matches the commit marker. The next run refuses that ref under the two-marker rule and emits
+bounded manual-recovery instructions; this applies both to a new ref without a PR and to a
+previously managed ref whose PR still carries the prior identity. Only a ref and PR whose markers
+already agree can be reconciled normally by a later run.
 
 When a successful non-dry run produces no changes, the workflow prechecks the current state, deletes
 only its verified automation branch using an expected-old-OID deletion lease, and then closes the
@@ -746,8 +761,9 @@ A maintained shell test creates temporary real Git repositories and bare remotes
 - Publication-race tests move the state ref after advertisement but before the automation-ref
   update, prove that the update may be accepted, and then prove that the post-push check performs
   exact-lease compensation without touching an unseen writer's ref.
-- A termination-after-push failpoint proves the documented residual stale-ref state and the next
-  run's automatic or bounded manual-recovery path, depending on whether a managed PR already exists.
+- Termination-after-push failpoints for both ref creation and ref update prove the documented
+  residual stale-ref state. The next run must refuse both absent and mismatched PR markers and emit
+  bounded manual-recovery instructions; it must not auto-adopt either ref.
 - Failpoint tests after ref creation or update, PR creation or edit, PR close, and ref deletion
   prove the documented exact-lease compensation and retry behaviour.
 - Malformed shared-config failure before matrix creation.
@@ -774,8 +790,11 @@ A maintained shell test creates temporary real Git repositories and bare remotes
 - Artefact names and manifests bind run ID, run attempt, policy ID, control OID, state ref, and base
   OID. A complete rerun creates and consumes only its own attempt's lineage; a failed-job rerun is
   rejected because its reused discovery output identifies a prior attempt.
-- Two roots sharing an injectable shortened cumulative deadline prove that the second root receives
-  only the remaining budget and that cleanup/artefact upload completes before the job deadline.
+- An injectable shortened absolute deadline recorded before setup proves that setup and the first
+  root reduce the second root's remaining budget, and that normal timeout handling reaches
+  cleanup/artefact upload before the larger job deadline. Separate late-returning and non-returning
+  setup fixtures prove the fixed third-party-step timeout, are classified as job-level automation
+  failures, and make no cleanup/upload guarantee.
 - The command-scoped Git authentication helper works against a real authenticated bare HTTP test
   service without storing a token in a remote URL or process argument and removes its temporary
   files after each command.
@@ -851,8 +870,9 @@ The example README defines an acceptance procedure using a disposable GitHub rep
 - An unowned update-ref collision and concurrent update/deletion races that preserve the remote
   ref.
 - A state-base movement between advertisement and automation-ref update whose accepted update is
-  exact-lease-compensated by the post-push check, plus termination immediately after push and the
-  documented next-run/manual recovery result.
+  exact-lease-compensated by the post-push check, plus termination immediately after ref creation
+  and ref update; both next runs refuse the absent or stale PR marker and report bounded manual
+  recovery.
 - A complete workflow rerun whose artefacts remain isolated by run attempt, followed by a failed-job
   rerun that is rejected with instructions to use **Re-run all jobs**.
 - A policy collision that refuses to adopt or overwrite the foreign marked ref and PR.
@@ -946,8 +966,11 @@ The feature is complete when:
   clear failure), provider-free directories may omit the file, disposable `.terraform/` data is
   excluded, and symlinked, escaping, non-regular, or otherwise unexpected paths are rejected before
   writing.
-- Preparation and validation each use one cumulative 20-minute branch deadline inside a 30-minute
-  job, so multiple sequential roots cannot individually consume the entire cleanup reserve.
+- Preparation and validation each record one absolute 20-minute branch deadline before setup inside
+  a 30-minute job. Setup and all sequential roots consume that same budget, so the deadline is
+  never renewed per root. Every third-party action step is capped at 10 minutes, but actions that
+  collectively overrun the absolute deadline remain job-level failures for which cleanup cannot be
+  guaranteed.
 - Terraform's Actions wrapper is disabled; validation runs with the documented fixed resource
   limits and no network after a separate networked initialisation phase.
 - GitHub.com caller and publication concurrency use the supported `queue: max` behaviour so pending

--- a/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
+++ b/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
@@ -1,0 +1,433 @@
+# GitHub Actions state-branch automation design
+
+## Purpose
+
+Add a copyable GitHub Actions example that applies a `tf-version-bump` configuration across
+Terraform state branches, upgrades provider selections, validates the result, and reconciles one
+pull request or failure issue per state branch.
+
+The example lives in this repository under `examples/github-actions/`, but consumers copy its
+`.github` tree into their own default branch. The implementation is deliberately separate from
+the core Go CLI and from `examples/update-branches.sh`. It reuses the existing script's safe branch
+selection and commit principles while using isolated GitHub Actions jobs for the PR and issue
+lifecycle.
+
+## Goals
+
+- Provide one reusable workflow containing the update behaviour.
+- Provide non-production and production caller workflows with both manual and scheduled triggers.
+- Select remote state branches using configured literal prefixes.
+- Permit a manual run to narrow, but never widen, the caller's branch allow-list.
+- Use separate default-branch configurations for production and non-production updates.
+- Apply updates, run `terraform init -upgrade -backend=false`, and run `terraform validate` before
+  publishing a branch.
+- Persist `.terraform.lock.hcl` changes alongside Terraform source changes.
+- Maintain stable update branches, pull requests, and validation-failure issues without creating
+  duplicates on scheduled runs.
+- Support a side-effect-free dry run that still applies and validates the proposed changes in the
+  disposable runner checkout.
+- Support the built-in `GITHUB_TOKEN`, optional GitHub App authentication, and optional SSH commit
+  signing.
+- Show how the same workflow can validate multiple Terraform root modules without complicating the
+  root-directory example.
+
+## Non-goals
+
+- Change the `tf-version-bump` CLI or its YAML configuration format.
+- Turn `examples/update-branches.sh` into a GitHub API orchestration tool.
+- Initialise or access Terraform state backends.
+- Merge or approve generated pull requests.
+- Delete, reset, force-push, or otherwise modify a state branch.
+- Provide arbitrary regular-expression or shell-glob branch matching.
+- Add configurable post-update command hooks in the initial example.
+
+## Example layout
+
+The example mirrors the destination paths in a consuming repository:
+
+```text
+examples/github-actions/
+├── README.md
+└── .github/
+    ├── scripts/
+    │   ├── discover-state-branches.sh
+    │   └── process-state-branch.sh
+    ├── tf-version-bump/
+    │   ├── nonproduction.yml
+    │   └── production.yml
+    └── workflows/
+        ├── tf-version-bump-reusable.yml
+        ├── tf-version-bump-nonproduction.yml
+        └── tf-version-bump-production.yml
+```
+
+GitHub requires reusable workflow files to be directly under `.github/workflows`, so consumers
+copy the example's `.github` directory rather than invoke a workflow from its example path.
+
+The shell scripts keep non-trivial orchestration out of YAML blocks. They have help output,
+validate their inputs, fail with stage-specific messages, and limit routine output while retaining
+failure logs for diagnosis.
+
+## Workflow architecture
+
+The production and non-production callers own policy. Each caller defines its allowed prefixes,
+configuration path, pinned tool versions, schedule, and concurrency group, then invokes the local
+reusable workflow.
+
+The reusable workflow contains two jobs:
+
+1. `discover` validates the configuration and produces a sorted JSON matrix of matching remote
+   state branches.
+2. `update` runs once per matrix entry with `fail-fast: false`, so every discovered state branch is
+   processed even if another branch fails.
+
+The update matrix defaults to four concurrent branches. This bounds Terraform downloads and GitHub
+API writes while retaining useful parallelism. A caller can lower or raise the limit through the
+reusable workflow's `max_parallel` input.
+
+Each update job uses two independent checkouts:
+
+- A control checkout of `github.event.repository.default_branch` supplies the reviewed workflow,
+  scripts, and `tf-version-bump` configuration.
+- A target checkout of the selected remote state branch receives the proposed changes.
+
+The separation ensures that a state branch cannot replace the automation or configuration that is
+processing it.
+
+## Triggers and schedules
+
+Both caller workflows support `workflow_dispatch` and `schedule`.
+
+The manual interface contains:
+
+- `branch_prefix`: an optional literal prefix used to narrow the configured allow-list.
+- `dry_run`: a Boolean input whose default is `false`.
+
+Scheduled runs always use the complete caller allow-list and `dry_run: false`.
+
+The example schedules are deliberately away from the top of the hour and use GitHub's IANA
+timezone support:
+
+- Non-production: daily at 04:17 in `Australia/Melbourne`.
+- Production: Sunday at 04:43 in `Australia/Melbourne`.
+
+Each caller has its own concurrency group with cancellation disabled. A new run queues behind an
+active run for the same environment rather than interrupting branch, PR, or issue reconciliation.
+Production and non-production can run independently.
+
+## Reusable workflow interface
+
+| Input | Type | Required/default | Purpose |
+|---|---|---|---|
+| `allowed_branch_prefixes` | string | Required | Newline-separated literal prefix allow-list |
+| `branch_prefix` | string | `""` | Optional manual narrowing prefix |
+| `config_path` | string | Required | Config path in the default-branch control checkout |
+| `file_pattern` | string | `**/*.tf` | Terraform files passed to `tf-version-bump` |
+| `terraform_directories` | string | `.` | Newline-separated root-module directories |
+| `terraform_version` | string | Required | Exact Terraform version installed for the run |
+| `tf_version_bump_version` | string | Required | Exact `tf-version-bump` release tag used by `go install` |
+| `go_version` | string | Required | Exact Go version used by `go install` |
+| `dry_run` | boolean | `false` | Suppress every remote mutation |
+| `max_parallel` | number | `4` | Maximum concurrent state-branch jobs |
+| `commit_author_name` | string | Bot identity | Commit author and committer name |
+| `commit_author_email` | string | Bot identity | Commit author and committer email |
+| `github_app_client_id` | string | `""` | Enable GitHub App authentication when paired with its key |
+
+Optional reusable-workflow secrets are:
+
+- `github_app_private_key`
+- `commit_signing_private_key`
+
+The workflow rejects partial authentication or signing configurations. When signing is enabled,
+the caller must explicitly supply both commit identity inputs rather than inherit a bot default.
+
+Production and non-production callers demonstrate separate config paths, prefix lists, schedules,
+concurrency groups, and tool versions. Their illustrative allow-lists are:
+
+```text
+# Non-production
+state/nonproduction/
+state/staging/
+aws-state/nonproduction/
+
+# Production
+state/production/
+aws-state/production/
+```
+
+## Branch discovery and validation
+
+Discovery lists remote heads from `origin`; it does not depend on whatever subset
+`actions/checkout` fetched. A state branch matches when its complete name begins with one of the
+configured literal prefixes. The remainder of the branch name is unrestricted except by Git's
+normal ref-name rules.
+
+The discovery script:
+
+1. Rejects an empty allow-list, empty entries, absolute-looking values, control characters, and
+   values that are not valid literal branch prefixes.
+2. If `branch_prefix` is supplied, verifies that it begins with at least one allowed prefix.
+3. Selects remote branches using the allow-list plus optional narrowing prefix.
+4. Deduplicates branches selected by overlapping prefixes.
+5. Sorts names bytewise for deterministic output.
+6. Fails when no branches match so a configuration mistake cannot look successful.
+7. Encodes the final list as JSON for the matrix without evaluating branch names as shell code.
+
+The manual prefix can narrow `state/nonproduction/` to `state/nonproduction/example-`, but a
+non-production caller rejects `state/production/`.
+
+All repository-relative paths are resolved beneath their checkout roots. The workflow rejects
+absolute paths, `..` traversal, missing config files, missing Terraform directories, and
+directories that resolve outside the target checkout.
+
+## Per-branch update flow
+
+Each matrix job performs the following sequence:
+
+1. Create the control and target checkouts.
+2. Install the exact Go, `tf-version-bump`, and Terraform versions supplied by the caller.
+3. Apply `tf-version-bump` once across the target checkout with the config from the control
+   checkout and the configured file pattern.
+4. For every configured Terraform directory, run sequentially:
+
+   ```text
+   terraform -chdir=<directory> init -upgrade -backend=false -input=false -no-color
+   terraform -chdir=<directory> validate -no-color
+   ```
+
+5. Require a `.terraform.lock.hcl` file in every configured Terraform directory after
+   initialisation, including a newly created untracked lock file.
+6. Remove or ignore disposable `.terraform/` working data, then confirm that only Terraform source
+   files and `.terraform.lock.hcl` files changed. Any other unexpected path fails the safety check.
+7. If the run is a dry run, report the proposed file changes and stop without remote side effects.
+8. If no allowed files changed, reconcile obsolete automation state and stop without an empty
+   commit.
+9. Stage only allowed changed files.
+10. Create a commit from the latest state-branch tip on `update_<state-branch>`.
+11. Fetch any existing automation branch and update it using an explicit force-with-lease that
+    protects against an unseen concurrent writer.
+12. Create or update the single pull request from the automation branch to the state branch.
+13. Close any open validation-failure issue for the state branch.
+
+For example, `state/nonproduction/example-thing` maps to
+`update_state/nonproduction/example-thing`. Only branches beginning with `update_` are regenerated
+or deleted by this workflow. State branches are read-only bases.
+
+When a successful non-dry run produces no changes, the workflow closes an existing automation PR
+as obsolete and deletes only the corresponding `update_<state-branch>` branch. It also closes any
+open validation-failure issue because the branch completed the update and validation flow.
+
+## Dry-run semantics
+
+Dry-run mode is a remote side-effect boundary, not a read-only filesystem mode. The workflow still:
+
+- Runs `tf-version-bump` without the CLI's `-dry-run` flag.
+- Runs real Terraform initialisation and validation.
+- Creates or updates the required lock files in the disposable checkout.
+- Performs the allowed-path safety check.
+- Reports the proposed changes and failures in workflow output.
+
+It never commits, pushes, creates or edits a pull request, creates or edits an issue, closes an
+issue or pull request, or deletes an automation branch. This validates the proposed result rather
+than the branch's old contents.
+
+## Commit and pull-request lifecycle
+
+The stable commit subject is:
+
+```text
+chore: apply tf-version-bump config
+```
+
+The pull request identifies the state branch and is looked up by exact base and head refs rather
+than title alone. Its body is refreshed on every run with:
+
+- State-branch base revision.
+- Config path.
+- Go, `tf-version-bump`, and Terraform versions.
+- Changed files.
+- Initialised and validated Terraform directories.
+- Workflow-run link.
+- A statement that the branch is automation-owned and may be regenerated.
+
+The workflow recreates the automation commit from the latest state-branch tip instead of
+accumulating obsolete generated commits or rebasing them indefinitely. The force-with-lease applies
+only to the stable automation ref. A lease mismatch fails as an automation error and does not retry
+with an unconditional force.
+
+## Failure classification and issues
+
+Failures from these stages are state-branch failures:
+
+- `tf-version-bump`
+- `terraform init -upgrade -backend=false`
+- `terraform validate`
+
+A non-dry run creates or updates one open issue per failing state branch. The issue is identified
+by an exact stable title and a machine-readable marker, not a fuzzy title search. Its body is
+replaced with the latest:
+
+- State branch and base revision.
+- Failing stage and Terraform directory, when applicable.
+- Executed command without secret values.
+- Concise tail of captured standard output and standard error.
+- Workflow-run and uploaded-log links.
+
+Full captured logs are uploaded as a workflow artefact with a branch-safe name. The issue body is
+bounded so recurring scheduled failures do not grow without limit. A successful later non-dry run
+closes the issue with a recovery comment.
+
+Authentication, GitHub API, invalid input, unsafe diff, signing, commit, push, lease, PR, issue
+reconciliation, and workflow configuration failures are automation failures. They fail the matrix
+job without creating a misleading state-validation issue. `fail-fast: false` ensures other state
+branches continue.
+
+## Authentication and permissions
+
+The caller job grants only:
+
+- `contents: write`
+- `pull-requests: write`
+- `issues: write`
+
+The default path uses the job's `GITHUB_TOKEN`. Consumers must enable the repository setting that
+permits GitHub Actions to create pull requests. Pull-request workflows generated with this token
+may require manual approval under GitHub's current recursion protection.
+
+When both GitHub App inputs are supplied, the workflow uses the GitHub-maintained App-token action
+to mint a short-lived installation token limited to the current repository and the same three
+explicit permissions. It obtains the App bot's user ID through the GitHub API and constructs the
+correct bot name and noreply address for commit attribution. App-authenticated PR activity allows
+future PR checks to run without the built-in token's approval gate.
+
+Every referenced action is pinned to an immutable commit SHA with a version comment, matching the
+repository's existing workflow convention.
+
+## Optional SSH commit signing
+
+When `commit_signing_private_key` is absent, the workflow creates the correctly attributed unsigned
+bot or App commit.
+
+When it is present, the workflow:
+
+1. Requires explicit `commit_author_name` and `commit_author_email` values.
+2. Writes the private key under the runner's temporary directory with mode `0600` without printing
+   it.
+3. Configures SSH signing only in the target repository: `gpg.format=ssh`, the temporary key path,
+   and `commit.gpgsign=true`.
+4. Derives the public key with `ssh-keygen` and constructs a temporary allowed-signers file for the
+   configured author email.
+5. Creates the commit with an explicit signature and verifies it locally before pushing.
+6. Removes the private key and allowed-signers file in an unconditional cleanup step.
+
+Signing and verification failure stops the job. There is no unsigned fallback. The documentation
+states that the signing key must work non-interactively and that its public key must be registered
+as a signing key on the GitHub account associated with the author email for GitHub to show the
+commit as verified.
+
+## Multiple Terraform root modules
+
+The example callers use `terraform_directories: .`. A consumer with multiple root modules can pass
+newline-separated paths such as:
+
+```text
+environments/network
+environments/platform
+```
+
+`tf-version-bump` still runs once for the configured repository file pattern. Terraform
+initialisation and validation then run sequentially in each root module. All roots must pass before
+the workflow publishes any commit. A failure issue names the affected root.
+
+The initial example does not run root modules in parallel within a state-branch job. Branch-level
+matrix parallelism already provides concurrency, while sequential roots keep output and failure
+attribution straightforward.
+
+## Testing strategy
+
+Implementation follows test-driven development.
+
+### Local integration tests
+
+A maintained shell test creates temporary real Git repositories and bare remotes. It exercises:
+
+- Prefix allow-lists and manual narrowing.
+- Rejection of manual widening.
+- Overlapping-prefix deduplication and deterministic ordering.
+- Branch names containing slashes.
+- No-match and invalid-path failures.
+- Successful update, initialisation, and validation with the real `tf-version-bump` binary and a
+  pinned real Terraform CLI.
+- Terraform source and lock-file staging.
+- Multi-directory success and failure attribution.
+- Dry-run isolation.
+- Rejection of unexpected changed files.
+- Stable automation-branch regeneration and explicit lease protection.
+- Signed commits, local signature verification, cleanup of key material, and signing failure.
+- Unsigned operation when no signing key is configured.
+- Obsolete no-change branch and PR payload generation.
+
+The tests do not mock `gh` or assert against invented GitHub API behaviour. Deterministic PR and
+issue payload construction is tested locally. Actual PR, issue, token, and permissions behaviour is
+covered by the real-service acceptance run.
+
+### Workflow validation
+
+The project adds a pinned `actionlint` invocation for all three example workflow files. It also
+runs `bash -n` and the integration test for both helper scripts. Existing Go tests, race detection,
+branch-automation tests, linting, and build validation remain required and must produce pristine
+output.
+
+After implementation and TDD finish, a separate test-cleanup pass reviews new tests for duplicated
+or low-value coverage.
+
+### Real-service acceptance
+
+The example README defines an acceptance procedure using a disposable GitHub repository with:
+
+- One matching non-production state branch.
+- One non-matching production branch.
+- A committed lock file and default-branch config.
+- Built-in-token and GitHub App runs.
+- Successful update, repeated idempotent update, validation failure, issue update, recovery, and
+  obsolete-PR cleanup.
+- A dry run that demonstrates no remote refs, PRs, or issues changed.
+- An optional signed run whose pushed commit is locally verified and shown as verified by GitHub
+  when the signing identity is configured correctly.
+
+The acceptance transcript is reviewed before completion is claimed.
+
+## Documentation changes
+
+`examples/github-actions/README.md` documents:
+
+- Files to copy and paths to customise.
+- Repository settings and least-privilege permissions.
+- Exact tool-version pinning.
+- Production and non-production prefix/config separation.
+- Manual narrowing and dry-run behaviour.
+- Built-in-token limitations and optional GitHub App configuration.
+- Unsigned and signed commit setup.
+- Stable branch, PR, issue, and cleanup lifecycles.
+- Single-root and multi-root configurations.
+- Backend-disabled Terraform initialisation.
+- Troubleshooting and real-service acceptance.
+
+`examples/README.md` and `docs/ADVANCED-USAGE.md` link to the GitHub Actions example and distinguish
+it from the local sequential `update-branches.sh` workflow. The root README remains concise.
+
+## Completion criteria
+
+The feature is complete when:
+
+- The three copyable workflows and two documented scripts implement this design.
+- Non-production and production examples have manual and timezone-aware scheduled triggers.
+- Dry runs perform real local updates and validation without any remote mutation.
+- Normal runs safely reconcile signed or unsigned commits, stable automation branches, PRs, and
+  failure issues.
+- Every configured Terraform root has a lock file after initialisation; new and changed lock files
+  are staged, disposable `.terraform/` data is excluded, and unexpected paths are rejected.
+- Local integration tests, pinned `actionlint`, the repository's full validation suite, and the
+  disposable-repository acceptance procedure all pass with pristine output.
+- User-facing documentation describes configuration, permissions, security boundaries, and
+  recovery behaviour without relying on unstated setup.

--- a/integration_config_test.go
+++ b/integration_config_test.go
@@ -142,7 +142,53 @@ func TestRunConfigModeTerraformAllFilesSucceed(t *testing.T) {
 	}
 }
 
-/*
+func TestRunConfigModeReportsProviderFileFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	malformedFile := filepath.Join(tmpDir, "01-malformed.tf")
+	if err := os.WriteFile(malformedFile, []byte("terraform {"), 0o644); err != nil {
+		t.Fatalf("failed to write malformed Terraform file: %v", err)
+	}
+	validFile := filepath.Join(tmpDir, "02-valid.tf")
+	if err := os.WriteFile(validFile, []byte(`terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+`), 0o644); err != nil {
+		t.Fatalf("failed to write valid Terraform file: %v", err)
+	}
+	configFile := filepath.Join(tmpDir, "updates.yml")
+	if err := os.WriteFile(configFile, []byte(`providers:
+  - name: aws
+    version: "~> 5.0"
+`), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	stdout, diagnostic, runnerErr := captureRunnerOutput(t, func() error {
+		return runConfigFileMode([]string{malformedFile, validFile}, &cliFlags{configFile: configFile, output: "text"})
+	})
+	updated, err := os.ReadFile(validFile)
+	if err != nil {
+		t.Fatalf("failed to read updated Terraform file: %v", err)
+	}
+	if !strings.Contains(string(updated), `version = "~> 5.0"`) {
+		t.Fatalf("expected valid file to be updated, got: %s", updated)
+	}
+	if !strings.Contains(diagnostic, "Error processing "+malformedFile+": failed to parse HCL:") {
+		t.Errorf("expected malformed-file diagnostic, got %q", diagnostic)
+	}
+	if !strings.Contains(stdout, "Providers: 1 update(s) applied") {
+		t.Errorf("expected existing config summary in stdout, got %q", stdout)
+	}
+	if runnerErr == nil {
+		t.Fatal("expected runner to report the malformed file failure")
+	}
+}
+
 func TestRunConfigModeProviderAllFilesSucceed(t *testing.T) {
 	tmpDir := t.TempDir()
 	files := []string{
@@ -184,8 +230,6 @@ func TestRunConfigModeProviderAllFilesSucceed(t *testing.T) {
 		t.Errorf("expected existing config summary in stdout, got %q", stdout)
 	}
 }
-
-*/
 
 // TestConfigFileWithTerraformVersion tests processing config files with terraform_version
 func TestConfigFileWithTerraformVersion(t *testing.T) {
@@ -286,7 +330,7 @@ func TestConfigFileWithMultipleProviders(t *testing.T) {
 
 	totalUpdates := 0
 	for _, provider := range config.Providers {
-		count := processProviderVersion(files, provider.Name, provider.Version, flags.dryRun, flags.output)
+		count, _ := processProviderVersion(files, provider.Name, provider.Version, flags.dryRun, flags.output)
 		totalUpdates += count
 	}
 
@@ -365,7 +409,7 @@ modules:
 	// Process providers
 	providerUpdates := 0
 	for _, provider := range config.Providers {
-		count := processProviderVersion(files, provider.Name, provider.Version, flags.dryRun, flags.output)
+		count, _ := processProviderVersion(files, provider.Name, provider.Version, flags.dryRun, flags.output)
 		providerUpdates += count
 	}
 

--- a/integration_config_test.go
+++ b/integration_config_test.go
@@ -55,7 +55,137 @@ func TestRunConfigModeReportsModuleFileFailure(t *testing.T) {
 	if runnerErr == nil {
 		t.Fatal("expected runner to report the malformed file failure")
 	}
+	if got, want := runnerErr.Error(), "1 module update error(s)"; got != want {
+		t.Errorf("module-only runner error = %q, want %q", got, want)
+	}
 }
+
+func TestRunConfigModeReportsTerraformFileFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	malformedFile := filepath.Join(tmpDir, "01-malformed.tf")
+	if err := os.WriteFile(malformedFile, []byte("terraform {"), 0o644); err != nil {
+		t.Fatalf("failed to write malformed Terraform file: %v", err)
+	}
+
+	validFile := filepath.Join(tmpDir, "02-valid.tf")
+	if err := os.WriteFile(validFile, []byte(`terraform {
+  required_version = ">= 1.0"
+}
+`), 0o644); err != nil {
+		t.Fatalf("failed to write valid Terraform file: %v", err)
+	}
+
+	configFile := filepath.Join(tmpDir, "updates.yml")
+	if err := os.WriteFile(configFile, []byte(`terraform_version: ">= 1.5"
+`), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	stdout, diagnostic, runnerErr := captureRunnerOutput(t, func() error {
+		return runConfigFileMode([]string{malformedFile, validFile}, &cliFlags{
+			configFile: configFile,
+			output:     "text",
+		})
+	})
+
+	updated, err := os.ReadFile(validFile)
+	if err != nil {
+		t.Fatalf("failed to read updated Terraform file: %v", err)
+	}
+	if !strings.Contains(string(updated), `required_version = ">= 1.5"`) {
+		t.Fatalf("expected valid file to be updated, got: %s", updated)
+	}
+
+	if !strings.Contains(diagnostic, "Error processing "+malformedFile+": failed to parse HCL:") {
+		t.Errorf("expected malformed-file diagnostic, got %q", diagnostic)
+	}
+	if !strings.Contains(stdout, "Terraform version: 1 file(s) updated") {
+		t.Errorf("expected existing config summary in stdout, got %q", stdout)
+	}
+	if runnerErr == nil {
+		t.Fatal("expected runner to report the malformed file failure")
+	}
+}
+
+func TestRunConfigModeTerraformAllFilesSucceed(t *testing.T) {
+	tmpDir := t.TempDir()
+	files := []string{
+		filepath.Join(tmpDir, "01.tf"),
+		filepath.Join(tmpDir, "02.tf"),
+	}
+	for _, file := range files {
+		if err := os.WriteFile(file, []byte(`terraform {
+  required_version = ">= 1.0"
+}
+`), 0o644); err != nil {
+			t.Fatalf("failed to write Terraform file: %v", err)
+		}
+	}
+
+	configFile := filepath.Join(tmpDir, "updates.yml")
+	if err := os.WriteFile(configFile, []byte(`terraform_version: ">= 1.5"
+`), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	stdout, diagnostic, runnerErr := captureRunnerOutput(t, func() error {
+		return runConfigFileMode(files, &cliFlags{configFile: configFile, output: "text"})
+	})
+	if runnerErr != nil {
+		t.Fatalf("expected all valid files to succeed: %v", runnerErr)
+	}
+	if diagnostic != "" {
+		t.Errorf("expected no diagnostics, got %q", diagnostic)
+	}
+	if !strings.Contains(stdout, "Terraform version: 2 file(s) updated") {
+		t.Errorf("expected existing summary in stdout, got %q", stdout)
+	}
+}
+
+/*
+func TestRunConfigModeProviderAllFilesSucceed(t *testing.T) {
+	tmpDir := t.TempDir()
+	files := []string{
+		filepath.Join(tmpDir, "01.tf"),
+		filepath.Join(tmpDir, "02.tf"),
+	}
+	for _, file := range files {
+		if err := os.WriteFile(file, []byte(`terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+`), 0o644); err != nil {
+			t.Fatalf("failed to write Terraform file: %v", err)
+		}
+	}
+
+	configFile := filepath.Join(tmpDir, "updates.yml")
+	if err := os.WriteFile(configFile, []byte(`providers:
+  - name: aws
+    version: "~> 5.0"
+`), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	stdout, diagnostic, runnerErr := captureRunnerOutput(t, func() error {
+		return runConfigFileMode(files, &cliFlags{configFile: configFile, output: "text"})
+	})
+	if runnerErr != nil {
+		t.Fatalf("expected all valid files to succeed: %v", runnerErr)
+	}
+	if diagnostic != "" {
+		t.Errorf("expected no diagnostics, got %q", diagnostic)
+	}
+	if !strings.Contains(stdout, "Providers: 2 update(s) applied") {
+		t.Errorf("expected existing config summary in stdout, got %q", stdout)
+	}
+}
+
+*/
 
 // TestConfigFileWithTerraformVersion tests processing config files with terraform_version
 func TestConfigFileWithTerraformVersion(t *testing.T) {
@@ -91,7 +221,7 @@ func TestConfigFileWithTerraformVersion(t *testing.T) {
 	files := []string{tfFile}
 	flags := &cliFlags{dryRun: false, output: "text"}
 
-	count := processTerraformVersion(files, config.TerraformVersion, flags.dryRun, flags.output)
+	count, _ := processTerraformVersion(files, config.TerraformVersion, flags.dryRun, flags.output)
 	if count != 1 {
 		t.Errorf("Expected 1 file updated, got %d", count)
 	}
@@ -229,7 +359,7 @@ modules:
 	// Process terraform version
 	terraformUpdates := 0
 	if config.TerraformVersion != "" {
-		terraformUpdates = processTerraformVersion(files, config.TerraformVersion, flags.dryRun, flags.output)
+		terraformUpdates, _ = processTerraformVersion(files, config.TerraformVersion, flags.dryRun, flags.output)
 	}
 
 	// Process providers

--- a/integration_config_test.go
+++ b/integration_config_test.go
@@ -189,6 +189,104 @@ func TestRunConfigModeReportsProviderFileFailure(t *testing.T) {
 	}
 }
 
+func TestRunConfigModeAggregatesMixedFileFailures(t *testing.T) {
+	tmpDir := t.TempDir()
+	malformedFiles := []string{
+		filepath.Join(tmpDir, "01-malformed.tf"),
+		filepath.Join(tmpDir, "02-malformed.tf"),
+	}
+	for _, file := range malformedFiles {
+		if err := os.WriteFile(file, []byte("module \"broken\" {"), 0o644); err != nil {
+			t.Fatalf("failed to write malformed Terraform file: %v", err)
+		}
+	}
+
+	validFile := filepath.Join(tmpDir, "03-valid.tf")
+	if err := os.WriteFile(validFile, []byte(`terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.0.0"
+}
+
+module "ec2" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "4.0.0"
+}
+`), 0o644); err != nil {
+		t.Fatalf("failed to write valid Terraform file: %v", err)
+	}
+
+	configFile := filepath.Join(tmpDir, "updates.yml")
+	if err := os.WriteFile(configFile, []byte(`terraform_version: ">= 1.6"
+providers:
+  - name: aws
+    version: "~> 5.0"
+  - name: azurerm
+    version: "~> 4.0"
+modules:
+  - source: terraform-aws-modules/vpc/aws
+    version: 5.0.0
+  - source: terraform-aws-modules/ec2-instance/aws
+    version: 6.0.0
+`), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	files := []string{malformedFiles[0], malformedFiles[1], validFile}
+	stdout, diagnostic, runnerErr := captureRunnerOutput(t, func() error {
+		return runConfigFileMode(files, &cliFlags{configFile: configFile, output: "text"})
+	})
+
+	updated, err := os.ReadFile(validFile)
+	if err != nil {
+		t.Fatalf("failed to read updated Terraform file: %v", err)
+	}
+	updatedText := string(updated)
+	for _, want := range []string{
+		`required_version = ">= 1.6"`,
+		`version = "~> 5.0"`,
+		`version = "~> 4.0"`,
+		`source  = "terraform-aws-modules/vpc/aws"
+  version = "5.0.0"`,
+		`source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "6.0.0"`,
+	} {
+		if !strings.Contains(updatedText, want) {
+			t.Errorf("expected valid file to contain %q, got: %s", want, updatedText)
+		}
+	}
+
+	diagnosticLines := strings.Split(strings.TrimSuffix(diagnostic, "\n"), "\n")
+	if got, want := len(diagnosticLines), 10; got != want {
+		t.Errorf("diagnostic count = %d, want %d; diagnostics: %q", got, want, diagnostic)
+	}
+	if !strings.Contains(stdout, "Terraform version: 1 file(s) updated") ||
+		!strings.Contains(stdout, "Providers: 2 update(s) applied") ||
+		!strings.Contains(stdout, "Modules: 2 file(s) updated") {
+		t.Errorf("expected mixed config summary in stdout, got %q", stdout)
+	}
+	if runnerErr == nil {
+		t.Fatal("expected runner to report aggregate file failures")
+	}
+	if got, want := runnerErr.Error(), "10 update error(s)"; got != want {
+		t.Errorf("aggregate runner error = %q, want %q", got, want)
+	}
+}
+
 func TestRunConfigModeProviderAllFilesSucceed(t *testing.T) {
 	tmpDir := t.TempDir()
 	files := []string{

--- a/integration_config_test.go
+++ b/integration_config_test.go
@@ -7,6 +7,56 @@ import (
 	"testing"
 )
 
+func TestRunConfigModeReportsModuleFileFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	malformedFile := filepath.Join(tmpDir, "01-malformed.tf")
+	if err := os.WriteFile(malformedFile, []byte("module \"broken\" {"), 0o644); err != nil {
+		t.Fatalf("failed to write malformed Terraform file: %v", err)
+	}
+
+	validFile := filepath.Join(tmpDir, "02-valid.tf")
+	if err := os.WriteFile(validFile, []byte(`module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.0.0"
+}
+`), 0o644); err != nil {
+		t.Fatalf("failed to write valid Terraform file: %v", err)
+	}
+
+	configFile := filepath.Join(tmpDir, "updates.yml")
+	if err := os.WriteFile(configFile, []byte(`modules:
+  - source: terraform-aws-modules/vpc/aws
+    version: 5.0.0
+`), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	stdout, diagnostic, runnerErr := captureRunnerOutput(t, func() error {
+		return runConfigFileMode([]string{malformedFile, validFile}, &cliFlags{
+			configFile: configFile,
+			output:     "text",
+		})
+	})
+
+	updated, err := os.ReadFile(validFile)
+	if err != nil {
+		t.Fatalf("failed to read updated Terraform file: %v", err)
+	}
+	if !strings.Contains(string(updated), `version = "5.0.0"`) {
+		t.Fatalf("expected valid file to be updated, got: %s", updated)
+	}
+
+	if got, want := diagnostic, "Error processing "+malformedFile+": failed to parse HCL: "+malformedFile+":1,17-18: Unclosed configuration block; There is no closing brace for this block before the end of the file. This may be caused by incorrect brace nesting elsewhere in this file.\n"; got != want {
+		t.Errorf("malformed-file diagnostic = %q, want %q", got, want)
+	}
+	if !strings.Contains(stdout, "Modules: 1 file(s) updated") {
+		t.Errorf("expected existing config summary in stdout, got %q", stdout)
+	}
+	if runnerErr == nil {
+		t.Fatal("expected runner to report the malformed file failure")
+	}
+}
+
 // TestConfigFileWithTerraformVersion tests processing config files with terraform_version
 func TestConfigFileWithTerraformVersion(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -192,7 +242,7 @@ modules:
 	// Process modules
 	moduleUpdates := 0
 	if len(config.Modules) > 0 {
-		moduleUpdates = processFiles(files, config.Modules, flags)
+		moduleUpdates, _ = processFiles(files, config.Modules, flags)
 	}
 
 	// Verify counts

--- a/main.go
+++ b/main.go
@@ -352,8 +352,8 @@ func findMatchingFiles(flags *cliFlags) []string {
 func runConfigFileMode(files []string, flags *cliFlags) error {
 	config, err := loadConfig(flags.configFile)
 	if err != nil {
-		fatalf("Error loading config file: %v", err)
-		return nil
+		//nolint:staticcheck // The capitalised prefix is user-facing CLI output.
+		return fmt.Errorf("Error loading config file: %w", err)
 	}
 
 	var terraformUpdates, terraformErrors, providerUpdates, providerErrors, moduleUpdates, moduleErrors int

--- a/main.go
+++ b/main.go
@@ -235,12 +235,14 @@ func main() {
 	files := findMatchingFiles(flags)
 
 	// Run the appropriate operation mode
+	var err error
 	if flags.configFile != "" {
-		// Task 3 will convert runner errors into the process exit status.
-		_ = runConfigFileMode(files, flags)
+		err = runConfigFileMode(files, flags)
 	} else {
-		// Task 3 will convert runner errors into the process exit status.
-		_ = runCLIMode(files, flags)
+		err = runCLIMode(files, flags)
+	}
+	if err != nil {
+		fatalf("%v", err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -354,11 +354,11 @@ func runConfigFileMode(files []string, flags *cliFlags) error {
 		return nil
 	}
 
-	var terraformUpdates, providerUpdates, moduleUpdates, moduleErrors int
+	var terraformUpdates, terraformErrors, providerUpdates, moduleUpdates, moduleErrors int
 
 	// Process terraform version if specified
 	if config.TerraformVersion != "" {
-		terraformUpdates = processTerraformVersion(files, config.TerraformVersion, flags.dryRun, flags.output)
+		terraformUpdates, terraformErrors = processTerraformVersion(files, config.TerraformVersion, flags.dryRun, flags.output)
 	}
 
 	// Process provider updates if specified
@@ -374,8 +374,11 @@ func runConfigFileMode(files []string, flags *cliFlags) error {
 
 	// Print summary
 	printConfigSummary(terraformUpdates, providerUpdates, moduleUpdates)
-	if moduleErrors > 0 {
+	if terraformErrors == 0 && moduleErrors > 0 {
 		return fmt.Errorf("%d module update error(s)", moduleErrors)
+	}
+	if totalErrors := terraformErrors + moduleErrors; totalErrors > 0 {
+		return fmt.Errorf("%d update error(s)", totalErrors)
 	}
 	return nil
 }
@@ -387,8 +390,12 @@ func runCLIMode(files []string, flags *cliFlags) error {
 
 	switch {
 	case flags.terraformVersion != "":
-		totalUpdates = processTerraformVersion(files, flags.terraformVersion, flags.dryRun, flags.output)
+		var totalErrors int
+		totalUpdates, totalErrors = processTerraformVersion(files, flags.terraformVersion, flags.dryRun, flags.output)
 		printTerraformSummary(totalUpdates, flags.dryRun)
+		if totalErrors > 0 {
+			return fmt.Errorf("%d Terraform version update error(s)", totalErrors)
+		}
 		return nil
 	case flags.providerName != "":
 		if flags.toVersion == "" {
@@ -474,13 +481,14 @@ func containsVersion(versions []string, version string) bool {
 //   - outputFormat: Output format ("text" or "md")
 //
 // Returns:
-//   - int: Number of files that were updated (or would be updated in dry-run mode)
-func processTerraformVersion(files []string, version string, dryRun bool, outputFormat string) int {
-	totalUpdates := 0
+//   - totalUpdates: Number of files that were updated (or would be updated in dry-run mode)
+//   - totalErrors: Number of files that could not be processed
+func processTerraformVersion(files []string, version string, dryRun bool, outputFormat string) (totalUpdates, totalErrors int) {
 	for _, file := range files {
 		updated, err := updateTerraformVersion(file, version, dryRun)
 		if err != nil {
 			log.Printf("Error processing %s: %v", file, err)
+			totalErrors++
 			continue
 		}
 		if updated {
@@ -494,7 +502,7 @@ func processTerraformVersion(files []string, version string, dryRun bool, output
 			totalUpdates++
 		}
 	}
-	return totalUpdates
+	return totalUpdates, totalErrors
 }
 
 // processProviderVersion updates provider versions in terraform required_providers blocks across all files

--- a/main.go
+++ b/main.go
@@ -354,7 +354,7 @@ func runConfigFileMode(files []string, flags *cliFlags) error {
 		return nil
 	}
 
-	var terraformUpdates, terraformErrors, providerUpdates, moduleUpdates, moduleErrors int
+	var terraformUpdates, terraformErrors, providerUpdates, providerErrors, moduleUpdates, moduleErrors int
 
 	// Process terraform version if specified
 	if config.TerraformVersion != "" {
@@ -363,8 +363,9 @@ func runConfigFileMode(files []string, flags *cliFlags) error {
 
 	// Process provider updates if specified
 	for _, provider := range config.Providers {
-		count := processProviderVersion(files, provider.Name, provider.Version, flags.dryRun, flags.output)
+		count, errors := processProviderVersion(files, provider.Name, provider.Version, flags.dryRun, flags.output)
 		providerUpdates += count
+		providerErrors += errors
 	}
 
 	// Process module updates if specified
@@ -374,10 +375,10 @@ func runConfigFileMode(files []string, flags *cliFlags) error {
 
 	// Print summary
 	printConfigSummary(terraformUpdates, providerUpdates, moduleUpdates)
-	if terraformErrors == 0 && moduleErrors > 0 {
+	if terraformErrors == 0 && providerErrors == 0 && moduleErrors > 0 {
 		return fmt.Errorf("%d module update error(s)", moduleErrors)
 	}
-	if totalErrors := terraformErrors + moduleErrors; totalErrors > 0 {
+	if totalErrors := terraformErrors + providerErrors + moduleErrors; totalErrors > 0 {
 		return fmt.Errorf("%d update error(s)", totalErrors)
 	}
 	return nil
@@ -401,8 +402,12 @@ func runCLIMode(files []string, flags *cliFlags) error {
 		if flags.toVersion == "" {
 			fatalf("Error: -to flag is required when using -provider")
 		}
-		totalUpdates = processProviderVersion(files, flags.providerName, flags.toVersion, flags.dryRun, flags.output)
+		var totalErrors int
+		totalUpdates, totalErrors = processProviderVersion(files, flags.providerName, flags.toVersion, flags.dryRun, flags.output)
 		printProviderSummary(flags.providerName, totalUpdates, flags.dryRun, flags.output)
+		if totalErrors > 0 {
+			return fmt.Errorf("%d provider update error(s)", totalErrors)
+		}
 		return nil
 	default:
 		updates = loadModuleUpdates(flags)
@@ -515,13 +520,14 @@ func processTerraformVersion(files []string, version string, dryRun bool, output
 //   - outputFormat: Output format ("text" or "md")
 //
 // Returns:
-//   - int: Number of files that were updated (or would be updated in dry-run mode)
-func processProviderVersion(files []string, providerName, version string, dryRun bool, outputFormat string) int {
-	totalUpdates := 0
+//   - totalUpdates: Number of files that were updated (or would be updated in dry-run mode)
+//   - totalErrors: Number of files that could not be processed
+func processProviderVersion(files []string, providerName, version string, dryRun bool, outputFormat string) (totalUpdates, totalErrors int) {
 	for _, file := range files {
 		updated, err := updateProviderVersion(file, providerName, version, dryRun)
 		if err != nil {
 			log.Printf("Error processing %s: %v", file, err)
+			totalErrors++
 			continue
 		}
 		if updated {
@@ -535,7 +541,7 @@ func processProviderVersion(files []string, providerName, version string, dryRun
 			totalUpdates++
 		}
 	}
-	return totalUpdates
+	return totalUpdates, totalErrors
 }
 
 // updateTerraformVersion updates the required_version attribute in terraform blocks

--- a/main.go
+++ b/main.go
@@ -171,14 +171,14 @@ func loadModuleUpdates(flags *cliFlags) []ModuleUpdate {
 	}
 }
 
-// processFiles processes all matching files and applies module updates
-func processFiles(files []string, updates []ModuleUpdate, flags *cliFlags) int {
-	totalUpdates := 0
+// processFiles processes all matching files and applies module updates.
+func processFiles(files []string, updates []ModuleUpdate, flags *cliFlags) (totalUpdates, totalErrors int) {
 	for _, file := range files {
 		for _, update := range updates {
 			updated, err := updateModuleVersion(file, update.Source, update.Version, update.From, update.IgnoreVersions, update.IgnoreModules, flags.forceAdd, flags.dryRun, flags.verbose, flags.output)
 			if err != nil {
 				log.Printf("Error processing %s: %v", file, err)
+				totalErrors++
 				continue
 			}
 			if updated {
@@ -197,7 +197,7 @@ func processFiles(files []string, updates []ModuleUpdate, flags *cliFlags) int {
 			}
 		}
 	}
-	return totalUpdates
+	return totalUpdates, totalErrors
 }
 
 // printSummary prints the final summary of updates
@@ -236,9 +236,11 @@ func main() {
 
 	// Run the appropriate operation mode
 	if flags.configFile != "" {
-		runConfigFileMode(files, flags)
+		// Task 3 will convert runner errors into the process exit status.
+		_ = runConfigFileMode(files, flags)
 	} else {
-		runCLIMode(files, flags)
+		// Task 3 will convert runner errors into the process exit status.
+		_ = runCLIMode(files, flags)
 	}
 }
 
@@ -344,14 +346,15 @@ func findMatchingFiles(flags *cliFlags) []string {
 	return files
 }
 
-// runConfigFileMode handles config file mode operations
-func runConfigFileMode(files []string, flags *cliFlags) {
+// runConfigFileMode handles config file mode operations.
+func runConfigFileMode(files []string, flags *cliFlags) error {
 	config, err := loadConfig(flags.configFile)
 	if err != nil {
 		fatalf("Error loading config file: %v", err)
+		return nil
 	}
 
-	var terraformUpdates, providerUpdates, moduleUpdates int
+	var terraformUpdates, providerUpdates, moduleUpdates, moduleErrors int
 
 	// Process terraform version if specified
 	if config.TerraformVersion != "" {
@@ -366,15 +369,19 @@ func runConfigFileMode(files []string, flags *cliFlags) {
 
 	// Process module updates if specified
 	if len(config.Modules) > 0 {
-		moduleUpdates = processFiles(files, config.Modules, flags)
+		moduleUpdates, moduleErrors = processFiles(files, config.Modules, flags)
 	}
 
 	// Print summary
 	printConfigSummary(terraformUpdates, providerUpdates, moduleUpdates)
+	if moduleErrors > 0 {
+		return fmt.Errorf("%d module update error(s)", moduleErrors)
+	}
+	return nil
 }
 
 // runCLIMode handles CLI mode operations
-func runCLIMode(files []string, flags *cliFlags) {
+func runCLIMode(files []string, flags *cliFlags) error {
 	var totalUpdates int
 	var updates []ModuleUpdate
 
@@ -382,16 +389,23 @@ func runCLIMode(files []string, flags *cliFlags) {
 	case flags.terraformVersion != "":
 		totalUpdates = processTerraformVersion(files, flags.terraformVersion, flags.dryRun, flags.output)
 		printTerraformSummary(totalUpdates, flags.dryRun)
+		return nil
 	case flags.providerName != "":
 		if flags.toVersion == "" {
 			fatalf("Error: -to flag is required when using -provider")
 		}
 		totalUpdates = processProviderVersion(files, flags.providerName, flags.toVersion, flags.dryRun, flags.output)
 		printProviderSummary(flags.providerName, totalUpdates, flags.dryRun, flags.output)
+		return nil
 	default:
 		updates = loadModuleUpdates(flags)
-		totalUpdates = processFiles(files, updates, flags)
+		var totalErrors int
+		totalUpdates, totalErrors = processFiles(files, updates, flags)
 		printSummary(totalUpdates, len(updates), flags.dryRun)
+		if totalErrors > 0 {
+			return fmt.Errorf("%d module update error(s)", totalErrors)
+		}
+		return nil
 	}
 }
 

--- a/main_coverage_test.go
+++ b/main_coverage_test.go
@@ -49,6 +49,75 @@ func withFlagArgs(t *testing.T, args []string, fn func()) {
 	fn()
 }
 
+type commandResult struct {
+	stdout      string
+	diagnostics string
+	exitCode    int
+}
+
+func runMainCommand(t *testing.T, args []string) commandResult {
+	t.Helper()
+
+	restoreExit, code := stubExit(t)
+	defer restoreExit()
+
+	var diagnostics bytes.Buffer
+	originalLogWriter := log.Writer()
+	originalLogFlags := log.Flags()
+	originalLogPrefix := log.Prefix()
+	log.SetOutput(&diagnostics)
+	log.SetFlags(0)
+	log.SetPrefix("")
+	defer func() {
+		log.SetOutput(originalLogWriter)
+		log.SetFlags(originalLogFlags)
+		log.SetPrefix(originalLogPrefix)
+	}()
+
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdout pipe: %v", err)
+	}
+	defer func() {
+		if err := stdoutReader.Close(); err != nil {
+			t.Errorf("failed to close stdout reader: %v", err)
+		}
+	}()
+
+	originalStdout := os.Stdout
+	os.Stdout = stdoutWriter
+	defer func() { os.Stdout = originalStdout }()
+
+	var stdout bytes.Buffer
+	stdoutDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&stdout, stdoutReader)
+		close(stdoutDone)
+	}()
+
+	withFlagArgs(t, args, func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				if _, ok := recovered.(exitCall); !ok {
+					panic(recovered)
+				}
+			}
+		}()
+		main()
+	})
+
+	if err := stdoutWriter.Close(); err != nil {
+		t.Fatalf("failed to close stdout writer: %v", err)
+	}
+	<-stdoutDone
+
+	return commandResult{
+		stdout:      stdout.String(),
+		diagnostics: diagnostics.String(),
+		exitCode:    *code,
+	}
+}
+
 func TestParseFlagsInvalidOutput(t *testing.T) {
 	restoreExit, code := stubExit(t)
 	defer restoreExit()
@@ -194,23 +263,7 @@ func TestMainConfigFilePath(t *testing.T) {
 	}
 }
 
-func TestCommandReportsAggregateFileFailure(t *testing.T) {
-	restoreExit, code := stubExit(t)
-	defer restoreExit()
-
-	var diagnostics bytes.Buffer
-	originalLogWriter := log.Writer()
-	originalLogFlags := log.Flags()
-	originalLogPrefix := log.Prefix()
-	log.SetOutput(&diagnostics)
-	log.SetFlags(0)
-	log.SetPrefix("")
-	defer func() {
-		log.SetOutput(originalLogWriter)
-		log.SetFlags(originalLogFlags)
-		log.SetPrefix(originalLogPrefix)
-	}()
-
+func TestCommandCLIReportsAggregateFileFailure(t *testing.T) {
 	tmpDir := t.TempDir()
 	malformedFile := filepath.Join(tmpDir, "01-malformed.tf")
 	if err := os.WriteFile(malformedFile, []byte("!!!\n"), 0o644); err != nil {
@@ -221,59 +274,76 @@ func TestCommandReportsAggregateFileFailure(t *testing.T) {
 		t.Fatalf("failed to write valid Terraform file: %v", err)
 	}
 
-	stdoutReader, stdoutWriter, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("failed to create stdout pipe: %v", err)
-	}
-	defer func() {
-		if err := stdoutReader.Close(); err != nil {
-			t.Errorf("failed to close stdout reader: %v", err)
-		}
-	}()
-	originalStdout := os.Stdout
-	os.Stdout = stdoutWriter
-	defer func() { os.Stdout = originalStdout }()
-	var stdout bytes.Buffer
-	stdoutDone := make(chan struct{})
-	go func() {
-		_, _ = io.Copy(&stdout, stdoutReader)
-		close(stdoutDone)
-	}()
-
-	withFlagArgs(t, []string{
+	result := runMainCommand(t, []string{
 		"tf-version-bump",
 		"-pattern", filepath.Join(tmpDir, "*.tf"),
 		"-module", "example/module",
 		"-to", "2.0.0",
-	}, func() {
-		defer func() {
-			if recovered := recover(); recovered != nil {
-				if _, ok := recovered.(exitCall); !ok {
-					panic(recovered)
-				}
-			}
-		}()
-		main()
 	})
-	if err := stdoutWriter.Close(); err != nil {
-		t.Fatalf("failed to close stdout writer: %v", err)
-	}
-	<-stdoutDone
 
 	wantStdout := "Found 2 file(s) matching pattern '" + filepath.Join(tmpDir, "*.tf") + "'\n" +
 		"✓ Updated module source 'example/module' to version '2.0.0' in " + validFile + "\n" +
 		"\nSuccessfully updated 1 file(s)\n"
-	if got := stdout.String(); got != wantStdout {
-		t.Errorf("stdout = %q, want %q", got, wantStdout)
+	if result.stdout != wantStdout {
+		t.Errorf("stdout = %q, want %q", result.stdout, wantStdout)
 	}
 
 	wantDiagnostic := "Error processing " + malformedFile + ": failed to parse HCL: " + malformedFile + ":1,1-2: Argument or block definition required; An argument or block definition is required here.\n" +
 		"1 module update error(s)\n"
-	if got := diagnostics.String(); got != wantDiagnostic {
-		t.Errorf("stderr = %q, want %q", got, wantDiagnostic)
+	if result.diagnostics != wantDiagnostic {
+		t.Errorf("stderr = %q, want %q", result.diagnostics, wantDiagnostic)
 	}
-	if *code != 1 {
-		t.Fatalf("expected exit code 1, got %d", *code)
+	if result.exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", result.exitCode)
+	}
+
+	contents, err := os.ReadFile(validFile)
+	if err != nil {
+		t.Fatalf("failed to read valid Terraform file: %v", err)
+	}
+	if !strings.Contains(string(contents), `version = "2.0.0"`) {
+		t.Fatalf("expected later valid file to update, got %q", contents)
+	}
+}
+
+func TestCommandConfigReportsAggregateFileFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	malformedFile := filepath.Join(tmpDir, "01-malformed.tf")
+	if err := os.WriteFile(malformedFile, []byte("!!!\n"), 0o644); err != nil {
+		t.Fatalf("failed to write malformed Terraform file: %v", err)
+	}
+	validFile := filepath.Join(tmpDir, "02-valid.tf")
+	if err := os.WriteFile(validFile, []byte("module \"example\" {\n  source  = \"example/module\"\n  version = \"1.0.0\"\n}\n"), 0o644); err != nil {
+		t.Fatalf("failed to write valid Terraform file: %v", err)
+	}
+	configFile := filepath.Join(tmpDir, "updates.yml")
+	if err := os.WriteFile(configFile, []byte("modules:\n  - source: example/module\n    version: 2.0.0\n"), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	result := runMainCommand(t, []string{
+		"tf-version-bump",
+		"-pattern", filepath.Join(tmpDir, "*.tf"),
+		"-config", configFile,
+	})
+
+	wantStdout := "Found 2 file(s) matching pattern '" + filepath.Join(tmpDir, "*.tf") + "'\n" +
+		"✓ Updated module source 'example/module' to version '2.0.0' in " + validFile + "\n" +
+		"\n==================================================\n" +
+		"Config File Update Summary\n" +
+		"==================================================\n" +
+		"Modules: 1 file(s) updated\n"
+	if result.stdout != wantStdout {
+		t.Errorf("stdout = %q, want %q", result.stdout, wantStdout)
+	}
+
+	wantDiagnostic := "Error processing " + malformedFile + ": failed to parse HCL: " + malformedFile + ":1,1-2: Argument or block definition required; An argument or block definition is required here.\n" +
+		"1 module update error(s)\n"
+	if result.diagnostics != wantDiagnostic {
+		t.Errorf("stderr = %q, want %q", result.diagnostics, wantDiagnostic)
+	}
+	if result.exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", result.exitCode)
 	}
 
 	contents, err := os.ReadFile(validFile)

--- a/main_coverage_test.go
+++ b/main_coverage_test.go
@@ -129,7 +129,7 @@ func TestMainExecutionPath(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	tfFile := filepath.Join(tmpDir, "main.tf")
-	if err := os.WriteFile(tfFile, []byte(`module "example" { source = "example/module" version = "1.0.0" }`), 0o644); err != nil {
+	if err := os.WriteFile(tfFile, []byte("module \"example\" {\n  source  = \"example/module\"\n  version = \"1.0.0\"\n}\n"), 0o644); err != nil {
 		t.Fatalf("failed to write terraform file: %v", err)
 	}
 
@@ -190,6 +190,67 @@ func TestMainConfigFilePath(t *testing.T) {
 
 	if *code != -1 {
 		t.Fatalf("unexpected exit code recorded: %d", *code)
+	}
+}
+
+func TestCommandReportsAggregateFileFailure(t *testing.T) {
+	restoreExit, code := stubExit(t)
+	defer restoreExit()
+
+	var diagnostics bytes.Buffer
+	originalLogWriter := log.Writer()
+	originalLogFlags := log.Flags()
+	originalLogPrefix := log.Prefix()
+	log.SetOutput(&diagnostics)
+	log.SetFlags(0)
+	log.SetPrefix("")
+	defer func() {
+		log.SetOutput(originalLogWriter)
+		log.SetFlags(originalLogFlags)
+		log.SetPrefix(originalLogPrefix)
+	}()
+
+	tmpDir := t.TempDir()
+	malformedFile := filepath.Join(tmpDir, "01-malformed.tf")
+	if err := os.WriteFile(malformedFile, []byte("!!!\n"), 0o644); err != nil {
+		t.Fatalf("failed to write malformed Terraform file: %v", err)
+	}
+	validFile := filepath.Join(tmpDir, "02-valid.tf")
+	if err := os.WriteFile(validFile, []byte("module \"example\" {\n  source  = \"example/module\"\n  version = \"1.0.0\"\n}\n"), 0o644); err != nil {
+		t.Fatalf("failed to write valid Terraform file: %v", err)
+	}
+
+	withFlagArgs(t, []string{
+		"tf-version-bump",
+		"-pattern", filepath.Join(tmpDir, "*.tf"),
+		"-module", "example/module",
+		"-to", "2.0.0",
+	}, func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				if _, ok := recovered.(exitCall); !ok {
+					panic(recovered)
+				}
+			}
+		}()
+		main()
+	})
+
+	wantDiagnostic := "Error processing " + malformedFile + ": failed to parse HCL: " + malformedFile + ":1,1-2: Argument or block definition required; An argument or block definition is required here."
+	diagnosticLines := strings.Split(strings.TrimSuffix(diagnostics.String(), "\n"), "\n")
+	if len(diagnosticLines) == 0 || diagnosticLines[0] != wantDiagnostic {
+		t.Fatalf("expected first diagnostic %q, got %q", wantDiagnostic, diagnostics.String())
+	}
+	if *code != 1 {
+		t.Fatalf("expected exit code 1, got %d", *code)
+	}
+
+	contents, err := os.ReadFile(validFile)
+	if err != nil {
+		t.Fatalf("failed to read valid Terraform file: %v", err)
+	}
+	if !strings.Contains(string(contents), `version = "2.0.0"`) {
+		t.Fatalf("expected later valid file to update, got %q", contents)
 	}
 }
 

--- a/main_coverage_test.go
+++ b/main_coverage_test.go
@@ -310,7 +310,7 @@ func TestRunConfigFileModeLoadError(t *testing.T) {
 	log.SetOutput(io.Discard)
 
 	defer func() { _ = recover() }()
-	runConfigFileMode(nil, &cliFlags{configFile: "does-not-exist"})
+	_ = runConfigFileMode(nil, &cliFlags{configFile: "does-not-exist"})
 	if *code != 1 {
 		t.Fatalf("expected exit code 1, got %d", *code)
 	}
@@ -322,7 +322,7 @@ func TestRunCLIModeProviderMissingVersion(t *testing.T) {
 	log.SetOutput(io.Discard)
 
 	defer func() { _ = recover() }()
-	runCLIMode(nil, &cliFlags{providerName: "aws"})
+	_ = runCLIMode(nil, &cliFlags{providerName: "aws"})
 	if *code != 1 {
 		t.Fatalf("expected exit code 1, got %d", *code)
 	}

--- a/main_coverage_test.go
+++ b/main_coverage_test.go
@@ -220,6 +220,25 @@ func TestCommandReportsAggregateFileFailure(t *testing.T) {
 		t.Fatalf("failed to write valid Terraform file: %v", err)
 	}
 
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdout pipe: %v", err)
+	}
+	defer func() {
+		if err := stdoutReader.Close(); err != nil {
+			t.Errorf("failed to close stdout reader: %v", err)
+		}
+	}()
+	originalStdout := os.Stdout
+	os.Stdout = stdoutWriter
+	defer func() { os.Stdout = originalStdout }()
+	var stdout bytes.Buffer
+	stdoutDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&stdout, stdoutReader)
+		close(stdoutDone)
+	}()
+
 	withFlagArgs(t, []string{
 		"tf-version-bump",
 		"-pattern", filepath.Join(tmpDir, "*.tf"),
@@ -235,11 +254,22 @@ func TestCommandReportsAggregateFileFailure(t *testing.T) {
 		}()
 		main()
 	})
+	if err := stdoutWriter.Close(); err != nil {
+		t.Fatalf("failed to close stdout writer: %v", err)
+	}
+	<-stdoutDone
 
-	wantDiagnostic := "Error processing " + malformedFile + ": failed to parse HCL: " + malformedFile + ":1,1-2: Argument or block definition required; An argument or block definition is required here."
-	diagnosticLines := strings.Split(strings.TrimSuffix(diagnostics.String(), "\n"), "\n")
-	if len(diagnosticLines) == 0 || diagnosticLines[0] != wantDiagnostic {
-		t.Fatalf("expected first diagnostic %q, got %q", wantDiagnostic, diagnostics.String())
+	wantStdout := "Found 2 file(s) matching pattern '" + filepath.Join(tmpDir, "*.tf") + "'\n" +
+		"✓ Updated module source 'example/module' to version '2.0.0' in " + validFile + "\n" +
+		"\nSuccessfully updated 1 file(s)\n"
+	if got := stdout.String(); got != wantStdout {
+		t.Errorf("stdout = %q, want %q", got, wantStdout)
+	}
+
+	wantDiagnostic := "Error processing " + malformedFile + ": failed to parse HCL: " + malformedFile + ":1,1-2: Argument or block definition required; An argument or block definition is required here.\n" +
+		"1 module update error(s)\n"
+	if got := diagnostics.String(); got != wantDiagnostic {
+		t.Errorf("stderr = %q, want %q", got, wantDiagnostic)
 	}
 	if *code != 1 {
 		t.Fatalf("expected exit code 1, got %d", *code)

--- a/main_coverage_test.go
+++ b/main_coverage_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"io"
 	"log"
@@ -395,15 +396,32 @@ func TestFindMatchingFilesDryRunMessage(t *testing.T) {
 	}
 }
 
-func TestRunConfigFileModeLoadError(t *testing.T) {
+func TestRunConfigFileModeReturnsLoadError(t *testing.T) {
 	restoreExit, code := stubExit(t)
 	defer restoreExit()
 	log.SetOutput(io.Discard)
 
-	defer func() { _ = recover() }()
-	_ = runConfigFileMode(nil, &cliFlags{configFile: "does-not-exist"})
-	if *code != 1 {
-		t.Fatalf("expected exit code 1, got %d", *code)
+	var gotErr error
+	var recovered interface{}
+	func() {
+		defer func() { recovered = recover() }()
+		gotErr = runConfigFileMode(nil, &cliFlags{configFile: "does-not-exist"})
+	}()
+
+	if recovered != nil {
+		t.Fatalf("runConfigFileMode exited instead of returning an error: %v", recovered)
+	}
+	if *code != -1 {
+		t.Fatalf("runConfigFileMode exited with code %d", *code)
+	}
+	if gotErr == nil {
+		t.Fatal("expected config load error")
+	}
+	if !strings.Contains(gotErr.Error(), "Error loading config file: failed to read config file:") {
+		t.Fatalf("unexpected error: %v", gotErr)
+	}
+	if !errors.Is(gotErr, os.ErrNotExist) {
+		t.Fatalf("expected wrapped file-not-found error, got: %v", gotErr)
 	}
 }
 

--- a/main_coverage_test.go
+++ b/main_coverage_test.go
@@ -83,6 +83,7 @@ func runMainCommand(t *testing.T, args []string) commandResult {
 			t.Errorf("failed to close stdout reader: %v", err)
 		}
 	}()
+	defer func() { _ = stdoutWriter.Close() }()
 
 	originalStdout := os.Stdout
 	os.Stdout = stdoutWriter
@@ -263,7 +264,7 @@ func TestMainConfigFilePath(t *testing.T) {
 	}
 }
 
-func TestCommandCLIReportsAggregateFileFailure(t *testing.T) {
+func TestCommandReportsAggregateFileFailureCLI(t *testing.T) {
 	tmpDir := t.TempDir()
 	malformedFile := filepath.Join(tmpDir, "01-malformed.tf")
 	if err := os.WriteFile(malformedFile, []byte("!!!\n"), 0o644); err != nil {
@@ -306,7 +307,7 @@ func TestCommandCLIReportsAggregateFileFailure(t *testing.T) {
 	}
 }
 
-func TestCommandConfigReportsAggregateFileFailure(t *testing.T) {
+func TestCommandReportsAggregateFileFailureConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	malformedFile := filepath.Join(tmpDir, "01-malformed.tf")
 	if err := os.WriteFile(malformedFile, []byte("!!!\n"), 0o644); err != nil {

--- a/main_integration_test.go
+++ b/main_integration_test.go
@@ -1,11 +1,98 @@
 package main
 
 import (
+	"bytes"
+	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func captureRunnerOutput(t *testing.T, run func() error) (stdout, diagnostic string, runnerErr error) {
+	t.Helper()
+
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdout pipe: %v", err)
+	}
+	defer func() {
+		if err := stdoutReader.Close(); err != nil {
+			t.Errorf("failed to close stdout reader: %v", err)
+		}
+	}()
+
+	originalStdout := os.Stdout
+	os.Stdout = stdoutWriter
+	defer func() { os.Stdout = originalStdout }()
+
+	originalLogOutput := log.Writer()
+	originalLogFlags := log.Flags()
+	var logOutput bytes.Buffer
+	log.SetOutput(&logOutput)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(originalLogOutput)
+		log.SetFlags(originalLogFlags)
+	}()
+
+	runnerErr = run()
+
+	if err := stdoutWriter.Close(); err != nil {
+		t.Fatalf("failed to close stdout writer: %v", err)
+	}
+	output, err := io.ReadAll(stdoutReader)
+	if err != nil {
+		t.Fatalf("failed to read stdout: %v", err)
+	}
+
+	return string(output), logOutput.String(), runnerErr
+}
+
+func TestRunCLIModeReportsModuleFileFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	malformedFile := filepath.Join(tmpDir, "01-malformed.tf")
+	if err := os.WriteFile(malformedFile, []byte("module \"broken\" {"), 0o644); err != nil {
+		t.Fatalf("failed to write malformed Terraform file: %v", err)
+	}
+
+	validFile := filepath.Join(tmpDir, "02-valid.tf")
+	if err := os.WriteFile(validFile, []byte(`module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.0.0"
+}
+`), 0o644); err != nil {
+		t.Fatalf("failed to write valid Terraform file: %v", err)
+	}
+
+	stdout, diagnostic, runnerErr := captureRunnerOutput(t, func() error {
+		return runCLIMode([]string{malformedFile, validFile}, &cliFlags{
+			pattern:      "*.tf",
+			moduleSource: "terraform-aws-modules/vpc/aws",
+			toVersion:    "5.0.0",
+			output:       "text",
+		})
+	})
+
+	updated, err := os.ReadFile(validFile)
+	if err != nil {
+		t.Fatalf("failed to read updated Terraform file: %v", err)
+	}
+	if !strings.Contains(string(updated), `version = "5.0.0"`) {
+		t.Fatalf("expected valid file to be updated, got: %s", updated)
+	}
+
+	if got, want := diagnostic, "Error processing "+malformedFile+": failed to parse HCL: "+malformedFile+":1,17-18: Unclosed configuration block; There is no closing brace for this block before the end of the file. This may be caused by incorrect brace nesting elsewhere in this file.\n"; got != want {
+		t.Errorf("malformed-file diagnostic = %q, want %q", got, want)
+	}
+	if !strings.Contains(stdout, "Successfully updated 1 file(s)") {
+		t.Errorf("expected existing summary in stdout, got %q", stdout)
+	}
+	if runnerErr == nil {
+		t.Fatal("expected runner to report the malformed file failure")
+	}
+}
 
 // TestLoadModuleUpdatesErrorCases tests error handling in loadModuleUpdates
 func TestLoadModuleUpdatesErrorCases(t *testing.T) {

--- a/main_integration_test.go
+++ b/main_integration_test.go
@@ -94,6 +94,47 @@ func TestRunCLIModeReportsModuleFileFailure(t *testing.T) {
 	}
 }
 
+func TestRunCLIModeReportsTerraformFileFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	malformedFile := filepath.Join(tmpDir, "01-malformed.tf")
+	if err := os.WriteFile(malformedFile, []byte("terraform {"), 0o644); err != nil {
+		t.Fatalf("failed to write malformed Terraform file: %v", err)
+	}
+
+	validFile := filepath.Join(tmpDir, "02-valid.tf")
+	if err := os.WriteFile(validFile, []byte(`terraform {
+  required_version = ">= 1.0"
+}
+`), 0o644); err != nil {
+		t.Fatalf("failed to write valid Terraform file: %v", err)
+	}
+
+	stdout, diagnostic, runnerErr := captureRunnerOutput(t, func() error {
+		return runCLIMode([]string{malformedFile, validFile}, &cliFlags{
+			terraformVersion: ">= 1.5",
+			output:           "text",
+		})
+	})
+
+	updated, err := os.ReadFile(validFile)
+	if err != nil {
+		t.Fatalf("failed to read updated Terraform file: %v", err)
+	}
+	if !strings.Contains(string(updated), `required_version = ">= 1.5"`) {
+		t.Fatalf("expected valid file to be updated, got: %s", updated)
+	}
+
+	if !strings.Contains(diagnostic, "Error processing "+malformedFile+": failed to parse HCL:") {
+		t.Errorf("expected malformed-file diagnostic, got %q", diagnostic)
+	}
+	if !strings.Contains(stdout, "Successfully updated Terraform version in 1 file(s)") {
+		t.Errorf("expected existing summary in stdout, got %q", stdout)
+	}
+	if runnerErr == nil {
+		t.Fatal("expected runner to report the malformed file failure")
+	}
+}
+
 // TestLoadModuleUpdatesErrorCases tests error handling in loadModuleUpdates
 func TestLoadModuleUpdatesErrorCases(t *testing.T) {
 	tests := []struct {
@@ -204,7 +245,7 @@ func TestProcessTerraformVersionWithErrors(t *testing.T) {
 	}
 
 	files := []string{invalidFile}
-	count := processTerraformVersion(files, ">= 1.5", false, "text")
+	count, _ := processTerraformVersion(files, ">= 1.5", false, "text")
 
 	if count != 0 {
 		t.Errorf("Expected 0 updates for invalid file, got %d", count)
@@ -224,7 +265,7 @@ func TestProcessTerraformVersionDryRun(t *testing.T) {
 	}
 
 	files := []string{tfFile}
-	count := processTerraformVersion(files, ">= 1.5", true, "text")
+	count, _ := processTerraformVersion(files, ">= 1.5", true, "text")
 
 	if count != 1 {
 		t.Errorf("Expected 1 update in dry-run, got %d", count)

--- a/main_integration_test.go
+++ b/main_integration_test.go
@@ -135,6 +135,46 @@ func TestRunCLIModeReportsTerraformFileFailure(t *testing.T) {
 	}
 }
 
+func TestRunCLIModeReportsProviderFileFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	malformedFile := filepath.Join(tmpDir, "01-malformed.tf")
+	if err := os.WriteFile(malformedFile, []byte("terraform {"), 0o644); err != nil {
+		t.Fatalf("failed to write malformed Terraform file: %v", err)
+	}
+	validFile := filepath.Join(tmpDir, "02-valid.tf")
+	if err := os.WriteFile(validFile, []byte(`terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+`), 0o644); err != nil {
+		t.Fatalf("failed to write valid Terraform file: %v", err)
+	}
+
+	stdout, diagnostic, runnerErr := captureRunnerOutput(t, func() error {
+		return runCLIMode([]string{malformedFile, validFile}, &cliFlags{providerName: "aws", toVersion: "~> 5.0", output: "text"})
+	})
+	updated, err := os.ReadFile(validFile)
+	if err != nil {
+		t.Fatalf("failed to read updated Terraform file: %v", err)
+	}
+	if !strings.Contains(string(updated), `version = "~> 5.0"`) {
+		t.Fatalf("expected valid file to be updated, got: %s", updated)
+	}
+	if !strings.Contains(diagnostic, "Error processing "+malformedFile+": failed to parse HCL:") {
+		t.Errorf("expected malformed-file diagnostic, got %q", diagnostic)
+	}
+	if !strings.Contains(stdout, "Successfully updated 'aws' provider version in 1 file(s)") {
+		t.Errorf("expected existing summary in stdout, got %q", stdout)
+	}
+	if runnerErr == nil {
+		t.Fatal("expected runner to report the malformed file failure")
+	}
+}
+
 // TestLoadModuleUpdatesErrorCases tests error handling in loadModuleUpdates
 func TestLoadModuleUpdatesErrorCases(t *testing.T) {
 	tests := []struct {
@@ -293,7 +333,7 @@ func TestProcessProviderVersionWithErrors(t *testing.T) {
 	}
 
 	files := []string{invalidFile}
-	count := processProviderVersion(files, "aws", "~> 5.0", false, "text")
+	count, _ := processProviderVersion(files, "aws", "~> 5.0", false, "text")
 
 	if count != 0 {
 		t.Errorf("Expected 0 updates for invalid file, got %d", count)
@@ -318,7 +358,7 @@ func TestProcessProviderVersionDryRun(t *testing.T) {
 	}
 
 	files := []string{tfFile}
-	count := processProviderVersion(files, "aws", "~> 5.0", true, "text")
+	count, _ := processProviderVersion(files, "aws", "~> 5.0", true, "text")
 
 	if count != 1 {
 		t.Errorf("Expected 1 update in dry-run, got %d", count)
@@ -353,7 +393,7 @@ func TestProcessProviderVersionMarkdownOutput(t *testing.T) {
 	}
 
 	files := []string{tfFile}
-	count := processProviderVersion(files, "aws", "~> 5.0", false, "md")
+	count, _ := processProviderVersion(files, "aws", "~> 5.0", false, "md")
 
 	if count != 1 {
 		t.Errorf("Expected 1 update, got %d", count)

--- a/terraform_provider_test.go
+++ b/terraform_provider_test.go
@@ -483,11 +483,14 @@ func TestProcessProviderVersion(t *testing.T) {
 	files := []string{file1, file2, file3}
 
 	// Process all files
-	count := processProviderVersion(files, "aws", "~> 5.0", false, "text")
+	count, errors := processProviderVersion(files, "aws", "~> 5.0", false, "text")
 
 	// Should update 2 files (file1 and file2, not file3 which has no provider)
 	if count != 2 {
 		t.Errorf("Expected 2 files updated, got %d", count)
+	}
+	if errors != 0 {
+		t.Errorf("Expected no file errors, got %d", errors)
 	}
 
 	// Verify updates
@@ -773,7 +776,7 @@ func TestProcessProviderVersionAttributeSyntax(t *testing.T) {
 		t.Fatalf("Failed to glob pattern: %v", err)
 	}
 
-	count := processProviderVersion(files, "aws", "~> 5.0", false, "text")
+	count, _ := processProviderVersion(files, "aws", "~> 5.0", false, "text")
 
 	if count != 2 {
 		t.Errorf("Expected 2 files updated, got %d", count)

--- a/terraform_provider_test.go
+++ b/terraform_provider_test.go
@@ -405,11 +405,14 @@ module "vpc" {
 	files := []string{file1, file2, file3}
 
 	// Process all files
-	count := processTerraformVersion(files, ">= 1.5", false, "text")
+	count, errors := processTerraformVersion(files, ">= 1.5", false, "text")
 
 	// Should update 2 files (file1 and file2, not file3 which has no terraform block)
 	if count != 2 {
 		t.Errorf("Expected 2 files updated, got %d", count)
+	}
+	if errors != 0 {
+		t.Errorf("Expected no file errors, got %d", errors)
 	}
 
 	// Verify updates


### PR DESCRIPTION
## Summary

- add the reviewed security design and implementation plans for GitHub Actions state-branch automation
- make module, Terraform, and provider modes continue processing selected files while aggregating file-level failures
- return a non-zero process status after processing and any summary when one or more selected operations fail
- document the process-status contract and cover CLI, config, mixed-operation, continuation, and complete command-output behaviour with real files

## Why

The planned GitHub Actions automation must not treat a partially updated branch as successful. The released CLI artefact therefore needs an explicit aggregate-failure contract before the workflow example can safely consume it.

## Impact

Successful and dry-run output remains unchanged. Commands that encounter file-level update failures still process later files, but now exit with status 1 after emitting the aggregate failure. This is an intentional CLI behaviour change with no compatibility flag.

## Validation

- focused mixed-config and public-command regressions
- `make test-coverage` — pass with race detection and 98.8% statement coverage
- `golangci-lint run --timeout=5m` — 0 issues
- `go build ./...` — pass
- independent per-task reviews, test-cleanup passes, final whole-branch review, and scoped fix re-review
- all branch commits verified with the required GenAI ED25519 signature

## Follow-up gate

After this lands on `main`, `v1.0.0-rc.7` must be explicitly approved, published, and independently verified before implementation of the GitHub Actions example begins.
