### PR TITLE
feat: add config validation and idempotent updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,8 +105,9 @@ not atomic. Files are processed in memory, so very large files (>100MB) are impr
 
 ### Update flow
 
-`main()` → `validateOperationModes` → `findMatchingFiles` → either `runConfigFileMode`
-(YAML) or `runCLIMode` (one direct operation). Each dispatches to one of three update paths:
+`main()` → `validateOperationModes` → either standalone config validation or
+`findMatchingFiles` → `runConfigFileMode` (YAML) / `runCLIMode` (one direct operation).
+Each update mode dispatches to one of three update paths:
 `updateModuleVersionWithCount`, `updateTerraformVersion`, or `updateProviderVersionWithCount`.
 
 `updateModuleVersionWithCount` reads and parses the file, then bundles its many

--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ Then apply it:
 tf-version-bump -pattern "**/*.tf" -config versions.yml
 ```
 
+Validate the config structure without selecting or changing Terraform files:
+
+```bash
+tf-version-bump -validate-config versions.yml
+```
+
 Config mode is exclusive with `-module`, `-provider`, `-terraform-version`, `-to`, and the
 module-filter flags. It can still be combined with global behaviour flags such as `-dry-run`,
 `-force-add`, `-verbose`, `-output`, and `-report-file`.

--- a/command_test.go
+++ b/command_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 func TestParseFlagsContract(t *testing.T) {
-	args := []string{"tf-version-bump", "-pattern", "**/*.tf", "-module", "example/module", "-to", "2.0.0", "-from", "1.0.0", "-from", "1.5.0", "-ignore-version", "3.0.0", "-ignore-modules", "vpc, legacy-*", "-config", "config.yml", "-force-add", "-dry-run", "-verbose", "-version", "-output", "md", "-terraform-version", ">= 1.5", "-provider", "aws"}
+	args := []string{"tf-version-bump", "-pattern", "**/*.tf", "-module", "example/module", "-to", "2.0.0", "-from", "1.0.0", "-from", "1.5.0", "-ignore-version", "3.0.0", "-ignore-modules", "vpc, legacy-*", "-config", "config.yml", "-validate-config", "validate.yml", "-force-add", "-dry-run", "-verbose", "-version", "-output", "md", "-terraform-version", ">= 1.5", "-provider", "aws"}
 	withFlagArgs(t, args, func() {
 		got := parseFlags()
-		want := &cliFlags{pattern: "**/*.tf", moduleSource: "example/module", toVersion: "2.0.0", fromVersions: stringSliceFlag{"1.0.0", "1.5.0"}, ignoreVersions: stringSliceFlag{"3.0.0"}, ignoreModules: "vpc, legacy-*", configFile: "config.yml", forceAdd: true, dryRun: true, verbose: true, showVersion: true, output: "md", terraformVersion: ">= 1.5", providerName: "aws"}
+		want := &cliFlags{pattern: "**/*.tf", moduleSource: "example/module", toVersion: "2.0.0", fromVersions: stringSliceFlag{"1.0.0", "1.5.0"}, ignoreVersions: stringSliceFlag{"3.0.0"}, ignoreModules: "vpc, legacy-*", configFile: "config.yml", validationConfigFile: "validate.yml", forceAdd: true, dryRun: true, verbose: true, showVersion: true, output: "md", terraformVersion: ">= 1.5", providerName: "aws"}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("flags = %#v, want %#v", got, want)
 		}
@@ -98,6 +98,73 @@ func TestCommandVersion(t *testing.T) {
 	result := runMainCommand(t, []string{"tf-version-bump", "-version"})
 	if result.stdout != "tf-version-bump 1.2.3\n  commit: abc123\n  built:  2026-08-20\n" || result.diagnostics != "" || result.exitCode != 0 {
 		t.Fatalf("result %#v", result)
+	}
+}
+
+func TestCommandValidatesConfigWithoutTerraformFiles(t *testing.T) {
+	config := writeTestFile(t, t.TempDir(), "versions.yml", "providers:\n  - name: aws\n    version: '~> 5.0'\n")
+
+	result := runMainCommand(t, []string{"tf-version-bump", "-validate-config", config})
+
+	want := "Config '" + config + "' is valid\n"
+	if result.stdout != want || result.diagnostics != "" || result.exitCode != 0 {
+		t.Fatalf("result = %#v, want stdout %q and exit 0", result, want)
+	}
+}
+
+func TestCommandConfigValidationRejectsInvalidConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		wantDetail string
+	}{
+		{name: "malformed", content: "providers:\n  - name: [\n", wantDetail: "failed to parse YAML"},
+		{name: "empty operations", content: "# no updates\n", wantDetail: "config contains no updates"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := writeTestFile(t, t.TempDir(), "versions.yml", tt.content)
+			result := runMainCommand(t, []string{"tf-version-bump", "-validate-config", config})
+
+			if result.stdout != "" || result.exitCode != 1 || !strings.Contains(result.diagnostics, "Error validating config file: "+tt.wantDetail) {
+				t.Fatalf("result = %#v, want validation error containing %q", result, tt.wantDetail)
+			}
+		})
+	}
+}
+
+func TestCommandConfigValidationRejectsUpdateAndReportFlags(t *testing.T) {
+	config := writeTestFile(t, t.TempDir(), "versions.yml", "terraform_version: '>= 1.5'\n")
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "pattern", args: []string{"-pattern", "*.tf"}},
+		{name: "config update", args: []string{"-config", config}},
+		{name: "module", args: []string{"-module", "example/module"}},
+		{name: "target version", args: []string{"-to", "2.0.0"}},
+		{name: "source version", args: []string{"-from", "1.0.0"}},
+		{name: "ignored version", args: []string{"-ignore-version", "1.0.0"}},
+		{name: "ignored module", args: []string{"-ignore-modules", "legacy-*"}},
+		{name: "Terraform version", args: []string{"-terraform-version", ">= 1.5"}},
+		{name: "provider", args: []string{"-provider", "aws"}},
+		{name: "force add", args: []string{"-force-add"}},
+		{name: "dry run", args: []string{"-dry-run"}},
+		{name: "verbose", args: []string{"-verbose"}},
+		{name: "report", args: []string{"-report-file", "report.json"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := append([]string{"tf-version-bump", "-validate-config", config}, tt.args...)
+			result := runMainCommand(t, args)
+
+			want := "Error: Cannot use -validate-config with update or report flags\n"
+			if result.stdout != "" || result.diagnostics != want || result.exitCode != 1 {
+				t.Fatalf("result = %#v, want diagnostic %q and exit 1", result, want)
+			}
+		})
 	}
 }
 

--- a/command_test.go
+++ b/command_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseFlagsContract(t *testing.T) {
@@ -837,27 +838,34 @@ func TestCommandDoesNotPrepareReportBeforeRequiredFlagValidation(t *testing.T) {
 	}
 }
 
-func TestCommandReportOmitsSameTargetUpdates(t *testing.T) {
+func TestCommandReportOmitsEquivalentLiteralUpdates(t *testing.T) {
 	dir := t.TempDir()
-	file := writeTestFile(t, dir, "main.tf", `terraform {
+	input := `terraform {
+  required_version = "\u003e= 1.5"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "\u007e> 5.0"
     }
   }
 }
 module "current" {
   source  = "example/module"
-  version = "2.0.0"
+  version = "\u0032.0.0"
 }
-`)
+`
+	file := writeTestFile(t, dir, "main.tf", input)
+	wantModTime := time.Unix(1, 0)
+	if err := os.Chtimes(file, wantModTime, wantModTime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
 	config := writeTestFile(t, dir, "updates.yml", `providers:
   - name: aws
     version: "~> 5.0"
 modules:
   - source: example/module
     version: 2.0.0
