### PR TITLE
fix: restore supported SLSA provenance workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,8 +141,8 @@ jobs:
       id-token: write # For creating OIDC tokens for signing
       contents: write # For adding assets to a release
 
-    # Note: SLSA generator recommends using semantic version tags for reusable workflows
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    # The SLSA generator requires an exact semantic version tag for reusable workflows.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.combine-subjects.outputs.all-subjects }}"
       upload-assets: true

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -71,8 +71,9 @@ slsa-verifier verify-artifact "tf-version-bump_${VERSION}_linux_x86_64.tar.gz" \
 ```
 
 The release workflow requests GitHub's OIDC token, supplies artefact digests to the reusable SLSA
-generator, and uploads the resulting in-toto JSONL file to the release. GitHub Actions are pinned
-to commit SHAs and jobs declare their required permissions explicitly.
+generator, and uploads the resulting in-toto JSONL file to the release. Third-party actions are
+pinned to commit SHAs, except for the reusable SLSA generator's upstream-required exact semantic
+version tag. Jobs declare their required permissions explicitly.
 
 ## Create a release
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -86,8 +86,8 @@ Before tagging:
 Create and push an annotated tag:
 
 ```bash
-git tag -a v1.0.0-rc.7 -m "Release v1.0.0-rc.7"
-git push origin v1.0.0-rc.7
+git tag -a v1.0.0-rc.8 -m "Release v1.0.0-rc.8"
+git push origin v1.0.0-rc.8
 ```
 
 The tag push starts `.github/workflows/release.yml`, which:

--- a/docs/superpowers/plans/2026-08-18-github-actions-branch-automation.md
+++ b/docs/superpowers/plans/2026-08-18-github-actions-branch-automation.md
@@ -17,7 +17,7 @@ and split reconciliation into credential-free verification, authenticated prefli
 smallest possible publication step.
 
 **Tech stack:** Bash, Git, GitHub CLI, GitHub Actions, jq, Docker,
-`tf-version-bump v1.0.0-rc.7`, Terraform 1.15.5, actionlint 1.7.12.
+`tf-version-bump v1.0.0-rc.8`, Terraform 1.15.5, actionlint 1.7.12.
 
 **Spec:** `docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md`
 
@@ -27,7 +27,7 @@ smallest possible publication step.
 
 Do not begin Task 1 until
 `docs/superpowers/plans/2026-08-19-tf-version-bump-aggregate-failures.md` is complete and the
-published `v1.0.0-rc.7` Linux artefact has passed checksum, provenance, version, and aggregate-exit
+published `v1.0.0-rc.8` Linux artefact has passed checksum, provenance, version, and aggregate-exit
 verification. Record the actual Linux x86-64 archive SHA-256 in the release acceptance transcript.
 Tests and workflows must download and verify that archive; substituting a working-tree build would
 reopen the partial-publication defect.
@@ -72,7 +72,7 @@ reopen the partial-publication defect.
   - `actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1`
     (`v3.2.0`)
 - Tool pins:
-  - `tf-version-bump v1.0.0-rc.7`
+  - `tf-version-bump v1.0.0-rc.8`
   - Terraform `1.15.5`
   - `hashicorp/terraform:1.15.5@sha256:15bf5a08b1fb9c9747c8ff01098aeeefb4aec9a6c24eb13e7661bdf9447e4aee`
   - `github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
@@ -201,7 +201,7 @@ and create a signed commit.
 - Modify: `examples/github-actions/.github/scripts/process-state-branch.sh`
 - Modify: `examples/github-actions/test.sh`
 
-1. Add a RED test for `prepare` downloading the `v1.0.0-rc.7` Linux x86-64 archive, verifying its
+1. Add a RED test for `prepare` downloading the `v1.0.0-rc.8` Linux x86-64 archive, verifying its
    recorded SHA-256 before extraction, checking the binary's reported version, and running it with
    `*.tf` plus the control config in one real Terraform root. Implement only that download,
    verification, and update path.
@@ -289,7 +289,7 @@ For each check, add a targeted corrupt bundle, observe RED, implement rejection,
    undeclared paths.
 3. Patch paths outside the declaration or a changed `.tf` file not mapped directly to one root.
 4. Contradictory or unknown result classifications.
-5. Independent `v1.0.0-rc.7` source reproduction against a fresh exact-base checkout, accepting only
+5. Independent `v1.0.0-rc.8` source reproduction against a fresh exact-base checkout, accepting only
    an exact source diff before applying declared lock bytes.
 6. A complete rerun fixture whose run-attempt-specific artefacts cannot cross-consume, plus a
    failed-job rerun fixture whose reused discovery attempt is rejected with instructions to use
