### PR TITLE
[codex] add machine-readable update reports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,16 +107,16 @@ not atomic. Files are processed in memory, so very large files (>100MB) are impr
 
 `main()` → `validateOperationModes` → `findMatchingFiles` → either `runConfigFileMode`
 (YAML) or `runCLIMode` (one direct operation). Each dispatches to one of three update paths:
-`updateModuleVersion`, `updateTerraformVersion`, or `updateProviderVersion`.
+`updateModuleVersionWithCount`, `updateTerraformVersion`, or `updateProviderVersionWithCount`.
 
-`updateModuleVersion` reads and parses the file, then bundles its many
+`updateModuleVersionWithCount` reads and parses the file, then bundles its many
 parameters into a `moduleUpdateOptions` struct and delegates per-block work to
-`updateModuleBlock` → `shouldSkipModuleVersion`. Add new per-module filtering there rather
+`updateModuleBlockResult` → `shouldSkipModuleVersion`. Add new per-module filtering there rather
 than growing the parameter list.
 
 Provider updates are the fiddliest path: `required_providers` entries can be either a nested
-block or an object expression, so `updateProviderVersion` branches through
-`updateProviderBlockSyntax` and `updateProviderAttributeVersion` /
+block or an object expression, so `updateProviderVersionWithCount` branches through
+`updateProviderBlockSyntaxResult` and `updateProviderAttributeVersionResult` /
 `providerAttributeObject` / `replaceProviderObjectVersion`. Attribute-object updates replace only
 the version expression's byte range so other expressions such as `configuration_aliases` remain.
 
@@ -140,7 +140,7 @@ os.WriteFile(filename, output, fileInfo.Mode().Perm())
 
 ### Module update precedence
 
-Evaluated across `updateModuleBlock` and `shouldSkipModuleVersion`:
+Evaluated across `updateModuleBlockResult` and `shouldSkipModuleVersion`:
 
 1. Source must match exactly.
 2. Local sources are skipped.
@@ -187,9 +187,10 @@ Success is prefixed `✓`; dry-run lines use `→` with the verb "Would update".
 through rather than hardcoding quotes.
 
 `-report-file` is the machine-readable automation contract. It writes schema version 1 JSON with
-exact counts of module and provider blocks whose version values changed. Keep human summaries and
-the report separate: existing summaries count source/file operations, while the report counts
-individual changed blocks. Dry-run reports contain zero counts because no file values changed.
+exact counts of unique module and provider blocks whose version values changed across the complete
+command. Keep human summaries and the report separate: existing summaries count source/file
+operations, while the report counts individual changed blocks. Dry-run reports contain zero counts
+because no file values changed.
 
 ## Testing
 
@@ -221,7 +222,7 @@ Testing rules:
 A representative call — note the full 10-parameter signature:
 
 ```go
-updated, err := updateModuleVersion(
+updated, changedBlocks, err := updateModuleVersionWithCount(
     tmpFile, "terraform-aws-modules/vpc/aws", "5.0.0",
     nil, nil, nil, // fromVersions, ignoreVersions, ignorePatterns
     false, false, false, "text", // forceAdd, dryRun, verbose, outputFormat

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ through rather than hardcoding quotes.
 `-report-file` is the machine-readable automation contract. It writes schema version 1 JSON with
 exact counts of module and provider blocks whose version values changed. Keep human summaries and
 the report separate: existing summaries count source/file operations, while the report counts
-individual changed blocks.
+individual changed blocks. Dry-run reports contain zero counts because no file values changed.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,11 @@ Success is prefixed `✓`; dry-run lines use `→` with the verb "Would update".
 `quote(s, format)`: `'vpc'` for `text` output, `` `vpc` `` for `md`. Thread `outputFormat`
 through rather than hardcoding quotes.
 
+`-report-file` is the machine-readable automation contract. It writes schema version 1 JSON with
+exact counts of module and provider blocks whose version values changed. Keep human summaries and
+the report separate: existing summaries count source/file operations, while the report counts
+individual changed blocks.
+
 ## Testing
 
 Follow TDD. Tests are commonly table-driven with `t.Run` subtests; prefer `t.TempDir()` for new

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ tf-version-bump -pattern "**/*.tf" -config versions.yml
 
 Config mode is exclusive with `-module`, `-provider`, `-terraform-version`, `-to`, and the
 module-filter flags. It can still be combined with global behaviour flags such as `-dry-run`,
-`-force-add`, `-verbose`, and `-output`.
+`-force-add`, `-verbose`, `-output`, and `-report-file`.
 
 ## Preview and review
 
@@ -140,6 +140,10 @@ terraform validate
 `tf-version-bump` checks HCL syntax but cannot determine whether a new version is compatible
 with your Terraform configuration. Use your normal validation and planning workflow before
 deployment.
+
+Automation can pass `-report-file update-report.json` to receive exact updated module and
+provider block counts as JSON. See the [usage reference](docs/USAGE.md#machine-readable-update-report)
+for the report contract.
 
 ## Common controls
 

--- a/command_test.go
+++ b/command_test.go
@@ -339,6 +339,37 @@ modules:
 	}
 }
 
+func TestCommandReportCountsHardLinkedBlockOnce(t *testing.T) {
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "a.tf", "module \"example\" {\n  source  = \"example/module\"\n  version = \"1.0.0\"\n}\n")
+	linkedFile := dir + "/b.tf"
+	if err := os.Link(file, linkedFile); err != nil {
+		t.Skipf("cannot create hard link: %v", err)
+	}
+	config := writeTestFile(t, dir, "updates.yml", `modules:
+  - source: example/module
+    version: 2.0.0
+  - source: example/module
+    version: 3.0.0
+`)
+	report := dir + "/report.json"
+
+	result := runMainCommand(t, []string{
+		"tf-version-bump", "-pattern", dir + "/*.tf", "-config", config, "-report-file", report,
+	})
+
+	if result.exitCode != -1 || result.diagnostics != "" {
+		t.Fatalf("result = %#v", result)
+	}
+	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 1,\n  \"provider_blocks_updated\": 0\n}\n"
+	if got := readTestFile(t, report); got != wantReport {
+		t.Errorf("report = %q, want %q", got, wantReport)
+	}
+	if got := readTestFile(t, linkedFile); !strings.Contains(got, `version = "3.0.0"`) {
+		t.Errorf("final Terraform content = %q", got)
+	}
+}
+
 func TestCommandRejectsReportInputCollision(t *testing.T) {
 	t.Run("Terraform input", func(t *testing.T) {
 		dir := t.TempDir()
@@ -464,6 +495,38 @@ func TestCommandDiscardsPreparedReportAfterUpdateFailure(t *testing.T) {
 	}
 	if len(entries) != 1 || entries[0].Name() != "main.tf" {
 		t.Errorf("temporary directory entries = %v, want only main.tf", entries)
+	}
+}
+
+func TestCommandDoesNotPrepareReportBeforeRequiredFlagValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "module", args: []string{"-module", "example/module"}},
+		{name: "provider", args: []string{"-provider", "aws"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			file := writeTestFile(t, dir, "main.tf", "module \"example\" {\n  source  = \"example/module\"\n  version = \"1.0.0\"\n}\n")
+			report := dir + "/report.json"
+			args := append([]string{"tf-version-bump", "-pattern", file, "-report-file", report}, tt.args...)
+
+			result := runMainCommand(t, args)
+
+			if result.exitCode != 1 {
+				t.Errorf("result = %#v, want exit code 1", result)
+			}
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatalf("read temporary directory: %v", err)
+			}
+			if len(entries) != 1 || entries[0].Name() != "main.tf" {
+				t.Errorf("temporary directory entries = %v, want only main.tf", entries)
+			}
+		})
 	}
 }
 

--- a/command_test.go
+++ b/command_test.go
@@ -294,6 +294,93 @@ modules:
 	}
 }
 
+func TestCommandReportAggregatesDistinctFiles(t *testing.T) {
+	dir := t.TempDir()
+	firstFile := writeTestFile(t, dir, "first.tf", `terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+module "first" {
+  source  = "example/module"
+  version = "1.0.0"
+}
+`)
+	secondFile := writeTestFile(t, dir, "second.tf", `terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+module "second" {
+  source  = "example/module"
+  version = "1.0.0"
+}
+module "third" {
+  source  = "example/module"
+  version = "1.0.0"
+}
+`)
+	config := writeTestFile(t, dir, "updates.yml", `providers:
+  - name: aws
+    version: "~> 5.0"
+modules:
+  - source: example/module
+    version: 2.0.0
+`)
+	report := dir + "/report.json"
+
+	result := runMainCommand(t, []string{
+		"tf-version-bump", "-pattern", dir + "/*.tf", "-config", config, "-report-file", report,
+	})
+
+	if result.exitCode != -1 || result.diagnostics != "" {
+		t.Fatalf("result = %#v", result)
+	}
+	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 3,\n  \"provider_blocks_updated\": 2\n}\n"
+	if got := readTestFile(t, report); got != wantReport {
+		t.Errorf("report = %q, want %q", got, wantReport)
+	}
+	for _, file := range []string{firstFile, secondFile} {
+		content := readTestFile(t, file)
+		if !strings.Contains(content, `version = "~> 5.0"`) || !strings.Contains(content, `version = "2.0.0"`) {
+			t.Errorf("updated Terraform content for %s = %q", file, content)
+		}
+	}
+}
+
+func TestCommandReportCountsForceAddedModuleBlock(t *testing.T) {
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "main.tf", `module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+}
+`)
+	report := dir + "/report.json"
+
+	result := runMainCommand(t, []string{
+		"tf-version-bump", "-pattern", file,
+		"-module", "terraform-aws-modules/vpc/aws", "-to", "5.0.0",
+		"-force-add", "-report-file", report,
+	})
+
+	if result.exitCode != -1 || result.diagnostics != "" {
+		t.Fatalf("result = %#v", result)
+	}
+	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 1,\n  \"provider_blocks_updated\": 0\n}\n"
+	if got := readTestFile(t, report); got != wantReport {
+		t.Errorf("report = %q, want %q", got, wantReport)
+	}
+	wantTerraform := "module \"vpc\" {\n  source  = \"terraform-aws-modules/vpc/aws\"\n  version = \"5.0.0\"\n}\n"
+	if got := readTestFile(t, file); got != wantTerraform {
+		t.Errorf("Terraform content = %q, want %q", got, wantTerraform)
+	}
+}
+
 func TestCommandReportCountsEachBlockOnce(t *testing.T) {
 	dir := t.TempDir()
 	file := writeTestFile(t, dir, "main.tf", `terraform {

--- a/command_test.go
+++ b/command_test.go
@@ -381,6 +381,65 @@ func TestCommandReportCountsForceAddedModuleBlock(t *testing.T) {
 	}
 }
 