+terraform_version: ">= 1.5"
 `)
 	report := dir + "/report.json"
 
@@ -873,6 +881,16 @@ modules:
 	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 0,\n  \"provider_blocks_updated\": 0\n}\n"
 	if got := readTestFile(t, report); got != wantReport {
 		t.Fatalf("report = %q, want %q", got, wantReport)
+	}
+	if got := readTestFile(t, file); got != input {
+		t.Errorf("content = %q, want unchanged %q", got, input)
+	}
+	info, err := os.Stat(file)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.ModTime(); !got.Equal(wantModTime) {
+		t.Errorf("modification time = %v, want unchanged %v", got, wantModTime)
 	}
 }
 

--- a/command_test.go
+++ b/command_test.go
@@ -757,7 +757,7 @@ func TestCommandDoesNotPrepareReportBeforeRequiredFlagValidation(t *testing.T) {
 	}
 }
 
-func TestCommandReportPreservesSameTargetHumanOutput(t *testing.T) {
+func TestCommandReportOmitsSameTargetUpdates(t *testing.T) {
 	dir := t.TempDir()
 	file := writeTestFile(t, dir, "main.tf", `terraform {
   required_providers {
@@ -785,14 +785,8 @@ modules:
 		"tf-version-bump", "-pattern", file, "-config", config, "-report-file", report,
 	})
 
-	wantStdout := "Found 1 file(s) matching pattern '" + file + "'\n" +
-		"✓ Updated provider 'aws' to version '~> 5.0' in " + file + "\n" +
-		"✓ Updated module source 'example/module' to version '2.0.0' in " + file + "\n\n" +
-		"==================================================\n" +
-		"Config File Update Summary\n" +
-		"==================================================\n" +
-		"Providers: 1 update(s) applied\n" +
-		"Modules: 1 update(s) applied\n"
+	wantStdout := "Found 1 file(s) matching pattern '" + file + "'\n\n" +
+		"No updates were performed. Config file may be empty or contain no matching items.\n"
 	if result.exitCode != -1 || result.diagnostics != "" || result.stdout != wantStdout {
 		t.Fatalf("result = %#v, want stdout %q", result, wantStdout)
 	}