@@ -448,7 +448,7 @@ commit.
 1. Add the non-production caller with manual `branch_prefix`/`dry_run`, a 04:17 daily
    `Australia/Melbourne` schedule, policy `nonproduction`, the three documented prefixes, root `.`,
    exact release/archive/image pins, and `queue: max` concurrency. Populate the archive digest only
-   from the completed `v1.0.0-rc.7` release acceptance record.
+   from the completed `v1.0.0-rc.8` release acceptance record.
 2. Add the production caller with the same manual interface, a Sunday 04:43
    `Australia/Melbourne` schedule, policy `production`, and the two production prefixes.
 3. Make built-in-token mode the copyable default. Add commented/documented App inputs only with the
@@ -490,7 +490,7 @@ Run actionlint and the caller subset, then create a signed commit.
 Write the example guide specified by the design, including:
 
 - Copy paths, default-branch config ownership, single and newline-separated multiple roots.
-- `v1.0.0-rc.7` checksum/provenance prerequisite and digest-pinned Terraform image.
+- `v1.0.0-rc.8` checksum/provenance prerequisite and digest-pinned Terraform image.
 - Literal allow-lists, manual narrowing, dry run, 256-branch limit, and exact schedules.
 - Protected publication environment, least privileges, fixed secret names, optional signing, and
   no unsigned fallback after signing failure.

--- a/docs/superpowers/plans/2026-08-19-tf-version-bump-aggregate-failures.md
+++ b/docs/superpowers/plans/2026-08-19-tf-version-bump-aggregate-failures.md
@@ -1,4 +1,4 @@
-# Aggregate CLI Failure and v1.0.0-rc.7 Release Plan
+# Aggregate CLI Failure and v1.0.0-rc.8 Release Plan
 
 > **For Codex:** Use `superpowers:executing-plans` to implement this plan. Follow
 > `superpowers:test-driven-development` one behaviour at a time. After implementation, run the
@@ -176,7 +176,7 @@ Run `test-cleanup` in a separate subagent. Apply only removals that preserve all
 coverage, rerun the full commands above, inspect the complete diff, then create a signed commit such
 as `docs: define aggregate CLI failure status`.
 
-### Task 4: Merge and publish v1.0.0-rc.7
+### Task 4: Merge and publish v1.0.0-rc.8
 
 This task changes remote state and begins only after review, branch integration, and Dan's explicit
 release approval.
@@ -197,7 +197,7 @@ it did not leave unexpected source changes.
 
 **Step 2: Obtain explicit authorisation**
 
-Stop and ask Dan before creating or pushing `v1.0.0-rc.7`. Do not infer tag approval from approval
+Stop and ask Dan before creating or pushing `v1.0.0-rc.8`. Do not infer tag approval from approval
 to implement this plan.
 
 **Step 3: Create and push the signed annotated tag**

--- a/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
+++ b/docs/superpowers/specs/2026-08-18-github-actions-branch-automation-design.md
@@ -281,7 +281,7 @@ authentication or signing configurations. A GitHub App client ID requires the Ap
 both commit identity inputs rather than inherit a bot default. Environment secrets cannot be passed
 or selected by an untrusted caller.
 
-The example pins `tf_version_bump_version: v1.0.0-rc.7` and the Linux x86-64 archive's actual
+The example pins `tf_version_bump_version: v1.0.0-rc.8` and the Linux x86-64 archive's actual
 published SHA-256. Implementation of this workflow cannot start until the aggregate per-file
 failure change has been merged, released under that tag, and the published artefact has passed
 checksum/provenance verification. Each job downloads that exact archive, verifies it against the
@@ -741,7 +741,7 @@ A maintained shell test creates temporary real Git repositories and bare remotes
 - One immutable control OID across a default-branch movement.
 - Exact discovered base OIDs and rejection when a state ref advances before publication.
 - Successful update, initialisation, and validation with the independently downloaded
-  `v1.0.0-rc.7` release artefact and the digest-pinned Terraform image used by the workflows.
+  `v1.0.0-rc.8` release artefact and the digest-pinned Terraform image used by the workflows.
 - One-to-one mapping of directly changed source files to configured Terraform directories,
   including rejection of omitted, duplicate, and ambiguous roots.
 - Terraform source and lock-file staging into an immutable candidate before provider execution.
@@ -894,7 +894,7 @@ The acceptance transcript is reviewed before completion is claimed.
 - Protected publication-environment setup, default-branch restrictions, trusted-dispatch
   assumptions, and fixed optional secret names.
 - Exact tool-version pinning.
-- The prerequisite `v1.0.0-rc.7` release, its aggregate-failure contract, and verification of the
+- The prerequisite `v1.0.0-rc.8` release, its aggregate-failure contract, and verification of the
   downloaded artefact's checksum and provenance before use.
 - Production and non-production prefix/config separation.
 - Manual narrowing and dry-run behaviour.
