### PR TITLE
test: strengthen Terraform update contracts

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -354,6 +354,48 @@ modules:
 	}
 }
 
+func TestCommandReportCountsChangedBlockStyleProviders(t *testing.T) {
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "main.tf", `terraform {
+  required_providers {
+    aws {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+terraform {
+  required_providers {
+    aws {
+      source  = "hashicorp/aws"
+      version = "~> 4.1"
+    }
+  }
+}
+terraform {
+  required_providers {
+    aws {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+`)
+	report := dir + "/report.json"
+
+	result := runMainCommand(t, []string{
+		"tf-version-bump", "-pattern", file, "-provider", "aws", "-to", "~> 5.0", "-report-file", report,
+	})
+
+	if result.exitCode != -1 || result.diagnostics != "" {
+		t.Fatalf("result = %#v", result)
+	}
+	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 0,\n  \"provider_blocks_updated\": 2\n}\n"
+	if got := readTestFile(t, report); got != wantReport {
+		t.Errorf("report = %q, want %q", got, wantReport)
+	}
+}
+
 func TestCommandReportCountsForceAddedModuleBlock(t *testing.T) {
 	dir := t.TempDir()
 	file := writeTestFile(t, dir, "main.tf", `module "vpc" {
@@ -485,14 +527,31 @@ modules:
 	}
 }
 
-func TestCommandReportCountsHardLinkedBlockOnce(t *testing.T) {
+func TestCommandReportCountsHardLinkedBlocksOnce(t *testing.T) {
 	dir := t.TempDir()
-	file := writeTestFile(t, dir, "a.tf", "module \"example\" {\n  source  = \"example/module\"\n  version = \"1.0.0\"\n}\n")
+	file := writeTestFile(t, dir, "a.tf", `terraform {
+  required_providers {
+    aws {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+module "example" {
+  source  = "example/module"
+  version = "1.0.0"
+}
+`)
 	linkedFile := dir + "/b.tf"
 	if err := os.Link(file, linkedFile); err != nil {
 		t.Skipf("cannot create hard link: %v", err)
 	}
-	config := writeTestFile(t, dir, "updates.yml", `modules:
+	config := writeTestFile(t, dir, "updates.yml", `providers:
+  - name: aws
+    version: "~> 5.0"
+  - name: aws
+    version: "~> 6.0"
+modules:
   - source: example/module
     version: 2.0.0
   - source: example/module
@@ -507,12 +566,30 @@ func TestCommandReportCountsHardLinkedBlockOnce(t *testing.T) {
 	if result.exitCode != -1 || result.diagnostics != "" {
 		t.Fatalf("result = %#v", result)
 	}
-	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 1,\n  \"provider_blocks_updated\": 0\n}\n"
+	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 1,\n  \"provider_blocks_updated\": 1\n}\n"
 	if got := readTestFile(t, report); got != wantReport {
 		t.Errorf("report = %q, want %q", got, wantReport)
 	}
-	if got := readTestFile(t, linkedFile); !strings.Contains(got, `version = "3.0.0"`) {
+	if got := readTestFile(t, linkedFile); !strings.Contains(got, `version = "3.0.0"`) || !strings.Contains(got, `version = "~> 6.0"`) {
 		t.Errorf("final Terraform content = %q", got)
+	}
+}
+
+func TestCommandReplacesExistingReportAfterSuccessfulUpdate(t *testing.T) {
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "main.tf", "module \"example\" {\n  source  = \"example/module\"\n  version = \"1.0.0\"\n}\n")
+	report := writeTestFile(t, dir, "report.json", "stale report\n")
+
+	result := runMainCommand(t, []string{
+		"tf-version-bump", "-pattern", file, "-module", "example/module", "-to", "2.0.0", "-report-file", report,
+	})
+
+	if result.exitCode != -1 || result.diagnostics != "" {
+		t.Fatalf("result = %#v", result)
+	}
+	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 1,\n  \"provider_blocks_updated\": 0\n}\n"
+	if got := readTestFile(t, report); got != wantReport {
+		t.Errorf("report = %q, want %q", got, wantReport)
 	}
 }
 
@@ -626,7 +703,8 @@ func TestCommandRejectsReportDirectoryBeforeUpdating(t *testing.T) {
 func TestCommandDiscardsPreparedReportAfterUpdateFailure(t *testing.T) {
 	dir := t.TempDir()
 	file := writeTestFile(t, dir, "main.tf", "!!!\n")
-	report := dir + "/report.json"
+	reportContent := "previous report\n"
+	report := writeTestFile(t, dir, "report.json", reportContent)
 
 	result := runMainCommand(t, []string{
 		"tf-version-bump", "-pattern", file, "-module", "example/module", "-to", "2.0.0", "-report-file", report,
@@ -639,8 +717,11 @@ func TestCommandDiscardsPreparedReportAfterUpdateFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read temporary directory: %v", err)
 	}
-	if len(entries) != 1 || entries[0].Name() != "main.tf" {
-		t.Errorf("temporary directory entries = %v, want only main.tf", entries)
+	if len(entries) != 2 || entries[0].Name() != "main.tf" || entries[1].Name() != "report.json" {
+		t.Errorf("temporary directory entries = %v, want main.tf and report.json", entries)
+	}
+	if got := readTestFile(t, report); got != reportContent {
+		t.Errorf("report = %q, want preserved %q", got, reportContent)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -808,6 +808,10 @@ func updateTerraformVersion(filename, version string, dryRun bool) (bool, error)
 	for _, block := range file.Body().Blocks() {
 		// Look for terraform blocks
 		if block.Type() == "terraform" {
+			currentVersion := block.Body().GetAttribute("required_version")
+			if currentVersion != nil && attributeStringValue(currentVersion) == version {
+				continue
+			}
 			// Update or add the required_version attribute
 			block.Body().SetAttributeValue("required_version", cty.StringVal(version))
 			updated = true

--- a/main.go
+++ b/main.go
@@ -804,6 +804,7 @@ func updateTerraformVersion(filename, version string, dryRun bool) (bool, error)
 
 	// Track if we made any changes
 	updated := false
+	targetVersionTokens := bytes.TrimSpace(hclwrite.TokensForValue(cty.StringVal(version)).Bytes())
 
 	// Iterate through all blocks in the file
 	for _, block := range file.Body().Blocks() {
@@ -812,8 +813,7 @@ func updateTerraformVersion(filename, version string, dryRun bool) (bool, error)
 			currentVersion := block.Body().GetAttribute("required_version")
 			if currentVersion != nil {
 				currentTokens := currentVersion.Expr().BuildTokens(nil)
-				targetTokens := hclwrite.TokensForValue(cty.StringVal(version))
-				if bytes.Equal(bytes.TrimSpace(currentTokens.Bytes()), targetTokens.Bytes()) {
+				if bytes.Equal(bytes.TrimSpace(currentTokens.Bytes()), targetVersionTokens) {
 					continue
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -809,8 +810,12 @@ func updateTerraformVersion(filename, version string, dryRun bool) (bool, error)
 		// Look for terraform blocks
 		if block.Type() == "terraform" {
 			currentVersion := block.Body().GetAttribute("required_version")
-			if currentVersion != nil && attributeStringValue(currentVersion) == version {
-				continue
+			if currentVersion != nil {
+				currentTokens := currentVersion.Expr().BuildTokens(nil)
+				targetTokens := hclwrite.TokensForValue(cty.StringVal(version))
+				if bytes.Equal(bytes.TrimSpace(currentTokens.Bytes()), targetTokens.Bytes()) {
+					continue
+				}
 			}
 			// Update or add the required_version attribute
 			block.Body().SetAttributeValue("required_version", cty.StringVal(version))

--- a/provider_update_test.go
+++ b/provider_update_test.go
@@ -219,6 +219,28 @@ func TestUpdateProviderVersionDryRunContract(t *testing.T) {
 	}
 }
 
+func TestUpdateProviderVersionPreservesPermissions(t *testing.T) {
+	filename := writeTestFile(t, t.TempDir(), "main.tf", "terraform {\n  required_providers {\n    aws {\n      version = \"~> 4.0\"\n    }\n  }\n}\n")
+	if err := os.Chmod(filename, 0o640); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	updated, err := updateProviderVersion(filename, "aws", "~> 5.0", false)
+	if err != nil {
+		t.Fatalf("updateProviderVersion returned error: %v", err)
+	}
+	if !updated {
+		t.Fatal("updated = false, want true")
+	}
+	info, err := os.Stat(filename)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Errorf("permissions = %o, want 640", got)
+	}
+}
+
 func TestUpdateProviderVersionErrors(t *testing.T) {
 	t.Run("missing file", func(t *testing.T) {
 		_, err := updateProviderVersion(t.TempDir()+"/missing.tf", "aws", "~> 5.0", false)

--- a/terraform_version_test.go
+++ b/terraform_version_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestUpdateTerraformVersionContract(t *testing.T) {
@@ -70,11 +71,24 @@ terraform {
 `,
 		},
 		{
-			name: "leaves matching required version unchanged",
-			input: `terraform { required_version = ">= 1.5" }
+			name: "updates differing block when another already matches",
+			input: `terraform {
+  required_version = ">= 1.5"
+}
+
+terraform {
+  required_version = ">= 1.0"
+}
 `,
-			want: `terraform { required_version = ">= 1.5" }
+			want: `terraform {
+  required_version = ">= 1.5"
+}
+
+terraform {
+  required_version = ">= 1.5"
+}
 `,
+			wantUpdated: true,
 		},
 		{
 			name: "adds required version to terraform block without one",
@@ -113,6 +127,50 @@ terraform {
 				t.Errorf("content mismatch:\n--- got ---\n%s--- want ---\n%s", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestUpdateTerraformVersionRepairsMatchingNonStringExpression(t *testing.T) {
+	filename := writeTestFile(t, t.TempDir(), "main.tf", "terraform {\n  required_version = 1.5\n}\n")
+
+	updated, err := updateTerraformVersion(filename, "1.5", false)
+	if err != nil {
+		t.Fatalf("updateTerraformVersion returned error: %v", err)
+	}
+	if !updated {
+		t.Fatal("updated = false, want true")
+	}
+	want := "terraform {\n  required_version = \"1.5\"\n}\n"
+	if got := readTestFile(t, filename); got != want {
+		t.Errorf("content = %q, want %q", got, want)
+	}
+}
+
+func TestUpdateTerraformVersionMatchingVersionDoesNotWrite(t *testing.T) {
+	input := `terraform { required_version = ">= 1.5" }
+`
+	filename := writeTestFile(t, t.TempDir(), "main.tf", input)
+	wantModTime := time.Unix(1, 0)
+	if err := os.Chtimes(filename, wantModTime, wantModTime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	updated, err := updateTerraformVersion(filename, ">= 1.5", false)
+	if err != nil {
+		t.Fatalf("updateTerraformVersion returned error: %v", err)
+	}
+	if updated {
+		t.Fatal("updated = true, want false")
+	}
+	if got := readTestFile(t, filename); got != input {
+		t.Errorf("content = %q, want unchanged %q", got, input)
+	}
+	info, err := os.Stat(filename)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.ModTime(); !got.Equal(wantModTime) {
+		t.Errorf("modification time = %v, want unchanged %v", got, wantModTime)
 	}
 }
 

--- a/terraform_version_test.go
+++ b/terraform_version_test.go
@@ -70,6 +70,13 @@ terraform {
 `,
 		},
 		{
+			name: "leaves matching required version unchanged",
+			input: `terraform { required_version = ">= 1.5" }
+`,
+			want: `terraform { required_version = ">= 1.5" }
+`,
+		},
+		{
 			name: "adds required version to terraform block without one",
 			input: `terraform {
   required_providers {
@@ -106,6 +113,28 @@ terraform {
 				t.Errorf("content mismatch:\n--- got ---\n%s--- want ---\n%s", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestUpdateTerraformVersionPreservesPermissions(t *testing.T) {
+	filename := writeTestFile(t, t.TempDir(), "main.tf", "terraform {\n  required_version = \">= 1.0\"\n}\n")
+	if err := os.Chmod(filename, 0o640); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	updated, err := updateTerraformVersion(filename, ">= 1.5", false)
+	if err != nil {
+		t.Fatalf("updateTerraformVersion returned error: %v", err)
+	}
+	if !updated {
+		t.Fatal("updated = false, want true")
+	}
+	info, err := os.Stat(filename)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Errorf("permissions = %o, want 640", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make Terraform `required_version` updates idempotent when the existing string literal already matches
- preserve repair behaviour for matching non-string HCL expressions and mixed Terraform blocks
- strengthen provider reporting tests for block syntax and physical-file deduplication
- verify Terraform/provider permission preservation and atomic report replacement behaviour

## Testing

- `go test -count=1 -race ./...`
- `go test -count=1 -race -coverprofile=coverage.out -covermode=atomic ./...` (93.4%)
- `golangci-lint run --timeout=5m`
- `go build -buildvcs=false ./...`

## Scope

Real JSON Schema validation remains out of scope because it would require selecting and adding a validator dependency.