--- a/command_test.go
+++ b/command_test.go
@@ -103,12 +103,24 @@ func TestCommandVersion(t *testing.T) {
 
 func TestCommandValidatesConfigWithoutTerraformFiles(t *testing.T) {
 	config := writeTestFile(t, t.TempDir(), "versions.yml", "providers:\n  - name: aws\n    version: '~> 5.0'\n")
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "default output"},
+		{name: "Markdown output", args: []string{"-output", "md"}},
+	}
 
-	result := runMainCommand(t, []string{"tf-version-bump", "-validate-config", config})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := append([]string{"tf-version-bump", "-validate-config", config}, tt.args...)
+			result := runMainCommand(t, args)
 
-	want := "Config '" + config + "' is valid\n"
-	if result.stdout != want || result.diagnostics != "" || result.exitCode != 0 {
-		t.Fatalf("result = %#v, want stdout %q and exit 0", result, want)
+			want := "Config '" + config + "' is valid\n"
+			if result.stdout != want || result.diagnostics != "" || result.exitCode != 0 {
+				t.Fatalf("result = %#v, want stdout %q and exit 0", result, want)
+			}
+		})
 	}
 }
 
@@ -120,6 +132,7 @@ func TestCommandConfigValidationRejectsInvalidConfig(t *testing.T) {
 	}{
 		{name: "malformed", content: "providers:\n  - name: [\n", wantDetail: "failed to parse YAML"},
 		{name: "empty operations", content: "# no updates\n", wantDetail: "config contains no updates"},
+		{name: "multiple documents", content: "terraform_version: '>= 1.5'\n---\nunknown: true\n", wantDetail: "multiple YAML documents are not supported"},
 	}
 
 	for _, tt := range tests {

--- a/config.go
+++ b/config.go
@@ -127,6 +127,13 @@ func loadConfig(filename string) (*Config, error) {
 		}
 		return nil, fmt.Errorf("failed to parse YAML: %w", err)
 	}
+	var additionalDocument yaml.Node
+	if err := decoder.Decode(&additionalDocument); err != io.EOF {
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse YAML: %w", err)
+		}
+		return nil, fmt.Errorf("multiple YAML documents are not supported")
+	}
 
 	// Trim and validate terraform_version
 	config.TerraformVersion = strings.TrimSpace(config.TerraformVersion)

--- a/config.go
+++ b/config.go
@@ -141,6 +141,17 @@ func loadConfig(filename string) (*Config, error) {
 	return &config, nil
 }
 