+func TestProcessFilesSkipsReportBookkeepingWhenDisabled(t *testing.T) {
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "main.tf", "module \"example\" {\n  source  = \"example/module\"\n  version = \"1.0.0\"\n}\n")
+	flags := &cliFlags{}
+	updates := []ModuleUpdate{{Source: "example/module", Version: "2.0.0"}}
+
+	var updatesApplied, updateErrors int
+	captureStdout(t, func() {
+		updatesApplied, updateErrors = processFiles([]string{file}, updates, flags)
+	})
+
+	if updatesApplied != 1 || updateErrors != 0 {
+		t.Fatalf("processFiles() = (%d, %d), want (1, 0)", updatesApplied, updateErrors)
+	}
+	if flags.report.moduleBlockIDs != nil || flags.report.fileIdentities != nil {
+		t.Fatalf("disabled report bookkeeping = %#v", flags.report)
+	}
+}
+
+func TestProviderModesSkipReportBookkeepingWhenDisabled(t *testing.T) {
+	for _, mode := range []string{"CLI", "config"} {
+		t.Run(mode, func(t *testing.T) {
+			dir := t.TempDir()
+			file := writeTestFile(t, dir, "main.tf", `terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+`)
+			flags := &cliFlags{providerName: "aws", toVersion: "~> 5.0", output: "text"}
+			if mode == "config" {
+				flags = &cliFlags{configFile: writeTestFile(t, dir, "updates.yml", "providers:\n  - name: aws\n    version: '~> 5.0'\n"), output: "text"}
+			}
+
+			var runErr error
+			captureStdout(t, func() {
+				if mode == "CLI" {
+					runErr = runCLIMode([]string{file}, flags)
+				} else {
+					runErr = runConfigFileMode([]string{file}, flags)
+				}
+			})
+
+			if runErr != nil {
+				t.Fatalf("provider mode error = %v", runErr)
+			}
+			if flags.report.providerBlockIDs != nil || flags.report.fileIdentities != nil {
+				t.Fatalf("disabled report bookkeeping = %#v", flags.report)
+			}
+			if got := readTestFile(t, file); !strings.Contains(got, `version = "~> 5.0"`) {
+				t.Fatalf("updated Terraform content = %q", got)
+			}
+		})
+	}
+}
+
 func TestCommandReportCountsEachBlockOnce(t *testing.T) {
 	dir := t.TempDir()
 	file := writeTestFile(t, dir, "main.tf", `terraform {

--- a/command_test.go
+++ b/command_test.go
@@ -294,6 +294,51 @@ modules:
 	}
 }
 
+func TestCommandReportCountsEachBlockOnce(t *testing.T) {
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "main.tf", `terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+module "example" {
+  source  = "example/module"
+  version = "1.0.0"
+}
+`)
+	config := writeTestFile(t, dir, "updates.yml", `providers:
+  - name: aws
+    version: "~> 5.0"
+  - name: aws
+    version: "~> 6.0"
+modules:
+  - source: example/module
+    version: 2.0.0
+  - source: example/module
+    version: 3.0.0
+`)
+	report := dir + "/report.json"
+
+	result := runMainCommand(t, []string{
+		"tf-version-bump", "-pattern", file, "-config", config, "-report-file", report,
+	})
+
+	if result.exitCode != -1 || result.diagnostics != "" {
+		t.Fatalf("result = %#v", result)
+	}
+	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 1,\n  \"provider_blocks_updated\": 1\n}\n"
+	if got := readTestFile(t, report); got != wantReport {
+		t.Errorf("report = %q, want %q", got, wantReport)
+	}
+	content := readTestFile(t, file)
+	if !strings.Contains(content, `version = "~> 6.0"`) || !strings.Contains(content, `version = "3.0.0"`) {
+		t.Errorf("final Terraform content = %q", content)
+	}
+}
+
 func TestCommandReportPreservesSameTargetHumanOutput(t *testing.T) {
 	dir := t.TempDir()
 	file := writeTestFile(t, dir, "main.tf", `terraform {

--- a/command_test.go
+++ b/command_test.go
@@ -198,9 +198,10 @@ func TestCommandConfigDryRunOutputContract(t *testing.T) {
 	input := "terraform {\n  required_version = \">= 1.0\"\n  required_providers {\n    aws = {\n      source  = \"hashicorp/aws\"\n      version = \"~> 4.0\"\n    }\n  }\n}\nmodule \"example\" {\n  source  = \"example/module\"\n  version = \"1.0.0\"\n}\n"
 	file := writeTestFile(t, dir, "main.tf", input)
 	config := writeTestFile(t, dir, "updates.yml", "terraform_version: \">= 1.5\"\nproviders:\n  - name: aws\n    version: \"~> 5.0\"\nmodules:\n  - source: example/module\n    version: 2.0.0\n")
+	report := dir + "/report.json"
 
 	result := runMainCommand(t, []string{
-		"tf-version-bump", "-pattern", file, "-config", config, "-dry-run", "-output", "md",
+		"tf-version-bump", "-pattern", file, "-config", config, "-dry-run", "-output", "md", "-report-file", report,
 	})
 	wantStdout := "Found 1 file(s) matching pattern `" + file + "`\n" +
 		"Running in dry-run mode - no files will be modified\n" +
@@ -225,6 +226,10 @@ func TestCommandConfigDryRunOutputContract(t *testing.T) {
 	}
 	if got := readTestFile(t, file); got != input {
 		t.Errorf("config dry run content = %q, want %q", got, input)
+	}
+	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 0,\n  \"provider_blocks_updated\": 0\n}\n"
+	if got := readTestFile(t, report); got != wantReport {
+		t.Errorf("dry-run report = %q, want %q", got, wantReport)
 	}
 }
 
@@ -286,6 +291,51 @@ modules:
 	want := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 2,\n  \"provider_blocks_updated\": 2\n}\n"
 	if got := readTestFile(t, report); got != want {
 		t.Fatalf("report = %q, want %q", got, want)
+	}
+}
+
+func TestCommandReportPreservesSameTargetHumanOutput(t *testing.T) {
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "main.tf", `terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+module "current" {
+  source  = "example/module"
+  version = "2.0.0"
+}
+`)
+	config := writeTestFile(t, dir, "updates.yml", `providers:
+  - name: aws
+    version: "~> 5.0"
+modules:
+  - source: example/module
+    version: 2.0.0
+`)
+	report := dir + "/report.json"
+
+	result := runMainCommand(t, []string{
+		"tf-version-bump", "-pattern", file, "-config", config, "-report-file", report,
+	})
+
+	wantStdout := "Found 1 file(s) matching pattern '" + file + "'\n" +
+		"✓ Updated provider 'aws' to version '~> 5.0' in " + file + "\n" +
+		"✓ Updated module source 'example/module' to version '2.0.0' in " + file + "\n\n" +
+		"==================================================\n" +
+		"Config File Update Summary\n" +
+		"==================================================\n" +
+		"Providers: 1 update(s) applied\n" +
+		"Modules: 1 update(s) applied\n"
+	if result.exitCode != -1 || result.diagnostics != "" || result.stdout != wantStdout {
+		t.Fatalf("result = %#v, want stdout %q", result, wantStdout)
+	}
+	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 0,\n  \"provider_blocks_updated\": 0\n}\n"
+	if got := readTestFile(t, report); got != wantReport {
+		t.Fatalf("report = %q, want %q", got, wantReport)
 	}
 }
 

--- a/command_test.go
+++ b/command_test.go
@@ -339,6 +339,134 @@ modules:
 	}
 }
 
