### PR TITLE
ci: group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,11 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "go"
-    commit-message:
-      prefix: "deps"
-      include: "scope"
+    groups:
+      gomod-backward-compatible:
+        update-types:
+          - "minor"
+          - "patch"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -19,9 +18,11 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "github-actions"
-    commit-message:
-      prefix: "ci"
-      include: "scope"
+    groups:
+      github-actions-breaking:
+        update-types:
+          - "major"
+      github-actions-backward-compatible:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

- group Go minor and patch dependency updates while leaving major updates as individual PRs
- group GitHub Actions breaking updates separately from backward-compatible updates
- use Dependabot defaults for labels and commit messages

## Verification

- `uvx check-jsonschema --builtin-schema vendor.dependabot .github/dependabot.yml`
- `go test -v -race -coverprofile=/tmp/tf-version-bump-coverage-final.out -covermode=atomic ./...`
- `go build -o /tmp/tf-version-bump-final .`
- `golangci-lint run --timeout=5m`