+func validateConfigFile(filename string) error {
+	config, err := loadConfig(filename)
+	if err != nil {
+		return err
+	}
+	if config.TerraformVersion == "" && len(config.Providers) == 0 && len(config.Modules) == 0 {
+		return fmt.Errorf("config contains no updates")
+	}
+	return nil
+}
+
 func sanitizeProviderUpdates(providers []ProviderUpdate) error {
 	for i := range providers {
 		providers[i].Name = strings.TrimSpace(providers[i].Name)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -52,10 +52,11 @@ Validate the runtime YAML contract without selecting, parsing, or changing Terra
 tf-version-bump -validate-config versions.yml
 ```
 
-The command rejects malformed YAML, unknown fields, missing required entry fields, and configs
-without any Terraform, provider, or module updates. It trims and validates values in the same way
-as update mode. It does not execute the JSON Schema or validate Terraform version-constraint
-syntax. Validation is standalone and cannot be combined with update or report flags.
+The command rejects malformed YAML, multiple YAML documents, unknown fields, missing required
+entry fields, and configs without any Terraform, provider, or module updates. It trims and
+validates values in the same way as update mode. It does not execute the JSON Schema or validate
+Terraform version-constraint syntax. Validation is standalone and cannot be combined with update
+or report flags.
 
 ## Top-level fields
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -44,6 +44,19 @@ The repository's [JSON Schema](../schema/config-schema.json) provides editor com
 validates Terraform-style version-constraint syntax. The CLI's YAML loader does not execute that
 JSON Schema, so use an editor or separate schema validator when you need schema enforcement.
 
+## Validate without updating
+
+Validate the runtime YAML contract without selecting, parsing, or changing Terraform files:
+
+```bash
+tf-version-bump -validate-config versions.yml
+```
+
+The command rejects malformed YAML, unknown fields, missing required entry fields, and configs
+without any Terraform, provider, or module updates. It trims and validates values in the same way
+as update mode. It does not execute the JSON Schema or validate Terraform version-constraint
+syntax. Validation is standalone and cannot be combined with update or report flags.
+
 ## Top-level fields
 
 | Field | Type | Purpose |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -7,17 +7,22 @@ For a short introduction, start with the [README](../README.md#quick-start).
 
 ## Command modes
 
-The command supports four mutually exclusive entry points:
+The command supports five mutually exclusive entry points:
 
 ```text
 tf-version-bump -pattern <glob> -module <source> -to <version>
 tf-version-bump -pattern <glob> -terraform-version <constraint>
 tf-version-bump -pattern <glob> -provider <name> -to <constraint>
 tf-version-bump -pattern <glob> -config <file>
+tf-version-bump -validate-config <file>
 ```
 
 `-config` can combine module, Terraform, and provider updates internally. It cannot be combined
-with the three direct operation flags or their module filters.
+with the three direct operation flags or their module filters. `-validate-config` checks only the
+YAML runtime contract and cannot be combined with update or report flags.
+
+An eligible module, provider, or Terraform version that already equals its requested literal value
+is a no-op: the command does not rewrite the file or count it as an update.
 
 ## Flag reference
 
@@ -30,6 +35,7 @@ with the three direct operation flags or their module filters.
 | `-ignore-version <version>` | Direct module mode | Skip this exact current-version string. Repeatable. |
 | `-ignore-modules <patterns>` | Direct module mode | Comma-separated module block labels; `*` is a wildcard. |
 | `-config <file>` | Config mode | YAML file containing one or more update groups. |
+| `-validate-config <file>` | Standalone | Validate a non-empty YAML update config without selecting Terraform files. |
 | `-terraform-version <constraint>` | Direct Terraform mode | Value to set as `required_version`. |
 | `-provider <name>` | Direct provider mode | Local provider name within `required_providers`. |
 | `-force-add` | Module updates | Add a missing module `version` attribute to registry modules. |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -45,8 +45,9 @@ is a no-op: the command does not rewrite the file or count it as an update.
 | `-report-file <path>` | All update modes | Write exact updated module and provider block counts as JSON. |
 | `-version` | Standalone | Print version, commit, and build date metadata, then exit. |
 
-`-output md` changes quoting in human-readable messages; it does not emit a structured Markdown
-document or machine-readable result.
+`-output md` changes quoting in human-readable update messages; it does not emit a structured
+Markdown document or machine-readable result. Standalone validation keeps its fixed
+`Config '<path>' is valid` success message in every output format.
 
 ### Machine-readable update report
 

--- a/main.go
+++ b/main.go
@@ -322,7 +322,7 @@ func main() {
 		if err := validateConfigFile(flags.validationConfigFile); err != nil {
 			fatalf("Error validating config file: %v", err)
 		}
-		fmt.Printf("Config %s is valid\n", quote(flags.validationConfigFile, flags.output))
+		fmt.Printf("Config '%s' is valid\n", flags.validationConfigFile)
 		exitFunc(0)
 	}
 
@@ -469,10 +469,7 @@ func validateReportFileDoesNotOverwriteInput(reportFile string, inputFiles []str
 // validateOperationModes validates that the CLI flags are properly set
 func validateOperationModes(flags *cliFlags) {
 	if flags.validationConfigFile != "" {
-		if flags.pattern != "" || flags.configFile != "" || flags.moduleSource != "" || flags.toVersion != "" ||
-			len(flags.fromVersions) > 0 || len(flags.ignoreVersions) > 0 || flags.ignoreModules != "" ||
-			flags.terraformVersion != "" || flags.providerName != "" || flags.forceAdd || flags.dryRun ||
-			flags.verbose || flags.reportFile != "" {
+		if configValidationHasConflicts(flags) {
 			fatalf("Error: Cannot use -validate-config with update or report flags")
 		}
 		return
@@ -480,10 +477,7 @@ func validateOperationModes(flags *cliFlags) {
 
 	// Config file mode is exclusive with all other CLI flags
 	if flags.configFile != "" {
-		if flags.moduleSource != "" || flags.terraformVersion != "" || flags.providerName != "" ||
-			flags.toVersion != "" || len(flags.fromVersions) > 0 || len(flags.ignoreVersions) > 0 || flags.ignoreModules != "" {
-			fatalf("Error: Cannot use -config with other operation flags (-module, -to, -terraform-version, -provider, -from, -ignore-version, -ignore-modules)")
-		}
+		validateConfigUpdateMode(flags)
 		return
 	}
 
@@ -513,6 +507,20 @@ func validateOperationModes(flags *cliFlags) {
 	if modesSet > 1 {
 		fatalf("Error: Cannot use -module, -terraform-version, and -provider flags together. Choose one operation mode or use a config file.")
 	}
+}
+
+func validateConfigUpdateMode(flags *cliFlags) {
+	if flags.moduleSource != "" || flags.terraformVersion != "" || flags.providerName != "" ||
+		flags.toVersion != "" || len(flags.fromVersions) > 0 || len(flags.ignoreVersions) > 0 || flags.ignoreModules != "" {
+		fatalf("Error: Cannot use -config with other operation flags (-module, -to, -terraform-version, -provider, -from, -ignore-version, -ignore-modules)")
+	}
+}
+
+func configValidationHasConflicts(flags *cliFlags) bool {
+	return flags.pattern != "" || flags.configFile != "" || flags.moduleSource != "" || flags.toVersion != "" ||
+		len(flags.fromVersions) > 0 || len(flags.ignoreVersions) > 0 || flags.ignoreModules != "" ||
+		flags.terraformVersion != "" || flags.providerName != "" || flags.forceAdd || flags.dryRun ||
+		flags.verbose || flags.reportFile != ""
 }
 
 // findMatchingFiles finds all files matching the pattern
@@ -960,7 +968,7 @@ func updateProviderBlockSyntaxResult(nestedBlock *hclwrite.Block, providerName, 
 			continue
 		}
 		versionAttribute := providerBlock.Body().GetAttribute("version")
-		if versionAttribute != nil && attributeStringValue(versionAttribute) == version {
+		if versionAttribute != nil && attributeHasStringValue(versionAttribute, version) {
 			continue
 		}
 		changedBlocks = append(changedBlocks, providerIndex)
@@ -1033,7 +1041,7 @@ func replaceProviderObjectVersion(objExpr *hclsyntax.ObjectConsExpr, expression 
 			return nil, false, false
 		}
 		hasVersion = true
-		if attributeExpressionStringValue(expression[valueRange.Start.Byte:valueRange.End.Byte]) == newVersion {
+		if expressionHasStringValue(expression[valueRange.Start.Byte:valueRange.End.Byte], newVersion) {
 			continue
 		}
 
@@ -1048,8 +1056,9 @@ func replaceProviderObjectVersion(objExpr *hclsyntax.ObjectConsExpr, expression 
 	return updated, hasVersion, changed
 }
 
-func attributeExpressionStringValue(expression []byte) string {
-	return trimQuotes(strings.TrimSpace(string(expression)))
+func expressionHasStringValue(expression []byte, value string) bool {
+	target := hclwrite.TokensForValue(cty.StringVal(value)).Bytes()
+	return bytes.Equal(bytes.TrimSpace(expression), bytes.TrimSpace(target))
 }
 
 func providerObjectItemKey(item hclsyntax.ObjectConsItem) (string, bool) {
@@ -1212,7 +1221,7 @@ func updateModuleBlockResult(block *hclwrite.Block, opts *moduleUpdateOptions) (
 		if shouldSkipModuleVersion(moduleName, currentVersion, opts) {
 			return false, false
 		}
-		if currentVersion == opts.version {
+		if attributeHasStringValue(versionAttr, opts.version) {
 			return false, false
 		}
 		block.Body().SetAttributeValue("version", cty.StringVal(opts.version))
@@ -1241,6 +1250,10 @@ func moduleSourceValue(block *hclwrite.Block) (string, bool) {
 func attributeStringValue(attr *hclwrite.Attribute) string {
 	tokens := attr.Expr().BuildTokens(nil)
 	return trimQuotes(strings.TrimSpace(string(tokens.Bytes())))
+}
+
+func attributeHasStringValue(attr *hclwrite.Attribute, value string) bool {
+	return expressionHasStringValue(attr.Expr().BuildTokens(nil).Bytes(), value)
 }
 
 func shouldSkipModuleVersion(moduleName, currentVersion string, opts *moduleUpdateOptions) bool {

--- a/main.go
+++ b/main.go
@@ -104,22 +104,23 @@ func quote(s, format string) string {
 
 // cliFlags holds all command-line flags
 type cliFlags struct {
-	pattern          string
-	moduleSource     string
-	toVersion        string
-	fromVersions     stringSliceFlag
-	ignoreVersions   stringSliceFlag
-	ignoreModules    string
-	configFile       string
-	forceAdd         bool
-	dryRun           bool
-	verbose          bool
-	showVersion      bool
-	output           string
-	terraformVersion string
-	providerName     string
-	reportFile       string
-	report           updateReport
+	pattern              string
+	moduleSource         string
+	toVersion            string
+	fromVersions         stringSliceFlag
+	ignoreVersions       stringSliceFlag
+	ignoreModules        string
+	configFile           string
+	validationConfigFile string
+	forceAdd             bool
+	dryRun               bool
+	verbose              bool
+	showVersion          bool
+	output               string
+	terraformVersion     string
+	providerName         string
+	reportFile           string
+	report               updateReport
 }
 
 type updateReport struct {
@@ -210,6 +211,7 @@ func parseFlags() *cliFlags {
 	flag.Var(&flags.ignoreVersions, "ignore-version", "Optional: version(s) to skip (can be specified multiple times, e.g., -ignore-version 3.0.0 -ignore-version '~> 3.0')")
 	flag.StringVar(&flags.ignoreModules, "ignore-modules", "", "Optional: comma-separated list of module names or patterns to ignore (e.g., 'vpc,legacy-*')")
 	flag.StringVar(&flags.configFile, "config", "", "Path to YAML config file with multiple module updates")
+	flag.StringVar(&flags.validationConfigFile, "validate-config", "", "Validate a YAML config file without updating Terraform files")
 	flag.BoolVar(&flags.forceAdd, "force-add", false, "Add a missing version attribute to registry modules (default: skip with warning)")
 	flag.BoolVar(&flags.dryRun, "dry-run", false, "Show what changes would be made without actually modifying files")
 	flag.BoolVar(&flags.verbose, "verbose", false, "Show verbose output including skipped modules")
@@ -316,6 +318,13 @@ func main() {
 
 	// Validate operation modes
 	validateOperationModes(flags)
+	if flags.validationConfigFile != "" {
+		if err := validateConfigFile(flags.validationConfigFile); err != nil {
+			fatalf("Error validating config file: %v", err)
+		}
+		fmt.Printf("Config %s is valid\n", quote(flags.validationConfigFile, flags.output))
+		exitFunc(0)
+	}
 
 	// Find and validate matching files
 	files := findMatchingFiles(flags)
@@ -459,6 +468,16 @@ func validateReportFileDoesNotOverwriteInput(reportFile string, inputFiles []str
 
 // validateOperationModes validates that the CLI flags are properly set
 func validateOperationModes(flags *cliFlags) {
+	if flags.validationConfigFile != "" {
+		if flags.pattern != "" || flags.configFile != "" || flags.moduleSource != "" || flags.toVersion != "" ||
+			len(flags.fromVersions) > 0 || len(flags.ignoreVersions) > 0 || flags.ignoreModules != "" ||
+			flags.terraformVersion != "" || flags.providerName != "" || flags.forceAdd || flags.dryRun ||
+			flags.verbose || flags.reportFile != "" {
+			fatalf("Error: Cannot use -validate-config with update or report flags")
+		}
+		return
+	}
+
 	// Config file mode is exclusive with all other CLI flags
 	if flags.configFile != "" {
 		if flags.moduleSource != "" || flags.terraformVersion != "" || flags.providerName != "" ||
@@ -484,6 +503,7 @@ func validateOperationModes(flags *cliFlags) {
 		fmt.Println("Usage:")
 		fmt.Println("  Module update:     tf-version-bump -pattern <glob> -module <source> -to <version>")
 		fmt.Println("  Config file:       tf-version-bump -pattern <glob> -config <config-file>")
+		fmt.Println("  Config validation: tf-version-bump -validate-config <config-file>")
 		fmt.Println("  Terraform version: tf-version-bump -pattern <glob> -terraform-version <version>")
 		fmt.Println("  Provider version:  tf-version-bump -pattern <glob> -provider <name> -to <version>")
 		flag.PrintDefaults()

--- a/main.go
+++ b/main.go
@@ -1,11 +1,12 @@
 // Package main provides a CLI tool for updating Terraform module versions, Terraform versions,
 // and provider versions across multiple files.
 //
-// The tool supports four modes of operation:
+// The tool supports five modes of operation:
 //  1. Single Module Mode: Update one module at a time via command-line flags
 //  2. Config File Mode: Update multiple modules using a YAML configuration file
-//  3. Terraform Version Mode: Update Terraform required_version in terraform blocks
-//  4. Provider Version Mode: Update provider versions in terraform required_providers blocks
+//  3. Config Validation Mode: Validate a YAML configuration file without updating Terraform files
+//  4. Terraform Version Mode: Update Terraform required_version in terraform blocks
+//  5. Provider Version Mode: Update provider versions in terraform required_providers blocks
 //
 // It uses the official HashiCorp HCL library to parse and modify Terraform files while retaining
 // comments and HCL structure. Changed files are normalised by hclwrite.Format.

--- a/main.go
+++ b/main.go
@@ -940,9 +940,10 @@ func updateProviderBlockSyntaxResult(nestedBlock *hclwrite.Block, providerName, 
 			continue
 		}
 		versionAttribute := providerBlock.Body().GetAttribute("version")
-		if versionAttribute == nil || attributeStringValue(versionAttribute) != version {
-			changedBlocks = append(changedBlocks, providerIndex)
+		if versionAttribute != nil && attributeStringValue(versionAttribute) == version {
+			continue
 		}
+		changedBlocks = append(changedBlocks, providerIndex)
 		providerBlock.Body().SetAttributeValue("version", cty.StringVal(version))
 		updated = true
 	}
@@ -959,7 +960,7 @@ func updateProviderAttributeVersionResult(nestedBlock *hclwrite.Block, providerN
 	}
 
 	updatedExpression, hasVersion, changed := replaceProviderObjectVersion(objExpr, expression, newVersion)
-	if !hasVersion {
+	if !hasVersion || !changed {
 		return false, false
 	}
 
@@ -1191,8 +1192,11 @@ func updateModuleBlockResult(block *hclwrite.Block, opts *moduleUpdateOptions) (
 		if shouldSkipModuleVersion(moduleName, currentVersion, opts) {
 			return false, false
 		}
+		if currentVersion == opts.version {
+			return false, false
+		}
 		block.Body().SetAttributeValue("version", cty.StringVal(opts.version))
-		return true, currentVersion != opts.version
+		return true, true
 	}
 
 	block.Body().SetAttributeValue("version", cty.StringVal(opts.version))

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -833,18 +832,13 @@ func updateTerraformVersion(filename, version string, dryRun bool) (bool, error)
 
 	// Track if we made any changes
 	updated := false
-	targetVersionTokens := bytes.TrimSpace(hclwrite.TokensForValue(cty.StringVal(version)).Bytes())
-
 	// Iterate through all blocks in the file
 	for _, block := range file.Body().Blocks() {
 		// Look for terraform blocks
 		if block.Type() == "terraform" {
 			currentVersion := block.Body().GetAttribute("required_version")
-			if currentVersion != nil {
-				currentTokens := currentVersion.Expr().BuildTokens(nil)
-				if bytes.Equal(bytes.TrimSpace(currentTokens.Bytes()), targetVersionTokens) {
-					continue
-				}
+			if currentVersion != nil && attributeHasStringValue(currentVersion, version) {
+				continue
 			}
 			// Update or add the required_version attribute
 			block.Body().SetAttributeValue("required_version", cty.StringVal(version))
@@ -1058,8 +1052,13 @@ func replaceProviderObjectVersion(objExpr *hclsyntax.ObjectConsExpr, expression 
 }
 
 func expressionHasStringValue(expression []byte, value string) bool {
-	target := hclwrite.TokensForValue(cty.StringVal(value)).Bytes()
-	return bytes.Equal(bytes.TrimSpace(expression), bytes.TrimSpace(target))
+	expr, diags := hclsyntax.ParseExpression(expression, "inline", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return false
+	}
+	expressionValue, diags := expr.Value(&hcl.EvalContext{})
+	return !diags.HasErrors() && expressionValue.IsKnown() && !expressionValue.IsNull() &&
+		expressionValue.Type().Equals(cty.String) && expressionValue.AsString() == value
 }
 
 func providerObjectItemKey(item hclsyntax.ObjectConsItem) (string, bool) {

--- a/module_update_test.go
+++ b/module_update_test.go
@@ -273,6 +273,31 @@ version="5.0.0"
 	}
 }
 
+func TestUpdateModuleVersionReplacesMatchingNonLiteralExpression(t *testing.T) {
+	input := `module "example" {
+  source  = "example/module"
+  version = var.constraint
+}
+`
+	filename := writeTestFile(t, t.TempDir(), "main.tf", input)
+
+	updated, err := updateModuleVersion(filename, "example/module", "var.constraint", nil, nil, nil, false, false, false, "text")
+	if err != nil {
+		t.Fatalf("updateModuleVersion returned error: %v", err)
+	}
+	if !updated {
+		t.Fatal("updated = false, want true")
+	}
+	want := `module "example" {
+  source  = "example/module"
+  version = "var.constraint"
+}
+`
+	if got := readTestFile(t, filename); got != want {
+		t.Errorf("content = %q, want %q", got, want)
+	}
+}
+
 func TestUpdateModuleVersionDryRunContract(t *testing.T) {
 	input := "module \"vpc\" {\n  source = \"terraform-aws-modules/vpc/aws\"\n  version = \"1.0.0\"\n}\n"
 	file := writeTestFile(t, t.TempDir(), "main.tf", input)

--- a/module_update_test.go
+++ b/module_update_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 type capturedStreams struct {
@@ -238,6 +239,37 @@ func TestUpdateModuleVersionPreservesPermissions(t *testing.T) {
 	}
 	if got := info.Mode().Perm(); got != 0o640 {
 		t.Errorf("mode = %o, want 640", got)
+	}
+}
+
+func TestUpdateModuleVersionMatchingVersionDoesNotWrite(t *testing.T) {
+	input := `module "vpc" {
+source="terraform-aws-modules/vpc/aws"
+version="5.0.0"
+}
+`
+	filename := writeTestFile(t, t.TempDir(), "main.tf", input)
+	wantModTime := time.Unix(1, 0)
+	if err := os.Chtimes(filename, wantModTime, wantModTime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	updated, err := updateModuleVersion(filename, "terraform-aws-modules/vpc/aws", "5.0.0", nil, nil, nil, false, false, false, "text")
+	if err != nil {
+		t.Fatalf("updateModuleVersion returned error: %v", err)
+	}
+	if updated {
+		t.Fatal("updated = true, want false")
+	}
+	if got := readTestFile(t, filename); got != input {
+		t.Errorf("content = %q, want unchanged %q", got, input)
+	}
+	info, err := os.Stat(filename)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.ModTime(); !got.Equal(wantModTime) {
+		t.Errorf("modification time = %v, want unchanged %v", got, wantModTime)
 	}
 }
 

--- a/provider_update_test.go
+++ b/provider_update_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestUpdateProviderVersionContract(t *testing.T) {
@@ -199,6 +200,50 @@ terraform {
 			}
 			if got := readTestFile(t, filename); got != tt.want {
 				t.Errorf("content mismatch:\n--- got ---\n%s--- want ---\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateProviderVersionMatchingVersionDoesNotWrite(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "block syntax",
+			input: "terraform {\nrequired_providers {\naws {\nsource=\"hashicorp/aws\"\nversion=\"~> 5.0\"\n}\n}\n}\n",
+		},
+		{
+			name:  "attribute syntax",
+			input: "terraform {\nrequired_providers {\naws={source=\"hashicorp/aws\",version=\"~> 5.0\"}\n}\n}\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filename := writeTestFile(t, t.TempDir(), "main.tf", tt.input)
+			wantModTime := time.Unix(1, 0)
+			if err := os.Chtimes(filename, wantModTime, wantModTime); err != nil {
+				t.Fatalf("chtimes: %v", err)
+			}
+
+			updated, err := updateProviderVersion(filename, "aws", "~> 5.0", false)
+			if err != nil {
+				t.Fatalf("updateProviderVersion returned error: %v", err)
+			}
+			if updated {
+				t.Fatal("updated = true, want false")
+			}
+			if got := readTestFile(t, filename); got != tt.input {
+				t.Errorf("content = %q, want unchanged %q", got, tt.input)
+			}
+			info, err := os.Stat(filename)
+			if err != nil {
+				t.Fatalf("stat: %v", err)
+			}
+			if got := info.ModTime(); !got.Equal(wantModTime) {
+				t.Errorf("modification time = %v, want unchanged %v", got, wantModTime)
 			}
 		})
 	}

--- a/provider_update_test.go
+++ b/provider_update_test.go
@@ -249,6 +249,74 @@ func TestUpdateProviderVersionMatchingVersionDoesNotWrite(t *testing.T) {
 	}
 }
 
+func TestUpdateProviderVersionReplacesMatchingNonLiteralExpression(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name: "block syntax",
+			input: `terraform {
+  required_providers {
+    aws {
+      source  = "hashicorp/aws"
+      version = var.constraint
+    }
+  }
+}
+`,
+			want: `terraform {
+  required_providers {
+    aws {
+      source  = "hashicorp/aws"
+      version = "var.constraint"
+    }
+  }
+}
+`,
+		},
+		{
+			name: "attribute syntax",
+			input: `terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = var.constraint
+    }
+  }
+}
+`,
+			want: `terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "var.constraint"
+    }
+  }
+}
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filename := writeTestFile(t, t.TempDir(), "main.tf", tt.input)
+
+			updated, err := updateProviderVersion(filename, "aws", "var.constraint", false)
+			if err != nil {
+				t.Fatalf("updateProviderVersion returned error: %v", err)
+			}
+			if !updated {
+				t.Fatal("updated = false, want true")
+			}
+			if got := readTestFile(t, filename); got != tt.want {
+				t.Errorf("content = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUpdateProviderVersionDryRunContract(t *testing.T) {
 	input := "terraform {\n  required_providers {\n    aws {\n      source = \"hashicorp/aws\"\n      version = \"~> 4.0\"\n    }\n  }\n}\n"
 	filename := writeTestFile(t, t.TempDir(), "main.tf", input)


### PR DESCRIPTION
## Summary

- Make same-target module and provider updates genuine no-ops, avoiding file rewrites, formatting churn, misleading success output, summary increments, and report counts.
- Add standalone `tf-version-bump -validate-config <file>` validation without requiring a Terraform file pattern.
- Reject empty update configs, incompatible update/report flags, and additional YAML documents while preserving the documented runtime-versus-JSON-Schema boundary.
- Compare HCL expression tokens before declaring a version value unchanged, so non-literal expressions are still replaced with the requested literal string.
- Update the README, usage/configuration guides, and contributor architecture notes.

## Verification

- `go test -v -race -coverprofile=coverage.out -covermode=atomic ./...` — pass, 93.8% statement coverage
- `golangci-lint run --timeout=5m` — pass, 0 issues
- `make docs-check` — pass
- `go build ./...` — pass
- `git diff --check` — pass
- Two independent test-cleanup passes removed no tests; all touched cases protect distinct behaviour or branches.
- Independent code review and fix verification found no remaining issues and assessed the branch ready to merge.
- All four branch commits are signed with the GenAI SSH key.