@@ -958,7 +958,7 @@ The feature is complete when:
   expected remote OID.
 - Complete reruns create a new attempt-bound artefact lineage, and partial failed-job reruns fail
   safely with instructions to use **Re-run all jobs**.
-- The independently downloaded `v1.0.0-rc.7` CLI reports aggregate per-file failure with a non-zero
+- The independently downloaded `v1.0.0-rc.8` CLI reports aggregate per-file failure with a non-zero
   status, and the workflow downloads and verifies the recorded SHA-256 of that exact released
   archive before use.
 - Every configured Terraform module directory with installed provider packages has a lock file

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -31,8 +31,26 @@ func TestReleaseWorkflowReferencesSLSAGeneratorByExactSemanticVersionTag(t *test
 	}
 
 	version := strings.TrimPrefix(reference, generator)
-	exactSemanticVersion := regexp.MustCompile(`^v\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$`)
-	if !exactSemanticVersion.MatchString(version) {
-		t.Fatalf("SLSA generator reference %q is unsupported; use an exact semantic version tag such as v2.1.0", version)
+	exactSemanticVersion := regexp.MustCompile(`^v[1-9]\d*\.\d+\.\d+(?:-rc\.\d+)?$`)
+	testCases := []struct {
+		name      string
+		version   string
+		supported bool
+	}{
+		{name: "workflow reference", version: version, supported: true},
+		{name: "stable release", version: "v2.1.0", supported: true},
+		{name: "release candidate", version: "v2.1.0-rc.1", supported: true},
+		{name: "commit hash", version: "f7dd8c54c2067bafc12ca7a55595d5ee9b75204a", supported: false},
+		{name: "short tag", version: "v2.1", supported: false},
+		{name: "malformed release candidate", version: "v2.1.0-rc.", supported: false},
+		{name: "unsupported prerelease", version: "v2.1.0-beta.1", supported: false},
+		{name: "zero-leading major", version: "v02.1.0", supported: false},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := exactSemanticVersion.MatchString(testCase.version); got != testCase.supported {
+				t.Errorf("SLSA generator reference support for %q = %t, want %t", testCase.version, got, testCase.supported)
+			}
+		})
 	}
 }

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestReleaseWorkflowReferencesSLSAGeneratorByExactSemanticVersionTag(t *testing.T) {
+	workflowData, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("failed to read release workflow: %v", err)
+	}
+
+	var workflow struct {
+		Jobs map[string]struct {
+			Uses string `yaml:"uses"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(workflowData, &workflow); err != nil {
+		t.Fatalf("failed to parse release workflow: %v", err)
+	}
+
+	const generator = "slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@"
+	reference := workflow.Jobs["assets-provenance"].Uses
+	if !strings.HasPrefix(reference, generator) {
+		t.Fatalf("assets-provenance uses %q, want the SLSA generic generator", reference)
+	}
+
+	version := strings.TrimPrefix(reference, generator)
+	exactSemanticVersion := regexp.MustCompile(`^v\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$`)
+	if !exactSemanticVersion.MatchString(version) {
+		t.Fatalf("SLSA generator reference %q is unsupported; use an exact semantic version tag such as v2.1.0", version)
+	}
+}

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -38,7 +38,6 @@ func TestReleaseWorkflowReferencesSLSAGeneratorByExactSemanticVersionTag(t *test
 		supported bool
 	}{
 		{name: "workflow reference", version: version, supported: true},
-		{name: "stable release", version: "v2.1.0", supported: true},
 		{name: "release candidate", version: "v2.1.0-rc.1", supported: true},
 		{name: "commit hash", version: "f7dd8c54c2067bafc12ca7a55595d5ee9b75204a", supported: false},
 		{name: "short tag", version: "v2.1", supported: false},


### PR DESCRIPTION
## Summary

- reference the SLSA generic reusable workflow by the exact semantic tag required upstream
- add a structural regression test covering the supported stable/RC grammar and rejected hash/short-tag forms
- advance the release and automation documentation from the incomplete `v1.0.0-rc.7` release to `v1.0.0-rc.8`

## Root cause

The `v1.0.0-rc.7` release used the SLSA reusable workflow at a commit SHA. The upstream generator requires a full semantic-version tag, so its final provenance job failed and no `.intoto.jsonl` asset was published. The normal archives, packages, and checksum manifest were published successfully; the existing tag and release remain immutable.

## Validation

- TDD RED: the regression test rejected the former SHA reference
- review-driven RED: malformed RC, beta, and zero-leading version forms failed against the original permissive validator
- `make test-coverage` (98.8%)
- `golangci-lint run --timeout=5m`
- `go build ./...`
- `actionlint`
- independent test-cleanup and read-only code review