+func TestCommandRejectsReportInputCollision(t *testing.T) {
+	t.Run("Terraform input", func(t *testing.T) {
+		dir := t.TempDir()
+		input := "module \"example\" {\n  source  = \"example/module\"\n  version = \"1.0.0\"\n}\n"
+		file := writeTestFile(t, dir, "main.tf", input)
+
+		result := runMainCommand(t, []string{
+			"tf-version-bump", "-pattern", file, "-module", "example/module", "-to", "2.0.0", "-report-file", file,
+		})
+
+		wantDiagnostic := "Error: report file must not overwrite input file: " + file + "\n"
+		if result.exitCode != 1 || result.diagnostics != wantDiagnostic {
+			t.Errorf("result = %#v, want diagnostic %q", result, wantDiagnostic)
+		}
+		if got := readTestFile(t, file); got != input {
+			t.Errorf("Terraform input = %q, want unchanged %q", got, input)
+		}
+	})
+
+	t.Run("config input", func(t *testing.T) {
+		dir := t.TempDir()
+		input := "module \"example\" {\n  source  = \"example/module\"\n  version = \"1.0.0\"\n}\n"
+		file := writeTestFile(t, dir, "main.tf", input)
+		configContent := "modules:\n  - source: example/module\n    version: 2.0.0\n"
+		config := writeTestFile(t, dir, "updates.yml", configContent)
+
+		result := runMainCommand(t, []string{
+			"tf-version-bump", "-pattern", file, "-config", config, "-report-file", config,
+		})
+
+		wantDiagnostic := "Error: report file must not overwrite input file: " + config + "\n"
+		if result.exitCode != 1 || result.diagnostics != wantDiagnostic {
+			t.Errorf("result = %#v, want diagnostic %q", result, wantDiagnostic)
+		}
+		if got := readTestFile(t, file); got != input {
+			t.Errorf("Terraform input = %q, want unchanged %q", got, input)
+		}
+		if got := readTestFile(t, config); got != configContent {
+			t.Errorf("config input = %q, want unchanged %q", got, configContent)
+		}
+	})
+
+	t.Run("symlink alias", func(t *testing.T) {
+		dir := t.TempDir()
+		input := "module \"example\" {\n  source  = \"example/module\"\n  version = \"1.0.0\"\n}\n"
+		file := writeTestFile(t, dir, "main.tf", input)
+		report := dir + "/report.json"
+		if err := os.Symlink(file, report); err != nil {
+			t.Skipf("cannot create symlink: %v", err)
+		}
+
+		result := runMainCommand(t, []string{
+			"tf-version-bump", "-pattern", file, "-module", "example/module", "-to", "2.0.0", "-report-file", report,
+		})
+
+		wantDiagnostic := "Error: report file must not overwrite input file: " + report + "\n"
+		if result.exitCode != 1 || result.diagnostics != wantDiagnostic {
+			t.Errorf("result = %#v, want diagnostic %q", result, wantDiagnostic)
+		}
+		if got := readTestFile(t, file); got != input {
+			t.Errorf("Terraform input = %q, want unchanged %q", got, input)
+		}
+	})
+}
+
+func TestCommandRejectsUnusableReportDestinationBeforeUpdating(t *testing.T) {
+	dir := t.TempDir()
+	input := "module \"example\" {\n  source  = \"example/module\"\n  version = \"1.0.0\"\n}\n"
+	file := writeTestFile(t, dir, "main.tf", input)
+	report := dir + "/missing/report.json"
+
+	result := runMainCommand(t, []string{
+		"tf-version-bump", "-pattern", file, "-module", "example/module", "-to", "2.0.0", "-report-file", report,
+	})
+
+	if result.exitCode != 1 || !strings.HasPrefix(result.diagnostics, "Error preparing update report: ") {
+		t.Errorf("result = %#v, want report preparation failure", result)
+	}
+	if got := readTestFile(t, file); got != input {
+		t.Errorf("Terraform input = %q, want unchanged %q", got, input)
+	}
+	if _, err := os.Stat(report); !os.IsNotExist(err) {
+		t.Errorf("report stat error = %v, want not exist", err)
+	}
+}
+
+func TestCommandRejectsReportDirectoryBeforeUpdating(t *testing.T) {
+	dir := t.TempDir()
+	input := "module \"example\" {\n  source  = \"example/module\"\n  version = \"1.0.0\"\n}\n"
+	file := writeTestFile(t, dir, "main.tf", input)
+	report := dir + "/report-target"
+	if err := os.Mkdir(report, 0o755); err != nil {
+		t.Fatalf("create report directory: %v", err)
+	}
+
+	result := runMainCommand(t, []string{
+		"tf-version-bump", "-pattern", file, "-module", "example/module", "-to", "2.0.0", "-report-file", report,
+	})
+
+	if result.exitCode != 1 || !strings.HasPrefix(result.diagnostics, "Error preparing update report: ") {
+		t.Errorf("result = %#v, want report preparation failure", result)
+	}
+	if got := readTestFile(t, file); got != input {
+		t.Errorf("Terraform input = %q, want unchanged %q", got, input)
+	}
+}
+
+func TestCommandDiscardsPreparedReportAfterUpdateFailure(t *testing.T) {
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "main.tf", "!!!\n")
+	report := dir + "/report.json"
+
+	result := runMainCommand(t, []string{
+		"tf-version-bump", "-pattern", file, "-module", "example/module", "-to", "2.0.0", "-report-file", report,
+	})
+
+	if result.exitCode != 1 || !strings.Contains(result.diagnostics, "1 module update error(s)") {
+		t.Errorf("result = %#v, want module update failure", result)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read temporary directory: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "main.tf" {
+		t.Errorf("temporary directory entries = %v, want only main.tf", entries)
+	}
+}
+
 func TestCommandReportPreservesSameTargetHumanOutput(t *testing.T) {
 	dir := t.TempDir()
 	file := writeTestFile(t, dir, "main.tf", `terraform {

--- a/command_test.go
+++ b/command_test.go
@@ -228,6 +228,67 @@ func TestCommandConfigDryRunOutputContract(t *testing.T) {
 	}
 }
 
+func TestCommandWritesExactUpdatedBlockCounts(t *testing.T) {
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "main.tf", `terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+module "first" {
+  source  = "example/module"
+  version = "1.0.0"
+}
+module "second" {
+  source  = "example/module"
+  version = "1.0.0"
+}
+module "current" {
+  source  = "example/module"
+  version = "2.0.0"
+}
+`)
+	config := writeTestFile(t, dir, "updates.yml", `providers:
+  - name: aws
+    version: "~> 5.0"
+modules:
+  - source: example/module
+    version: 2.0.0
+`)
+	report := dir + "/report.json"
+
+	result := runMainCommand(t, []string{
+		"tf-version-bump", "-pattern", file, "-config", config, "-report-file", report,
+	})
+
+	if result.exitCode != -1 || result.diagnostics != "" {
+		t.Fatalf("result = %#v", result)
+	}
+	want := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 2,\n  \"provider_blocks_updated\": 2\n}\n"
+	if got := readTestFile(t, report); got != want {
+		t.Fatalf("report = %q, want %q", got, want)
+	}
+}
+
 func TestCommandReportsAggregateFileFailure(t *testing.T) {
 	for _, mode := range []string{"CLI", "config"} {
 		t.Run(mode, func(t *testing.T) {

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -64,11 +64,13 @@ The report has this stable shape:
 }
 ```
 
-Counts represent individual blocks whose version value changed. Blocks already at the requested
+Counts represent unique individual blocks whose version value changed across the complete command.
+Repeated config entries that update the same block count it once. Blocks already at the requested
 version are excluded. Dry runs write zero counts because they do not change files. The report is
-written only after the update operation completes without errors. Terraform `required_version`
-changes and changed-file counts are outside this report; automation can derive file counts from
-its version-control diff.
+written only after the update operation completes without errors. Its destination is validated
+before Terraform files are modified and cannot be one of the selected Terraform or YAML config
+inputs. Terraform `required_version` changes and changed-file counts are outside this report;
+automation can derive file counts from its version-control diff.
 
 ## Module updates
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -65,9 +65,10 @@ The report has this stable shape:
 ```
 
 Counts represent individual blocks whose version value changed. Blocks already at the requested
-version are excluded. The report is written only after the update operation completes without
-errors. Terraform `required_version` changes and changed-file counts are outside this report;
-automation can derive file counts from its version-control diff.
+version are excluded. Dry runs write zero counts because they do not change files. The report is
+written only after the update operation completes without errors. Terraform `required_version`
+changes and changed-file counts are outside this report; automation can derive file counts from
+its version-control diff.
 
 ## Module updates
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -36,10 +36,38 @@ with the three direct operation flags or their module filters.
 | `-dry-run` | All update modes | Report changes without writing files. |
 | `-verbose` | Module updates | Report modules skipped by name or version filters. |
 | `-output <format>` | All update modes | `text` (default) uses single quotes; `md` uses backticks in messages. |
+| `-report-file <path>` | All update modes | Write exact updated module and provider block counts as JSON. |
 | `-version` | Standalone | Print version, commit, and build date metadata, then exit. |
 
 `-output md` changes quoting in human-readable messages; it does not emit a structured Markdown
 document or machine-readable result.
+
+### Machine-readable update report
+
+Use `-report-file` when automation needs exact block counts independently of the human-readable
+summary:
+
+```bash
+tf-version-bump \
+  -pattern "**/*.tf" \
+  -config versions.yml \
+  -report-file update-report.json
+```
+
+The report has this stable shape:
+
+```json
+{
+  "schema_version": 1,
+  "module_blocks_updated": 4,
+  "provider_blocks_updated": 2
+}
+```
+
+Counts represent individual blocks whose version value changed. Blocks already at the requested
+version are excluded. The report is written only after the update operation completes without
+errors. Terraform `required_version` changes and changed-file counts are outside this report;
+automation can derive file counts from its version-control diff.
 
 ## Module updates
 

--- a/docs/superpowers/plans/2026-08-21-report-review-fixes.md
+++ b/docs/superpowers/plans/2026-08-21-report-review-fixes.md
@@ -1,0 +1,233 @@
+# Update Report Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make machine-readable update counts unique per physical HCL entry, prevent report destinations from overwriting inputs, fail before Terraform mutation when a report cannot be prepared, and correct contributor documentation.
+
+**Architecture:** Keep the existing update order and accepted configuration shape. Record changed block identities as canonical file path plus deterministic HCL block indexes, and derive the public counters from identity sets. Prepare a temporary report in the destination directory before updates, reject aliases of selected inputs, and rename the completed temporary report into place only after successful processing.
+
+**Tech Stack:** Go 1.26, standard library filesystem APIs, HashiCorp HCL, existing command-level test harness.
+
+**Spec:** `/tmp/tf-version-bump-par-findings.md`
+
+## Global Constraints
+
+- Preserve all existing CLI and configuration behaviour except the reviewed defects.
+- Do not reject duplicate or sequential configuration entries.
+- Use real temporary files and directories; do not mock filesystem behaviour.
+- Follow red-green-refactor separately for counting and destination safety.
+- Keep all Codex-created commits signed with the repository's Codex git wrapper.
+
+---
+
+### Task 1: Count unique changed blocks
+
+**Files:**
+- Modify: `command_test.go`
+- Modify: `main.go`
+
+**Interfaces:**
+- Consumes: the existing `updateReport` JSON fields and config-mode update order.
+- Produces: internal report methods that record canonical file/block identities and keep `ModuleBlocksUpdated` and `ProviderBlocksUpdated` equal to the number of unique identities.
+
+- [ ] **Step 1: Write the failing duplicate-target command test**
+
+Add a command-level test with one module block and one provider entry. Configure two sequential updates for each target:
+
+```yaml
+providers:
+  - name: aws
+    version: "~> 5.0"
+  - name: aws
+    version: "~> 6.0"
+modules:
+  - source: example/module
+    version: 2.0.0
+  - source: example/module
+    version: 3.0.0
+```
+
+Assert the final versions are `~> 6.0` and `3.0.0`, while the report is exactly:
+
+```json
+{
+  "schema_version": 1,
+  "module_blocks_updated": 1,
+  "provider_blocks_updated": 1
+}
+```
+
+- [ ] **Step 2: Verify the test fails for inflated counts**
+
+Run:
+
+```bash
+go test -run TestCommandReportCountsEachBlockOnce -v
+```
+
+Expected: FAIL because both counters are `2`.
+
+- [ ] **Step 3: Implement unique identity recording**
+
+Retain the exported JSON counter fields and add unexported identity sets to `updateReport`. Change counted update helpers to return deterministic identities:
+
+```go
+type changedBlock struct {
+    kind  string
+    index string
+}
+```
+
+Use the canonical selected-file path plus top-level and nested block indexes as the identity. Record each identity through methods on `updateReport`; only the first insertion increments its public counter. Preserve the existing human-readable `updated` booleans and sequential update behaviour.
+
+- [ ] **Step 4: Verify the focused test and existing report tests pass**
+
+Run:
+
+```bash
+go test -run 'TestCommandReport(CountsEachBlockOnce|PreservesSameTargetHumanOutput)|TestCommandWritesExactUpdatedBlockCounts' -v
+```
+
+Expected: PASS with pristine output.
+
+- [ ] **Step 5: Commit the counting fix**
+
+Stage `command_test.go` and `main.go`, then create a signed commit named `fix: count unique updated blocks`.
+
+### Task 2: Reserve a safe report destination before updates
+
+**Files:**
+- Modify: `command_test.go`
+- Modify: `main.go`
+
+**Interfaces:**
+- Consumes: `flags.reportFile`, selected Terraform paths, and optional `flags.configFile`.
+- Produces: a prepared report destination that owns a same-directory temporary file, rejects input aliases, cleans up on ordinary failure, and publishes JSON by rename after successful updates.
+
+- [ ] **Step 1: Write failing collision tests**
+
+Add command-level subtests for a report path equal to the selected Terraform path and equal to the YAML config path. Assert exit code `1`, a collision diagnostic, and byte-for-byte unchanged input files.
+
+- [ ] **Step 2: Verify the collision tests fail destructively**
+
+Run:
+
+```bash
+go test -run TestCommandRejectsReportInputCollision -v
+```
+
+Expected: FAIL because the current command processes and overwrites the colliding destination.
+
+- [ ] **Step 3: Implement collision validation before updates**
+
+Resolve absolute paths, compare clean paths, and use `os.SameFile` when both paths exist so symlink and hard-link aliases are rejected. Validate against every selected Terraform path and the config path before running either update mode.
+
+- [ ] **Step 4: Verify collision tests pass**
+
+Run:
+
+```bash
+go test -run TestCommandRejectsReportInputCollision -v
+```
+
+Expected: PASS with unchanged fixtures.
+
+- [ ] **Step 5: Write the failing unusable-destination test**
+
+Run a real module update with `-report-file` under a nonexistent parent directory. Assert exit code `1`, a preparation diagnostic, and unchanged Terraform content.
+
+- [ ] **Step 6: Verify the destination test fails after mutation**
+
+Run:
+
+```bash
+go test -run TestCommandRejectsUnusableReportDestinationBeforeUpdating -v
+```
+
+Expected: FAIL because the Terraform version changes before `os.WriteFile` reports the missing directory.
+
+- [ ] **Step 7: Implement temporary reservation and publication**
+
+Before updates, create a temporary file in the report destination directory. After successful updates, marshal JSON, apply mode `0600`, write and close the temporary file, then rename it to the requested path. On ordinary processing or write failure, close and remove the temporary file before exiting.
+
+- [ ] **Step 8: Verify destination and report tests pass**
+
+Run:
+
+```bash
+go test -run 'TestCommand(RejectsReportInputCollision|RejectsUnusableReportDestinationBeforeUpdating|WritesExactUpdatedBlockCounts|ConfigDryRunOutputContract)' -v
+```
+
+Expected: PASS with pristine output.
+
+- [ ] **Step 9: Commit the destination fix**
+
+Stage `command_test.go` and `main.go`, then create a signed commit named `fix: prepare report output safely`.
+
+### Task 3: Correct contributor documentation
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Interfaces:**
+- Consumes: current production helper names in `main.go`.
+- Produces: contributor guidance that names `updateModuleVersionWithCount`, `updateModuleBlockResult`, `updateProviderVersionWithCount`, `updateProviderBlockSyntaxResult`, and `updateProviderAttributeVersionResult` accurately.
+
+- [ ] **Step 1: Update the architecture and testing examples**
+
+Correct the update-flow paragraphs, module precedence owner, provider helper chain, and representative call. The call must capture all three return values:
+
+```go
+updated, blocksChanged, err := updateModuleVersionWithCount(...)
+```
+
+- [ ] **Step 2: Verify documentation**
+
+Run:
+
+```bash
+make docs-check
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit the documentation correction**
+
+Stage `CLAUDE.md`, then create a signed commit named `docs: correct report helper architecture`.
+
+### Task 4: Cleanup and final verification
+
+**Files:**
+- Review: all branch changes against `main`
+- Verify against: `/tmp/tf-version-bump-par-findings.md`
+
+**Interfaces:**
+- Consumes: completed Tasks 1-3.
+- Produces: a clean, fully verified, signed topic branch with every review finding adjudicated.
+
+- [ ] **Step 1: Run the required independent test-cleanup pass**
+
+Use the `test-cleanup` skill in a separate subagent. Apply only legitimate cleanup findings through a new TDD-preserving signed commit.
+
+- [ ] **Step 2: Run full validation**
+
+Run:
+
+```bash
+make test-coverage
+golangci-lint run --timeout=5m
+go vet ./...
+make docs-check
+make build
+make test-github-actions TEST_GIT=/tmp/tf-version-bump-signed-test-git
+```
+
+Expected: every command passes, race-enabled coverage remains at least 90%, and lint output contains zero issues.
+
+- [ ] **Step 3: Verify the peer-review findings**
+
+Use `$verify` against `/tmp/tf-version-bump-par-findings.md`, checking each finding and collateral behaviour from the cumulative `main...HEAD` diff.
+
+- [ ] **Step 4: Verify repository integrity**
+
+Confirm the worktree is clean, `git diff --check main...HEAD` passes, and every `main..HEAD` commit has a good signature.

--- a/main.go
+++ b/main.go
@@ -641,7 +641,7 @@ func updateTerraformVersion(filename, version string, dryRun bool) (bool, error)
 	return updated, nil
 }
 
-// updateProviderVersion updates the version attribute for a specific provider in terraform required_providers blocks
+// updateProviderVersionWithCount updates a provider version and counts blocks whose values changed.
 //
 // This implementation supports both provider syntax styles:
 //
@@ -660,7 +660,8 @@ func updateTerraformVersion(filename, version string, dryRun bool) (bool, error)
 //   - dryRun: If true, show what would be changed without modifying files
 //
 // Returns:
-//   - bool: true if a provider was updated (or would be updated in dry-run mode)
+//   - updated: true if a provider operation was applied (or would be applied in dry-run mode)
+//   - blocksChanged: number of provider blocks whose version values differ from the target
 //   - error: Any error encountered during file reading, parsing, or writing
 func updateProviderVersionWithCount(filename, providerName, version string, dryRun bool) (updated bool, blocksChanged int, err error) {
 	// Get original file permissions to preserve them when writing
@@ -851,8 +852,7 @@ func providerObjectItemKey(item hclsyntax.ObjectConsItem) (string, bool) {
 	return rootName.Name, true
 }
 
-// updateModuleVersion parses a Terraform file, finds modules with the specified source,
-// updates their version attribute, and writes the modified content back to the file.
+// updateModuleVersionWithCount updates modules with the specified source and counts changed blocks.
 //
 // The function retains comments and other HCL structures, then normalises the changed file with
 // hclwrite.Format.
@@ -880,7 +880,8 @@ func providerObjectItemKey(item hclsyntax.ObjectConsItem) (string, bool) {
 //   - outputFormat: Output format ("text" or "md")
 //
 // Returns:
-//   - bool: true if at least one module was updated (or would be updated in dry-run mode), false otherwise
+//   - updated: true if at least one module operation was applied (or would be applied in dry-run mode)
+//   - blocksChanged: number of module blocks whose version values differ from the target
 //   - error: Any error encountered during file reading, parsing, or writing
 func updateModuleVersionWithCount(filename, moduleSource, version string, fromVersions, ignoreVersions, ignorePatterns []string, forceAdd, dryRun, verbose bool, outputFormat string) (updated bool, blocksChanged int, err error) {
 	// Get original file permissions to preserve them when writing

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io/fs"
@@ -116,6 +117,14 @@ type cliFlags struct {
 	output           string
 	terraformVersion string
 	providerName     string
+	reportFile       string
+	report           updateReport
+}
+
+type updateReport struct {
+	SchemaVersion         int `json:"schema_version"`
+	ModuleBlocksUpdated   int `json:"module_blocks_updated"`
+	ProviderBlocksUpdated int `json:"provider_blocks_updated"`
 }
 
 // parseFlags parses and validates command-line flags
@@ -136,6 +145,7 @@ func parseFlags() *cliFlags {
 	flag.StringVar(&flags.output, "output", "text", "Output format: 'text' (default) or 'md' (Markdown)")
 	flag.StringVar(&flags.terraformVersion, "terraform-version", "", "Update Terraform required_version in terraform blocks")
 	flag.StringVar(&flags.providerName, "provider", "", "Provider name to update (e.g., 'aws', 'azurerm')")
+	flag.StringVar(&flags.reportFile, "report-file", "", "Write exact updated module and provider block counts as JSON")
 	flag.Parse()
 
 	// Validate output format
@@ -176,13 +186,14 @@ func loadModuleUpdates(flags *cliFlags) []ModuleUpdate {
 func processFiles(files []string, updates []ModuleUpdate, flags *cliFlags) (totalUpdates, totalErrors int) {
 	for _, file := range files {
 		for _, update := range updates {
-			updated, err := updateModuleVersion(file, update.Source, update.Version, update.From, update.IgnoreVersions, update.IgnoreModules, flags.forceAdd, flags.dryRun, flags.verbose, flags.output)
+			updated, blocksUpdated, err := updateModuleVersionWithCount(file, update.Source, update.Version, update.From, update.IgnoreVersions, update.IgnoreModules, flags.forceAdd, flags.dryRun, flags.verbose, flags.output)
 			if err != nil {
 				log.Printf("Error processing %s: %v", file, err)
 				totalErrors++
 				continue
 			}
 			if updated {
+				flags.report.ModuleBlocksUpdated += blocksUpdated
 				prefix := "✓"
 				action := "Updated"
 				if flags.dryRun {
@@ -244,6 +255,17 @@ func main() {
 	}
 	if err != nil {
 		fatalf("%v", err)
+	}
+	if flags.reportFile != "" {
+		flags.report.SchemaVersion = 1
+		data, marshalErr := json.MarshalIndent(flags.report, "", "  ")
+		if marshalErr != nil {
+			fatalf("Error creating update report: %v", marshalErr)
+		}
+		data = append(data, '\n')
+		if writeErr := os.WriteFile(flags.reportFile, data, 0o600); writeErr != nil {
+			fatalf("Error writing update report: %v", writeErr)
+		}
 	}
 }
 
@@ -366,7 +388,7 @@ func runConfigFileMode(files []string, flags *cliFlags) error {
 
 	// Process provider updates if specified
 	for _, provider := range config.Providers {
-		count, errors := processProviderVersion(files, provider.Name, provider.Version, flags.dryRun, flags.output)
+		count, errors := processProviderVersion(files, provider.Name, provider.Version, flags.dryRun, flags.output, &flags.report)
 		providerUpdates += count
 		providerErrors += errors
 	}
@@ -406,7 +428,7 @@ func runCLIMode(files []string, flags *cliFlags) error {
 			fatalf("Error: -to flag is required when using -provider")
 		}
 		var totalErrors int
-		totalUpdates, totalErrors = processProviderVersion(files, flags.providerName, flags.toVersion, flags.dryRun, flags.output)
+		totalUpdates, totalErrors = processProviderVersion(files, flags.providerName, flags.toVersion, flags.dryRun, flags.output, &flags.report)
 		printProviderSummary(flags.providerName, totalUpdates, flags.dryRun, flags.output)
 		if totalErrors > 0 {
 			return fmt.Errorf("%d provider update error(s)", totalErrors)
@@ -537,15 +559,16 @@ func processTerraformVersion(files []string, version string, dryRun bool, output
 // Returns:
 //   - totalUpdates: Number of files that were updated (or would be updated in dry-run mode)
 //   - totalErrors: Number of files that could not be processed
-func processProviderVersion(files []string, providerName, version string, dryRun bool, outputFormat string) (totalUpdates, totalErrors int) {
+func processProviderVersion(files []string, providerName, version string, dryRun bool, outputFormat string, report *updateReport) (totalUpdates, totalErrors int) {
 	for _, file := range files {
-		updated, err := updateProviderVersion(file, providerName, version, dryRun)
+		updated, blocksUpdated, err := updateProviderVersionWithCount(file, providerName, version, dryRun)
 		if err != nil {
 			log.Printf("Error processing %s: %v", file, err)
 			totalErrors++
 			continue
 		}
 		if updated {
+			report.ProviderBlocksUpdated += blocksUpdated
 			prefix := "✓"
 			action := "Updated"
 			if dryRun {
@@ -636,80 +659,95 @@ func updateTerraformVersion(filename, version string, dryRun bool) (bool, error)
 //   - bool: true if a provider was updated (or would be updated in dry-run mode)
 //   - error: Any error encountered during file reading, parsing, or writing
 func updateProviderVersion(filename, providerName, version string, dryRun bool) (bool, error) {
+	updated, _, err := updateProviderVersionWithCount(filename, providerName, version, dryRun)
+	return updated, err
+}
+
+func updateProviderVersionWithCount(filename, providerName, version string, dryRun bool) (bool, int, error) {
 	// Get original file permissions to preserve them when writing
 	fileInfo, err := os.Stat(filename)
 	if err != nil {
-		return false, fmt.Errorf("failed to stat file: %w", err)
+		return false, 0, fmt.Errorf("failed to stat file: %w", err)
 	}
 	originalMode := fileInfo.Mode()
 
 	// Read the file
 	src, err := os.ReadFile(filename)
 	if err != nil {
-		return false, fmt.Errorf("failed to read file: %w", err)
+		return false, 0, fmt.Errorf("failed to read file: %w", err)
 	}
 
 	// Parse the file with hclwrite
 	file, diags := hclwrite.ParseConfig(src, filename, hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
-		return false, fmt.Errorf("failed to parse HCL: %s", diags.Error())
+		return false, 0, fmt.Errorf("failed to parse HCL: %s", diags.Error())
 	}
 
-	// Track if we made any changes
-	updated := false
+	blocksUpdated := 0
 
 	// Iterate through all blocks in the file
 	for _, block := range file.Body().Blocks() {
-		if updateProviderTerraformBlock(block, providerName, version) {
-			updated = true
-		}
+		blocksUpdated += updateProviderTerraformBlockCount(block, providerName, version)
 	}
 
 	// If we made changes, write the file back (unless in dry-run mode)
-	if updated && !dryRun {
+	if blocksUpdated > 0 && !dryRun {
 		output := hclwrite.Format(file.Bytes())
 		// Preserve original file permissions
 		if err := os.WriteFile(filename, output, originalMode.Perm()); err != nil {
-			return false, fmt.Errorf("failed to write file: %w", err)
+			return false, 0, fmt.Errorf("failed to write file: %w", err)
 		}
 	}
 
-	return updated, nil
+	return blocksUpdated > 0, blocksUpdated, nil
 }
 
 func updateProviderTerraformBlock(block *hclwrite.Block, providerName, version string) bool {
+	return updateProviderTerraformBlockCount(block, providerName, version) > 0
+}
+
+func updateProviderTerraformBlockCount(block *hclwrite.Block, providerName, version string) int {
 	if block.Type() != "terraform" {
-		return false
+		return 0
 	}
 
-	updated := false
+	blocksUpdated := 0
 	for _, nestedBlock := range block.Body().Blocks() {
 		if nestedBlock.Type() != "required_providers" {
 			continue
 		}
-		if updateProviderBlockSyntax(nestedBlock, providerName, version) {
-			updated = true
+		blockSyntaxUpdates := updateProviderBlockSyntaxCount(nestedBlock, providerName, version)
+		if blockSyntaxUpdates > 0 {
+			blocksUpdated += blockSyntaxUpdates
 			continue
 		}
 		if updateProviderAttributeVersion(nestedBlock, providerName, version) {
-			updated = true
+			blocksUpdated++
 		}
 	}
 
-	return updated
+	return blocksUpdated
 }
 
 func updateProviderBlockSyntax(nestedBlock *hclwrite.Block, providerName, version string) bool {
-	updated := false
+	return updateProviderBlockSyntaxCount(nestedBlock, providerName, version) > 0
+}
+
+func updateProviderBlockSyntaxCount(nestedBlock *hclwrite.Block, providerName, version string) int {
+	blocksUpdated := 0
 	for _, providerBlock := range nestedBlock.Body().Blocks() {
 		if providerBlock.Type() != providerName {
 			continue
 		}
+		versionAttribute := providerBlock.Body().GetAttribute("version")
+		if versionAttribute != nil && attributeStringValue(versionAttribute) == version {
+			continue
+		}
 		providerBlock.Body().SetAttributeValue("version", cty.StringVal(version))
-		updated = true
+		blocksUpdated++
 	}
 
-	return updated
+	return blocksUpdated
 }
 
 // updateProviderAttributeVersion updates the version value within a provider attribute's object expression
@@ -720,8 +758,8 @@ func updateProviderAttributeVersion(nestedBlock *hclwrite.Block, providerName, n
 		return false
 	}
 
-	updatedExpression, hasVersion := replaceProviderObjectVersion(objExpr, expression, newVersion)
-	if !hasVersion {
+	updatedExpression, hasVersion, changed := replaceProviderObjectVersion(objExpr, expression, newVersion)
+	if !hasVersion || !changed {
 		return false
 	}
 
@@ -756,9 +794,10 @@ func providerAttributeObject(nestedBlock *hclwrite.Block, providerName string) (
 	return objExpr, expression, ok
 }
 
-func replaceProviderObjectVersion(objExpr *hclsyntax.ObjectConsExpr, expression []byte, newVersion string) ([]byte, bool) {
+func replaceProviderObjectVersion(objExpr *hclsyntax.ObjectConsExpr, expression []byte, newVersion string) ([]byte, bool, bool) {
 	updated := append([]byte(nil), expression...)
 	hasVersion := false
+	changed := false
 	newValue := hclwrite.TokensForValue(cty.StringVal(newVersion)).Bytes()
 
 	for index := len(objExpr.Items) - 1; index >= 0; index-- {
@@ -770,7 +809,11 @@ func replaceProviderObjectVersion(objExpr *hclsyntax.ObjectConsExpr, expression 
 
 		valueRange := item.ValueExpr.Range()
 		if valueRange.Start.Byte < 0 || valueRange.End.Byte > len(expression) || valueRange.Start.Byte > valueRange.End.Byte {
-			return nil, false
+			return nil, false, false
+		}
+		hasVersion = true
+		if attributeExpressionStringValue(expression[valueRange.Start.Byte:valueRange.End.Byte]) == newVersion {
+			continue
 		}
 
 		next := make([]byte, 0, len(updated)-valueRange.End.Byte+valueRange.Start.Byte+len(newValue))
@@ -778,10 +821,14 @@ func replaceProviderObjectVersion(objExpr *hclsyntax.ObjectConsExpr, expression 
 		next = append(next, newValue...)
 		next = append(next, updated[valueRange.End.Byte:]...)
 		updated = next
-		hasVersion = true
+		changed = true
 	}
 
-	return updated, hasVersion
+	return updated, hasVersion, changed
+}
+
+func attributeExpressionStringValue(expression []byte) string {
+	return trimQuotes(strings.TrimSpace(string(expression)))
 }
 
 func providerObjectItemKey(item hclsyntax.ObjectConsItem) (string, bool) {
@@ -835,27 +882,31 @@ func providerObjectItemKey(item hclsyntax.ObjectConsItem) (string, bool) {
 //   - bool: true if at least one module was updated (or would be updated in dry-run mode), false otherwise
 //   - error: Any error encountered during file reading, parsing, or writing
 func updateModuleVersion(filename, moduleSource, version string, fromVersions, ignoreVersions, ignorePatterns []string, forceAdd, dryRun, verbose bool, outputFormat string) (bool, error) {
+	updated, _, err := updateModuleVersionWithCount(filename, moduleSource, version, fromVersions, ignoreVersions, ignorePatterns, forceAdd, dryRun, verbose, outputFormat)
+	return updated, err
+}
+
+func updateModuleVersionWithCount(filename, moduleSource, version string, fromVersions, ignoreVersions, ignorePatterns []string, forceAdd, dryRun, verbose bool, outputFormat string) (bool, int, error) {
 	// Get original file permissions to preserve them when writing
 	fileInfo, err := os.Stat(filename)
 	if err != nil {
-		return false, fmt.Errorf("failed to stat file: %w", err)
+		return false, 0, fmt.Errorf("failed to stat file: %w", err)
 	}
 	originalMode := fileInfo.Mode()
 
 	// Read the file
 	src, err := os.ReadFile(filename)
 	if err != nil {
-		return false, fmt.Errorf("failed to read file: %w", err)
+		return false, 0, fmt.Errorf("failed to read file: %w", err)
 	}
 
 	// Parse the file with hclwrite
 	file, diags := hclwrite.ParseConfig(src, filename, hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
-		return false, fmt.Errorf("failed to parse HCL: %s", diags.Error())
+		return false, 0, fmt.Errorf("failed to parse HCL: %s", diags.Error())
 	}
 
-	// Track if we made any changes
-	updated := false
+	blocksUpdated := 0
 	opts := moduleUpdateOptions{
 		filename:       filename,
 		moduleSource:   moduleSource,
@@ -871,20 +922,20 @@ func updateModuleVersion(filename, moduleSource, version string, fromVersions, i
 	// Iterate through all blocks in the file
 	for _, block := range file.Body().Blocks() {
 		if updateModuleBlock(block, &opts) {
-			updated = true
+			blocksUpdated++
 		}
 	}
 
 	// If we made changes, write the file back (unless in dry-run mode)
-	if updated && !dryRun {
+	if blocksUpdated > 0 && !dryRun {
 		output := hclwrite.Format(file.Bytes())
 		// Preserve original file permissions
 		if err := os.WriteFile(filename, output, originalMode.Perm()); err != nil {
-			return false, fmt.Errorf("failed to write file: %w", err)
+			return false, 0, fmt.Errorf("failed to write file: %w", err)
 		}
 	}
 
-	return updated, nil
+	return blocksUpdated > 0, blocksUpdated, nil
 }
 
 type moduleUpdateOptions struct {
@@ -935,8 +986,11 @@ func updateModuleBlock(block *hclwrite.Block, opts *moduleUpdateOptions) bool {
 				quote(moduleName, opts.outputFormat), opts.filename, quote(opts.moduleSource, opts.outputFormat))
 			return false
 		}
-	} else if shouldSkipModuleVersion(moduleName, attributeStringValue(versionAttr), opts) {
-		return false
+	} else {
+		currentVersion := attributeStringValue(versionAttr)
+		if shouldSkipModuleVersion(moduleName, currentVersion, opts) || currentVersion == opts.version {
+			return false
+		}
 	}
 
 	block.Body().SetAttributeValue("version", cty.StringVal(opts.version))

--- a/main.go
+++ b/main.go
@@ -662,12 +662,7 @@ func updateTerraformVersion(filename, version string, dryRun bool) (bool, error)
 // Returns:
 //   - bool: true if a provider was updated (or would be updated in dry-run mode)
 //   - error: Any error encountered during file reading, parsing, or writing
-func updateProviderVersion(filename, providerName, version string, dryRun bool) (bool, error) {
-	updated, _, err := updateProviderVersionWithCount(filename, providerName, version, dryRun)
-	return updated, err
-}
-
-func updateProviderVersionWithCount(filename, providerName, version string, dryRun bool) (bool, int, error) {
+func updateProviderVersionWithCount(filename, providerName, version string, dryRun bool) (updated bool, blocksChanged int, err error) {
 	// Get original file permissions to preserve them when writing
 	fileInfo, err := os.Stat(filename)
 	if err != nil {
@@ -687,8 +682,8 @@ func updateProviderVersionWithCount(filename, providerName, version string, dryR
 		return false, 0, fmt.Errorf("failed to parse HCL: %s", diags.Error())
 	}
 
-	updated := false
-	blocksChanged := 0
+	updated = false
+	blocksChanged = 0
 
 	// Iterate through all blocks in the file
 	for _, block := range file.Body().Blocks() {
@@ -709,18 +704,13 @@ func updateProviderVersionWithCount(filename, providerName, version string, dryR
 	return updated, blocksChanged, nil
 }
 
-func updateProviderTerraformBlock(block *hclwrite.Block, providerName, version string) bool {
-	updated, _ := updateProviderTerraformBlockResult(block, providerName, version)
-	return updated
-}
-
-func updateProviderTerraformBlockResult(block *hclwrite.Block, providerName, version string) (bool, int) {
+func updateProviderTerraformBlockResult(block *hclwrite.Block, providerName, version string) (updated bool, blocksChanged int) {
 	if block.Type() != "terraform" {
 		return false, 0
 	}
 
-	updated := false
-	blocksChanged := 0
+	updated = false
+	blocksChanged = 0
 	for _, nestedBlock := range block.Body().Blocks() {
 		if nestedBlock.Type() != "required_providers" {
 			continue
@@ -743,14 +733,9 @@ func updateProviderTerraformBlockResult(block *hclwrite.Block, providerName, ver
 	return updated, blocksChanged
 }
 
-func updateProviderBlockSyntax(nestedBlock *hclwrite.Block, providerName, version string) bool {
-	updated, _ := updateProviderBlockSyntaxResult(nestedBlock, providerName, version)
-	return updated
-}
-
-func updateProviderBlockSyntaxResult(nestedBlock *hclwrite.Block, providerName, version string) (bool, int) {
-	updated := false
-	blocksChanged := 0
+func updateProviderBlockSyntaxResult(nestedBlock *hclwrite.Block, providerName, version string) (updated bool, blocksChanged int) {
+	updated = false
+	blocksChanged = 0
 	for _, providerBlock := range nestedBlock.Body().Blocks() {
 		if providerBlock.Type() != providerName {
 			continue
@@ -768,12 +753,7 @@ func updateProviderBlockSyntaxResult(nestedBlock *hclwrite.Block, providerName, 
 
 // updateProviderAttributeVersion updates the version value within a provider attribute's object expression
 // This handles the attribute-based syntax: aws = { source = "..." version = "..." }
-func updateProviderAttributeVersion(nestedBlock *hclwrite.Block, providerName, newVersion string) bool {
-	updated, _ := updateProviderAttributeVersionResult(nestedBlock, providerName, newVersion)
-	return updated
-}
-
-func updateProviderAttributeVersionResult(nestedBlock *hclwrite.Block, providerName, newVersion string) (bool, bool) {
+func updateProviderAttributeVersionResult(nestedBlock *hclwrite.Block, providerName, newVersion string) (updated, changed bool) {
 	objExpr, expression, ok := providerAttributeObject(nestedBlock, providerName)
 	if !ok {
 		return false, false
@@ -815,10 +795,10 @@ func providerAttributeObject(nestedBlock *hclwrite.Block, providerName string) (
 	return objExpr, expression, ok
 }
 
-func replaceProviderObjectVersion(objExpr *hclsyntax.ObjectConsExpr, expression []byte, newVersion string) ([]byte, bool, bool) {
-	updated := append([]byte(nil), expression...)
-	hasVersion := false
-	changed := false
+func replaceProviderObjectVersion(objExpr *hclsyntax.ObjectConsExpr, expression []byte, newVersion string) (updated []byte, hasVersion, changed bool) {
+	updated = append([]byte(nil), expression...)
+	hasVersion = false
+	changed = false
 	newValue := hclwrite.TokensForValue(cty.StringVal(newVersion)).Bytes()
 
 	for index := len(objExpr.Items) - 1; index >= 0; index-- {
@@ -902,12 +882,7 @@ func providerObjectItemKey(item hclsyntax.ObjectConsItem) (string, bool) {
 // Returns:
 //   - bool: true if at least one module was updated (or would be updated in dry-run mode), false otherwise
 //   - error: Any error encountered during file reading, parsing, or writing
-func updateModuleVersion(filename, moduleSource, version string, fromVersions, ignoreVersions, ignorePatterns []string, forceAdd, dryRun, verbose bool, outputFormat string) (bool, error) {
-	updated, _, err := updateModuleVersionWithCount(filename, moduleSource, version, fromVersions, ignoreVersions, ignorePatterns, forceAdd, dryRun, verbose, outputFormat)
-	return updated, err
-}
-
-func updateModuleVersionWithCount(filename, moduleSource, version string, fromVersions, ignoreVersions, ignorePatterns []string, forceAdd, dryRun, verbose bool, outputFormat string) (bool, int, error) {
+func updateModuleVersionWithCount(filename, moduleSource, version string, fromVersions, ignoreVersions, ignorePatterns []string, forceAdd, dryRun, verbose bool, outputFormat string) (updated bool, blocksChanged int, err error) {
 	// Get original file permissions to preserve them when writing
 	fileInfo, err := os.Stat(filename)
 	if err != nil {
@@ -927,8 +902,8 @@ func updateModuleVersionWithCount(filename, moduleSource, version string, fromVe
 		return false, 0, fmt.Errorf("failed to parse HCL: %s", diags.Error())
 	}
 
-	updated := false
-	blocksChanged := 0
+	updated = false
+	blocksChanged = 0
 	opts := moduleUpdateOptions{
 		filename:       filename,
 		moduleSource:   moduleSource,
@@ -976,12 +951,7 @@ type moduleUpdateOptions struct {
 	outputFormat   string
 }
 
-func updateModuleBlock(block *hclwrite.Block, opts *moduleUpdateOptions) bool {
-	updated, _ := updateModuleBlockResult(block, opts)
-	return updated
-}
-
-func updateModuleBlockResult(block *hclwrite.Block, opts *moduleUpdateOptions) (bool, bool) {
+func updateModuleBlockResult(block *hclwrite.Block, opts *moduleUpdateOptions) (updated, changed bool) {
 	if block.Type() != "module" {
 		return false, false
 	}

--- a/main.go
+++ b/main.go
@@ -129,6 +129,11 @@ type updateReport struct {
 	providerBlockIDs      map[string]struct{}
 }
 
+type preparedReportFile struct {
+	destination string
+	file        *os.File
+}
+
 func (report *updateReport) recordModuleBlocks(filename string, blockIndexes []int) {
 	fileID := canonicalFileIdentity(filename)
 	if report.moduleBlockIDs == nil {
@@ -291,28 +296,132 @@ func main() {
 
 	// Find and validate matching files
 	files := findMatchingFiles(flags)
+	inputFiles := files
+	if flags.configFile != "" {
+		inputFiles = append(append([]string(nil), files...), flags.configFile)
+	}
+	preparedReport, err := prepareUpdateReport(flags.reportFile, inputFiles)
+	if err != nil {
+		fatalf("%v", err)
+	}
 
 	// Run the appropriate operation mode
-	var err error
 	if flags.configFile != "" {
 		err = runConfigFileMode(files, flags)
 	} else {
 		err = runCLIMode(files, flags)
 	}
 	if err != nil {
+		if preparedReport != nil {
+			if discardErr := preparedReport.discard(); discardErr != nil {
+				err = fmt.Errorf("%w; failed to discard prepared report: %v", err, discardErr)
+			}
+		}
 		fatalf("%v", err)
 	}
-	if flags.reportFile != "" {
+	if preparedReport != nil {
 		flags.report.SchemaVersion = 1
-		data, marshalErr := json.MarshalIndent(flags.report, "", "  ")
-		if marshalErr != nil {
-			fatalf("Error creating update report: %v", marshalErr)
-		}
-		data = append(data, '\n')
-		if writeErr := os.WriteFile(flags.reportFile, data, 0o600); writeErr != nil {
-			fatalf("Error writing update report: %v", writeErr)
+		if publishErr := preparedReport.publish(flags.report); publishErr != nil {
+			fatalf("Error writing update report: %v", publishErr)
 		}
 	}
+}
+
+func prepareUpdateReport(reportFile string, inputFiles []string) (*preparedReportFile, error) {
+	if reportFile == "" {
+		return nil, nil
+	}
+	if err := validateReportFileDoesNotOverwriteInput(reportFile, inputFiles); err != nil {
+		return nil, err
+	}
+
+	file, err := os.CreateTemp(filepath.Dir(reportFile), ".tf-version-bump-report-*")
+	if err != nil {
+		return nil, fmt.Errorf("Error preparing update report: %w", err) //nolint:staticcheck // User-facing CLI diagnostic.
+	}
+	return &preparedReportFile{destination: reportFile, file: file}, nil
+}
+
+func (prepared *preparedReportFile) publish(report updateReport) error {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		_ = prepared.discard()
+		return fmt.Errorf("create report: %w", err)
+	}
+	data = append(data, '\n')
+	if _, err := prepared.file.Write(data); err != nil {
+		_ = prepared.discard()
+		return err
+	}
+	if err := prepared.file.Sync(); err != nil {
+		_ = prepared.discard()
+		return err
+	}
+	temporaryName := prepared.file.Name()
+	if err := prepared.file.Close(); err != nil {
+		_ = os.Remove(temporaryName)
+		return err
+	}
+	prepared.file = nil
+	if err := os.Rename(temporaryName, prepared.destination); err != nil {
+		_ = os.Remove(temporaryName)
+		return err
+	}
+	return nil
+}
+
+func (prepared *preparedReportFile) discard() error {
+	if prepared == nil || prepared.file == nil {
+		return nil
+	}
+	temporaryName := prepared.file.Name()
+	closeErr := prepared.file.Close()
+	prepared.file = nil
+	removeErr := os.Remove(temporaryName)
+	if closeErr != nil {
+		return closeErr
+	}
+	return removeErr
+}
+
+func validateReportFileDoesNotOverwriteInput(reportFile string, inputFiles []string) error {
+	if reportFile == "" {
+		return nil
+	}
+
+	reportPath, err := filepath.Abs(reportFile)
+	if err != nil {
+		return fmt.Errorf("Error resolving report file: %w", err) //nolint:staticcheck // User-facing CLI diagnostic.
+	}
+	reportInfo, reportStatErr := os.Stat(reportPath)
+	if reportStatErr != nil && !os.IsNotExist(reportStatErr) {
+		return fmt.Errorf("Error inspecting report file: %w", reportStatErr) //nolint:staticcheck // User-facing CLI diagnostic.
+	}
+	if reportStatErr == nil && reportInfo.IsDir() {
+		return fmt.Errorf("Error preparing update report: destination is a directory: %s", reportFile) //nolint:staticcheck // User-facing CLI diagnostic.
+	}
+
+	for _, inputFile := range inputFiles {
+		inputPath, absErr := filepath.Abs(inputFile)
+		if absErr != nil {
+			return fmt.Errorf("Error resolving input file %s: %w", inputFile, absErr) //nolint:staticcheck // User-facing CLI diagnostic.
+		}
+		if filepath.Clean(reportPath) == filepath.Clean(inputPath) {
+			return fmt.Errorf("Error: report file must not overwrite input file: %s", reportFile) //nolint:staticcheck // User-facing CLI diagnostic.
+		}
+		if reportStatErr != nil {
+			continue
+		}
+		inputInfo, inputStatErr := os.Stat(inputPath)
+		if inputStatErr != nil {
+			return fmt.Errorf("Error inspecting input file %s: %w", inputFile, inputStatErr) //nolint:staticcheck // User-facing CLI diagnostic.
+		}
+		if os.SameFile(reportInfo, inputInfo) {
+			return fmt.Errorf("Error: report file must not overwrite input file: %s", reportFile) //nolint:staticcheck // User-facing CLI diagnostic.
+		}
+	}
+
+	return nil
 }
 
 // validateOperationModes validates that the CLI flags are properly set

--- a/main.go
+++ b/main.go
@@ -135,6 +135,13 @@ type preparedReportFile struct {
 	file        *os.File
 }
 
+func (flags *cliFlags) reportRecorder() *updateReport {
+	if flags.reportFile == "" {
+		return nil
+	}
+	return &flags.report
+}
+
 func (report *updateReport) recordModuleBlocks(filename string, blockIndexes []int) {
 	fileID := report.fileIdentity(filename)
 	if report.moduleBlockIDs == nil {
@@ -257,8 +264,8 @@ func processFiles(files []string, updates []ModuleUpdate, flags *cliFlags) (tota
 				continue
 			}
 			if updated {
-				if !flags.dryRun {
-					flags.report.recordModuleBlocks(file, changedBlocks)
+				if report := flags.reportRecorder(); report != nil && !flags.dryRun && len(changedBlocks) > 0 {
+					report.recordModuleBlocks(file, changedBlocks)
 				}
 				prefix := "✓"
 				action := "Updated"
@@ -568,7 +575,7 @@ func runConfigFileMode(files []string, flags *cliFlags) error {
 
 	// Process provider updates if specified
 	for _, provider := range config.Providers {
-		count, errors := processProviderVersion(files, provider.Name, provider.Version, flags.dryRun, flags.output, &flags.report)
+		count, errors := processProviderVersion(files, provider.Name, provider.Version, flags.dryRun, flags.output, flags.reportRecorder())
 		providerUpdates += count
 		providerErrors += errors
 	}
@@ -608,7 +615,7 @@ func runCLIMode(files []string, flags *cliFlags) error {
 			fatalf("Error: -to flag is required when using -provider")
 		}
 		var totalErrors int
-		totalUpdates, totalErrors = processProviderVersion(files, flags.providerName, flags.toVersion, flags.dryRun, flags.output, &flags.report)
+		totalUpdates, totalErrors = processProviderVersion(files, flags.providerName, flags.toVersion, flags.dryRun, flags.output, flags.reportRecorder())
 		printProviderSummary(flags.providerName, totalUpdates, flags.dryRun, flags.output)
 		if totalErrors > 0 {
 			return fmt.Errorf("%d provider update error(s)", totalErrors)
@@ -748,7 +755,7 @@ func processProviderVersion(files []string, providerName, version string, dryRun
 			continue
 		}
 		if updated {
-			if !dryRun {
+			if report != nil && !dryRun && len(changedBlocks) > 0 {
 				report.recordProviderBlocks(file, changedBlocks)
 			}
 			prefix := "✓"

--- a/main.go
+++ b/main.go
@@ -125,6 +125,50 @@ type updateReport struct {
 	SchemaVersion         int `json:"schema_version"`
 	ModuleBlocksUpdated   int `json:"module_blocks_updated"`
 	ProviderBlocksUpdated int `json:"provider_blocks_updated"`
+	moduleBlockIDs        map[string]struct{}
+	providerBlockIDs      map[string]struct{}
+}
+
+func (report *updateReport) recordModuleBlocks(filename string, blockIndexes []int) {
+	fileID := canonicalFileIdentity(filename)
+	if report.moduleBlockIDs == nil {
+		report.moduleBlockIDs = make(map[string]struct{})
+	}
+	for _, blockIndex := range blockIndexes {
+		blockID := fmt.Sprintf("%s\x00%d", fileID, blockIndex)
+		if _, recorded := report.moduleBlockIDs[blockID]; recorded {
+			continue
+		}
+		report.moduleBlockIDs[blockID] = struct{}{}
+		report.ModuleBlocksUpdated++
+	}
+}
+
+func (report *updateReport) recordProviderBlocks(filename string, blockLocations []string) {
+	fileID := canonicalFileIdentity(filename)
+	if report.providerBlockIDs == nil {
+		report.providerBlockIDs = make(map[string]struct{})
+	}
+	for _, blockLocation := range blockLocations {
+		blockID := fileID + "\x00" + blockLocation
+		if _, recorded := report.providerBlockIDs[blockID]; recorded {
+			continue
+		}
+		report.providerBlockIDs[blockID] = struct{}{}
+		report.ProviderBlocksUpdated++
+	}
+}
+
+func canonicalFileIdentity(filename string) string {
+	absolute, err := filepath.Abs(filename)
+	if err == nil {
+		filename = absolute
+	}
+	resolved, err := filepath.EvalSymlinks(filename)
+	if err == nil {
+		return filepath.Clean(resolved)
+	}
+	return filepath.Clean(filename)
 }
 
 // parseFlags parses and validates command-line flags
@@ -186,7 +230,7 @@ func loadModuleUpdates(flags *cliFlags) []ModuleUpdate {
 func processFiles(files []string, updates []ModuleUpdate, flags *cliFlags) (totalUpdates, totalErrors int) {
 	for _, file := range files {
 		for _, update := range updates {
-			updated, blocksUpdated, err := updateModuleVersionWithCount(file, update.Source, update.Version, update.From, update.IgnoreVersions, update.IgnoreModules, flags.forceAdd, flags.dryRun, flags.verbose, flags.output)
+			updated, changedBlocks, err := updateModuleVersionWithCount(file, update.Source, update.Version, update.From, update.IgnoreVersions, update.IgnoreModules, flags.forceAdd, flags.dryRun, flags.verbose, flags.output)
 			if err != nil {
 				log.Printf("Error processing %s: %v", file, err)
 				totalErrors++
@@ -194,7 +238,7 @@ func processFiles(files []string, updates []ModuleUpdate, flags *cliFlags) (tota
 			}
 			if updated {
 				if !flags.dryRun {
-					flags.report.ModuleBlocksUpdated += blocksUpdated
+					flags.report.recordModuleBlocks(file, changedBlocks)
 				}
 				prefix := "✓"
 				action := "Updated"
@@ -563,7 +607,7 @@ func processTerraformVersion(files []string, version string, dryRun bool, output
 //   - totalErrors: Number of files that could not be processed
 func processProviderVersion(files []string, providerName, version string, dryRun bool, outputFormat string, report *updateReport) (totalUpdates, totalErrors int) {
 	for _, file := range files {
-		updated, blocksUpdated, err := updateProviderVersionWithCount(file, providerName, version, dryRun)
+		updated, changedBlocks, err := updateProviderVersionWithCount(file, providerName, version, dryRun)
 		if err != nil {
 			log.Printf("Error processing %s: %v", file, err)
 			totalErrors++
@@ -571,7 +615,7 @@ func processProviderVersion(files []string, providerName, version string, dryRun
 		}
 		if updated {
 			if !dryRun {
-				report.ProviderBlocksUpdated += blocksUpdated
+				report.recordProviderBlocks(file, changedBlocks)
 			}
 			prefix := "✓"
 			action := "Updated"
@@ -661,36 +705,38 @@ func updateTerraformVersion(filename, version string, dryRun bool) (bool, error)
 //
 // Returns:
 //   - updated: true if a provider operation was applied (or would be applied in dry-run mode)
-//   - blocksChanged: number of provider blocks whose version values differ from the target
+//   - changedBlocks: locations of provider blocks whose version values differ from the target
 //   - error: Any error encountered during file reading, parsing, or writing
-func updateProviderVersionWithCount(filename, providerName, version string, dryRun bool) (updated bool, blocksChanged int, err error) {
+func updateProviderVersionWithCount(filename, providerName, version string, dryRun bool) (updated bool, changedBlocks []string, err error) {
 	// Get original file permissions to preserve them when writing
 	fileInfo, err := os.Stat(filename)
 	if err != nil {
-		return false, 0, fmt.Errorf("failed to stat file: %w", err)
+		return false, nil, fmt.Errorf("failed to stat file: %w", err)
 	}
 	originalMode := fileInfo.Mode()
 
 	// Read the file
 	src, err := os.ReadFile(filename)
 	if err != nil {
-		return false, 0, fmt.Errorf("failed to read file: %w", err)
+		return false, nil, fmt.Errorf("failed to read file: %w", err)
 	}
 
 	// Parse the file with hclwrite
 	file, diags := hclwrite.ParseConfig(src, filename, hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
-		return false, 0, fmt.Errorf("failed to parse HCL: %s", diags.Error())
+		return false, nil, fmt.Errorf("failed to parse HCL: %s", diags.Error())
 	}
 
 	updated = false
-	blocksChanged = 0
+	changedBlocks = nil
 
 	// Iterate through all blocks in the file
-	for _, block := range file.Body().Blocks() {
+	for blockIndex, block := range file.Body().Blocks() {
 		blockUpdated, blockChanges := updateProviderTerraformBlockResult(block, providerName, version)
 		updated = updated || blockUpdated
-		blocksChanged += blockChanges
+		for _, blockChange := range blockChanges {
+			changedBlocks = append(changedBlocks, fmt.Sprintf("%d/%s", blockIndex, blockChange))
+		}
 	}
 
 	// If we made changes, write the file back (unless in dry-run mode)
@@ -698,58 +744,60 @@ func updateProviderVersionWithCount(filename, providerName, version string, dryR
 		output := hclwrite.Format(file.Bytes())
 		// Preserve original file permissions
 		if err := os.WriteFile(filename, output, originalMode.Perm()); err != nil {
-			return false, 0, fmt.Errorf("failed to write file: %w", err)
+			return false, nil, fmt.Errorf("failed to write file: %w", err)
 		}
 	}
 
-	return updated, blocksChanged, nil
+	return updated, changedBlocks, nil
 }
 
-func updateProviderTerraformBlockResult(block *hclwrite.Block, providerName, version string) (updated bool, blocksChanged int) {
+func updateProviderTerraformBlockResult(block *hclwrite.Block, providerName, version string) (updated bool, changedBlocks []string) {
 	if block.Type() != "terraform" {
-		return false, 0
+		return false, nil
 	}
 
 	updated = false
-	blocksChanged = 0
-	for _, nestedBlock := range block.Body().Blocks() {
+	changedBlocks = nil
+	for nestedIndex, nestedBlock := range block.Body().Blocks() {
 		if nestedBlock.Type() != "required_providers" {
 			continue
 		}
 		blockSyntaxUpdated, blockSyntaxChanges := updateProviderBlockSyntaxResult(nestedBlock, providerName, version)
 		if blockSyntaxUpdated {
 			updated = true
-			blocksChanged += blockSyntaxChanges
+			for _, blockSyntaxIndex := range blockSyntaxChanges {
+				changedBlocks = append(changedBlocks, fmt.Sprintf("%d/block/%d", nestedIndex, blockSyntaxIndex))
+			}
 			continue
 		}
 		attributeUpdated, attributeChanged := updateProviderAttributeVersionResult(nestedBlock, providerName, version)
 		if attributeUpdated {
 			updated = true
 			if attributeChanged {
-				blocksChanged++
+				changedBlocks = append(changedBlocks, fmt.Sprintf("%d/attribute/%s", nestedIndex, providerName))
 			}
 		}
 	}
 
-	return updated, blocksChanged
+	return updated, changedBlocks
 }
 
-func updateProviderBlockSyntaxResult(nestedBlock *hclwrite.Block, providerName, version string) (updated bool, blocksChanged int) {
+func updateProviderBlockSyntaxResult(nestedBlock *hclwrite.Block, providerName, version string) (updated bool, changedBlocks []int) {
 	updated = false
-	blocksChanged = 0
-	for _, providerBlock := range nestedBlock.Body().Blocks() {
+	changedBlocks = nil
+	for providerIndex, providerBlock := range nestedBlock.Body().Blocks() {
 		if providerBlock.Type() != providerName {
 			continue
 		}
 		versionAttribute := providerBlock.Body().GetAttribute("version")
 		if versionAttribute == nil || attributeStringValue(versionAttribute) != version {
-			blocksChanged++
+			changedBlocks = append(changedBlocks, providerIndex)
 		}
 		providerBlock.Body().SetAttributeValue("version", cty.StringVal(version))
 		updated = true
 	}
 
-	return updated, blocksChanged
+	return updated, changedBlocks
 }
 
 // updateProviderAttributeVersion updates the version value within a provider attribute's object expression
@@ -881,30 +929,30 @@ func providerObjectItemKey(item hclsyntax.ObjectConsItem) (string, bool) {
 //
 // Returns:
 //   - updated: true if at least one module operation was applied (or would be applied in dry-run mode)
-//   - blocksChanged: number of module blocks whose version values differ from the target
+//   - changedBlocks: indexes of module blocks whose version values differ from the target
 //   - error: Any error encountered during file reading, parsing, or writing
-func updateModuleVersionWithCount(filename, moduleSource, version string, fromVersions, ignoreVersions, ignorePatterns []string, forceAdd, dryRun, verbose bool, outputFormat string) (updated bool, blocksChanged int, err error) {
+func updateModuleVersionWithCount(filename, moduleSource, version string, fromVersions, ignoreVersions, ignorePatterns []string, forceAdd, dryRun, verbose bool, outputFormat string) (updated bool, changedBlocks []int, err error) {
 	// Get original file permissions to preserve them when writing
 	fileInfo, err := os.Stat(filename)
 	if err != nil {
-		return false, 0, fmt.Errorf("failed to stat file: %w", err)
+		return false, nil, fmt.Errorf("failed to stat file: %w", err)
 	}
 	originalMode := fileInfo.Mode()
 
 	// Read the file
 	src, err := os.ReadFile(filename)
 	if err != nil {
-		return false, 0, fmt.Errorf("failed to read file: %w", err)
+		return false, nil, fmt.Errorf("failed to read file: %w", err)
 	}
 
 	// Parse the file with hclwrite
 	file, diags := hclwrite.ParseConfig(src, filename, hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
-		return false, 0, fmt.Errorf("failed to parse HCL: %s", diags.Error())
+		return false, nil, fmt.Errorf("failed to parse HCL: %s", diags.Error())
 	}
 
 	updated = false
-	blocksChanged = 0
+	changedBlocks = nil
 	opts := moduleUpdateOptions{
 		filename:       filename,
 		moduleSource:   moduleSource,
@@ -918,12 +966,12 @@ func updateModuleVersionWithCount(filename, moduleSource, version string, fromVe
 	}
 
 	// Iterate through all blocks in the file
-	for _, block := range file.Body().Blocks() {
+	for blockIndex, block := range file.Body().Blocks() {
 		blockUpdated, blockChanged := updateModuleBlockResult(block, &opts)
 		if blockUpdated {
 			updated = true
 			if blockChanged {
-				blocksChanged++
+				changedBlocks = append(changedBlocks, blockIndex)
 			}
 		}
 	}
@@ -933,11 +981,11 @@ func updateModuleVersionWithCount(filename, moduleSource, version string, fromVe
 		output := hclwrite.Format(file.Bytes())
 		// Preserve original file permissions
 		if err := os.WriteFile(filename, output, originalMode.Perm()); err != nil {
-			return false, 0, fmt.Errorf("failed to write file: %w", err)
+			return false, nil, fmt.Errorf("failed to write file: %w", err)
 		}
 	}
 
-	return updated, blocksChanged, nil
+	return updated, changedBlocks, nil
 }
 
 type moduleUpdateOptions struct {

--- a/main.go
+++ b/main.go
@@ -193,7 +193,9 @@ func processFiles(files []string, updates []ModuleUpdate, flags *cliFlags) (tota
 				continue
 			}
 			if updated {
-				flags.report.ModuleBlocksUpdated += blocksUpdated
+				if !flags.dryRun {
+					flags.report.ModuleBlocksUpdated += blocksUpdated
+				}
 				prefix := "✓"
 				action := "Updated"
 				if flags.dryRun {
@@ -568,7 +570,9 @@ func processProviderVersion(files []string, providerName, version string, dryRun
 			continue
 		}
 		if updated {
-			report.ProviderBlocksUpdated += blocksUpdated
+			if !dryRun {
+				report.ProviderBlocksUpdated += blocksUpdated
+			}
 			prefix := "✓"
 			action := "Updated"
 			if dryRun {
@@ -683,15 +687,18 @@ func updateProviderVersionWithCount(filename, providerName, version string, dryR
 		return false, 0, fmt.Errorf("failed to parse HCL: %s", diags.Error())
 	}
 
-	blocksUpdated := 0
+	updated := false
+	blocksChanged := 0
 
 	// Iterate through all blocks in the file
 	for _, block := range file.Body().Blocks() {
-		blocksUpdated += updateProviderTerraformBlockCount(block, providerName, version)
+		blockUpdated, blockChanges := updateProviderTerraformBlockResult(block, providerName, version)
+		updated = updated || blockUpdated
+		blocksChanged += blockChanges
 	}
 
 	// If we made changes, write the file back (unless in dry-run mode)
-	if blocksUpdated > 0 && !dryRun {
+	if updated && !dryRun {
 		output := hclwrite.Format(file.Bytes())
 		// Preserve original file permissions
 		if err := os.WriteFile(filename, output, originalMode.Perm()); err != nil {
@@ -699,82 +706,96 @@ func updateProviderVersionWithCount(filename, providerName, version string, dryR
 		}
 	}
 
-	return blocksUpdated > 0, blocksUpdated, nil
+	return updated, blocksChanged, nil
 }
 
 func updateProviderTerraformBlock(block *hclwrite.Block, providerName, version string) bool {
-	return updateProviderTerraformBlockCount(block, providerName, version) > 0
+	updated, _ := updateProviderTerraformBlockResult(block, providerName, version)
+	return updated
 }
 
-func updateProviderTerraformBlockCount(block *hclwrite.Block, providerName, version string) int {
+func updateProviderTerraformBlockResult(block *hclwrite.Block, providerName, version string) (bool, int) {
 	if block.Type() != "terraform" {
-		return 0
+		return false, 0
 	}
 
-	blocksUpdated := 0
+	updated := false
+	blocksChanged := 0
 	for _, nestedBlock := range block.Body().Blocks() {
 		if nestedBlock.Type() != "required_providers" {
 			continue
 		}
-		blockSyntaxUpdates := updateProviderBlockSyntaxCount(nestedBlock, providerName, version)
-		if blockSyntaxUpdates > 0 {
-			blocksUpdated += blockSyntaxUpdates
+		blockSyntaxUpdated, blockSyntaxChanges := updateProviderBlockSyntaxResult(nestedBlock, providerName, version)
+		if blockSyntaxUpdated {
+			updated = true
+			blocksChanged += blockSyntaxChanges
 			continue
 		}
-		if updateProviderAttributeVersion(nestedBlock, providerName, version) {
-			blocksUpdated++
+		attributeUpdated, attributeChanged := updateProviderAttributeVersionResult(nestedBlock, providerName, version)
+		if attributeUpdated {
+			updated = true
+			if attributeChanged {
+				blocksChanged++
+			}
 		}
 	}
 
-	return blocksUpdated
+	return updated, blocksChanged
 }
 
 func updateProviderBlockSyntax(nestedBlock *hclwrite.Block, providerName, version string) bool {
-	return updateProviderBlockSyntaxCount(nestedBlock, providerName, version) > 0
+	updated, _ := updateProviderBlockSyntaxResult(nestedBlock, providerName, version)
+	return updated
 }
 
-func updateProviderBlockSyntaxCount(nestedBlock *hclwrite.Block, providerName, version string) int {
-	blocksUpdated := 0
+func updateProviderBlockSyntaxResult(nestedBlock *hclwrite.Block, providerName, version string) (bool, int) {
+	updated := false
+	blocksChanged := 0
 	for _, providerBlock := range nestedBlock.Body().Blocks() {
 		if providerBlock.Type() != providerName {
 			continue
 		}
 		versionAttribute := providerBlock.Body().GetAttribute("version")
-		if versionAttribute != nil && attributeStringValue(versionAttribute) == version {
-			continue
+		if versionAttribute == nil || attributeStringValue(versionAttribute) != version {
+			blocksChanged++
 		}
 		providerBlock.Body().SetAttributeValue("version", cty.StringVal(version))
-		blocksUpdated++
+		updated = true
 	}
 
-	return blocksUpdated
+	return updated, blocksChanged
 }
 
 // updateProviderAttributeVersion updates the version value within a provider attribute's object expression
 // This handles the attribute-based syntax: aws = { source = "..." version = "..." }
 func updateProviderAttributeVersion(nestedBlock *hclwrite.Block, providerName, newVersion string) bool {
+	updated, _ := updateProviderAttributeVersionResult(nestedBlock, providerName, newVersion)
+	return updated
+}
+
+func updateProviderAttributeVersionResult(nestedBlock *hclwrite.Block, providerName, newVersion string) (bool, bool) {
 	objExpr, expression, ok := providerAttributeObject(nestedBlock, providerName)
 	if !ok {
-		return false
+		return false, false
 	}
 
 	updatedExpression, hasVersion, changed := replaceProviderObjectVersion(objExpr, expression, newVersion)
-	if !hasVersion || !changed {
-		return false
+	if !hasVersion {
+		return false, false
 	}
 
 	newAttribute := append([]byte(providerName+" = "), updatedExpression...)
 	newExpr, diags := hclwrite.ParseConfig(newAttribute, "inline", hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
-		return false
+		return false, false
 	}
 
 	for _, newAttr := range newExpr.Body().Attributes() {
 		nestedBlock.Body().SetAttributeRaw(providerName, newAttr.Expr().BuildTokens(nil))
-		return true
+		return true, changed
 	}
 
-	return false
+	return false, false
 }
 
 func providerAttributeObject(nestedBlock *hclwrite.Block, providerName string) (*hclsyntax.ObjectConsExpr, []byte, bool) {
@@ -906,7 +927,8 @@ func updateModuleVersionWithCount(filename, moduleSource, version string, fromVe
 		return false, 0, fmt.Errorf("failed to parse HCL: %s", diags.Error())
 	}
 
-	blocksUpdated := 0
+	updated := false
+	blocksChanged := 0
 	opts := moduleUpdateOptions{
 		filename:       filename,
 		moduleSource:   moduleSource,
@@ -921,13 +943,17 @@ func updateModuleVersionWithCount(filename, moduleSource, version string, fromVe
 
 	// Iterate through all blocks in the file
 	for _, block := range file.Body().Blocks() {
-		if updateModuleBlock(block, &opts) {
-			blocksUpdated++
+		blockUpdated, blockChanged := updateModuleBlockResult(block, &opts)
+		if blockUpdated {
+			updated = true
+			if blockChanged {
+				blocksChanged++
+			}
 		}
 	}
 
 	// If we made changes, write the file back (unless in dry-run mode)
-	if blocksUpdated > 0 && !dryRun {
+	if updated && !dryRun {
 		output := hclwrite.Format(file.Bytes())
 		// Preserve original file permissions
 		if err := os.WriteFile(filename, output, originalMode.Perm()); err != nil {
@@ -935,7 +961,7 @@ func updateModuleVersionWithCount(filename, moduleSource, version string, fromVe
 		}
 	}
 
-	return blocksUpdated > 0, blocksUpdated, nil
+	return updated, blocksChanged, nil
 }
 
 type moduleUpdateOptions struct {
@@ -951,27 +977,32 @@ type moduleUpdateOptions struct {
 }
 
 func updateModuleBlock(block *hclwrite.Block, opts *moduleUpdateOptions) bool {
+	updated, _ := updateModuleBlockResult(block, opts)
+	return updated
+}
+
+func updateModuleBlockResult(block *hclwrite.Block, opts *moduleUpdateOptions) (bool, bool) {
 	if block.Type() != "module" {
-		return false
+		return false, false
 	}
 
 	moduleName := moduleBlockName(block)
 	sourceValue, ok := moduleSourceValue(block)
 	if !ok || sourceValue != opts.moduleSource {
-		return false
+		return false, false
 	}
 
 	if isLocalModule(sourceValue) {
 		fmt.Fprintf(os.Stderr, "Warning: Module %s in %s (source: %s) is a local module and cannot be version-bumped, skipping\n",
 			quote(moduleName, opts.outputFormat), opts.filename, quote(opts.moduleSource, opts.outputFormat))
-		return false
+		return false, false
 	}
 
 	if shouldIgnoreModule(moduleName, opts.ignorePatterns) {
 		if opts.verbose {
 			fmt.Printf("  ⊗ Skipped module %s in %s (matches ignore pattern)\n", quote(moduleName, opts.outputFormat), opts.filename)
 		}
-		return false
+		return false, false
 	}
 
 	versionAttr := block.Body().GetAttribute("version")
@@ -979,22 +1010,24 @@ func updateModuleBlock(block *hclwrite.Block, opts *moduleUpdateOptions) bool {
 		if !opts.forceAdd {
 			fmt.Fprintf(os.Stderr, "Warning: Module %s in %s (source: %s) has no version attribute, skipping\n",
 				quote(moduleName, opts.outputFormat), opts.filename, quote(opts.moduleSource, opts.outputFormat))
-			return false
+			return false, false
 		}
 		if !isRegistryModule(sourceValue) {
 			fmt.Fprintf(os.Stderr, "Warning: Module %s in %s (source: %s) is not a registry module and cannot use a version attribute, skipping\n",
 				quote(moduleName, opts.outputFormat), opts.filename, quote(opts.moduleSource, opts.outputFormat))
-			return false
+			return false, false
 		}
 	} else {
 		currentVersion := attributeStringValue(versionAttr)
-		if shouldSkipModuleVersion(moduleName, currentVersion, opts) || currentVersion == opts.version {
-			return false
+		if shouldSkipModuleVersion(moduleName, currentVersion, opts) {
+			return false, false
 		}
+		block.Body().SetAttributeValue("version", cty.StringVal(opts.version))
+		return true, currentVersion != opts.version
 	}
 
 	block.Body().SetAttributeValue("version", cty.StringVal(opts.version))
-	return true
+	return true, true
 }
 
 func moduleBlockName(block *hclwrite.Block) string {

--- a/main.go
+++ b/main.go
@@ -127,6 +127,7 @@ type updateReport struct {
 	ProviderBlocksUpdated int `json:"provider_blocks_updated"`
 	moduleBlockIDs        map[string]struct{}
 	providerBlockIDs      map[string]struct{}
+	fileIdentities        []fs.FileInfo
 }
 
 type preparedReportFile struct {
@@ -135,7 +136,7 @@ type preparedReportFile struct {
 }
 
 func (report *updateReport) recordModuleBlocks(filename string, blockIndexes []int) {
-	fileID := canonicalFileIdentity(filename)
+	fileID := report.fileIdentity(filename)
 	if report.moduleBlockIDs == nil {
 		report.moduleBlockIDs = make(map[string]struct{})
 	}
@@ -150,7 +151,7 @@ func (report *updateReport) recordModuleBlocks(filename string, blockIndexes []i
 }
 
 func (report *updateReport) recordProviderBlocks(filename string, blockLocations []string) {
-	fileID := canonicalFileIdentity(filename)
+	fileID := report.fileIdentity(filename)
 	if report.providerBlockIDs == nil {
 		report.providerBlockIDs = make(map[string]struct{})
 	}
@@ -162,6 +163,20 @@ func (report *updateReport) recordProviderBlocks(filename string, blockLocations
 		report.providerBlockIDs[blockID] = struct{}{}
 		report.ProviderBlocksUpdated++
 	}
+}
+
+func (report *updateReport) fileIdentity(filename string) string {
+	fileInfo, err := os.Stat(filename)
+	if err == nil {
+		for index, existingIdentity := range report.fileIdentities {
+			if os.SameFile(fileInfo, existingIdentity) {
+				return fmt.Sprintf("file:%d", index)
+			}
+		}
+		report.fileIdentities = append(report.fileIdentities, fileInfo)
+		return fmt.Sprintf("file:%d", len(report.fileIdentities)-1)
+	}
+	return "path:" + canonicalFileIdentity(filename)
 }
 
 func canonicalFileIdentity(filename string) string {
@@ -296,6 +311,7 @@ func main() {
 
 	// Find and validate matching files
 	files := findMatchingFiles(flags)
+	validateRequiredOperationFlags(flags)
 	inputFiles := files
 	if flags.configFile != "" {
 		inputFiles = append(append([]string(nil), files...), flags.configFile)
@@ -324,6 +340,15 @@ func main() {
 		if publishErr := preparedReport.publish(flags.report); publishErr != nil {
 			fatalf("Error writing update report: %v", publishErr)
 		}
+	}
+}
+
+func validateRequiredOperationFlags(flags *cliFlags) {
+	if flags.moduleSource != "" {
+		_ = loadModuleUpdates(flags)
+	}
+	if flags.providerName != "" && flags.toVersion == "" {
+		fatalf("Error: -to flag is required when using -provider")
 	}
 }
 

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -50,6 +50,17 @@ type commandResult struct {
 	exitCode    int
 }
 
+//nolint:unparam // The adapter preserves the production call shape used by focused tests.
+func updateModuleVersion(filename, moduleSource, version string, fromVersions, ignoreVersions, ignorePatterns []string, forceAdd, dryRun, verbose bool, outputFormat string) (bool, error) {
+	updated, _, err := updateModuleVersionWithCount(filename, moduleSource, version, fromVersions, ignoreVersions, ignorePatterns, forceAdd, dryRun, verbose, outputFormat)
+	return updated, err
+}
+
+func updateProviderVersion(filename, providerName, version string, dryRun bool) (bool, error) {
+	updated, _, err := updateProviderVersionWithCount(filename, providerName, version, dryRun)
+	return updated, err
+}
+
 var testOutputMu sync.Mutex
 
 func startPipeDrain(reader *os.File) (output *bytes.Buffer, done <-chan struct{}) {


### PR DESCRIPTION
## What changed

- add `-report-file` JSON output with a schema version and exact module/provider block update counts
- count each physical Terraform block once across overlapping patterns, duplicate configuration entries, symlinks, and hard links
- preserve existing human-readable output and report zero updates for dry runs and same-value matches
- validate report destinations before Terraform files are mutated and publish reports through a same-directory temporary file
- document the machine-readable report contract and its intended GitHub Actions usage

## Why

The example GitHub Actions workflow needs deterministic tracking data for a later two-stage automation update. Git can provide the changed-file list, while this report supplies the exact number of module and provider blocks changed by `tf-version-bump`.

This PR intentionally delivers the CLI/reporting stage only. A follow-up can pin a release containing this feature, then update the example workflow to run dependency updates and `terraform init -upgrade` in one commit, followed by optional `terraform fmt -recursive` changes in a separate commit.

## Impact

Existing command output and update behaviour remain unchanged unless `-report-file` is supplied. Automation can consume the versioned JSON report without parsing console output.

## Validation

- `make test-coverage` (race detector enabled; 93.2% total function coverage)
- `golangci-lint run --timeout=5m`
- `go vet ./...`
- `make docs-check`
- `make build`
- `make test-github-actions TEST_GIT=/tmp/tf-version-bump-signed-test-git`
- `git diff --check main...HEAD`
- adversarial review and separate test-cleanup review
