### PR TITLE
feat: add CI check mode and automation examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ golangci-lint run --fix                                   # Auto-fix issues
 # Dry run
 ./tf-version-bump -pattern "*.tf" -module "..." -to "..." -dry-run
 
-# CI check: 0 when current, 2 when updates are required, 1 on error
+# CI check: 0 with no eligible update, 2 when updates are required, 1 on error
 ./tf-version-bump -pattern "**/*.tf" -config examples/config-basic.yml -check
 
 # Update Terraform version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,9 @@ golangci-lint run --fix                                   # Auto-fix issues
 # Dry run
 ./tf-version-bump -pattern "*.tf" -module "..." -to "..." -dry-run
 
+# CI check: 0 when current, 2 when updates are required, 1 on error
+./tf-version-bump -pattern "**/*.tf" -config examples/config-basic.yml -check
+
 # Update Terraform version
 ./tf-version-bump -pattern "*.tf" -terraform-version ">= 1.5"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,12 @@ command. Keep human summaries and the report separate: existing summaries count 
 operations, while the report counts individual changed blocks. Dry-run reports contain zero counts
 because no file values changed.
 
+`-check` uses the existing dry-run update paths but has a separate automation exit contract. The
+mode runners return their update-operation total to `main`: a processing error exits 1, a successful
+check with a positive total exits 2, and a successful already-current check returns normally with
+status 0. Check mode rejects `-dry-run` and `-report-file`, so it never writes Terraform or report
+files.
+
 ## Testing
 
 Follow TDD. Tests are commonly table-driven with `t.Run` subtests; prefer `t.TempDir()` for new

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,9 +195,9 @@ zero counts because no file values changed.
 
 `-check` uses the existing dry-run update paths but has a separate automation exit contract. The
 mode runners return their update-operation total to `main`: a processing error exits 1, a successful
-check with a positive total exits 2, and a successful already-current check returns normally with
-status 0. Check mode rejects `-dry-run` and `-report-file`, so it never writes Terraform or report
-files.
+check with a positive total exits 2, and a successful check with no eligible update returns normally
+with status 0. Check mode rejects `-dry-run` and `-report-file`, so it never writes Terraform or
+report files.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,11 +187,11 @@ Success is prefixed `✓`; dry-run lines use `→` with the verb "Would update".
 `quote(s, format)`: `'vpc'` for `text` output, `` `vpc` `` for `md`. Thread `outputFormat`
 through rather than hardcoding quotes.
 
-`-report-file` is the machine-readable automation contract. It writes schema version 1 JSON with
-exact counts of unique module and provider blocks whose version values changed across the complete
-command. Keep human summaries and the report separate: existing summaries count source/file
-operations, while the report counts individual changed blocks. Dry-run reports contain zero counts
-because no file values changed.
+`-report-file` is the machine-readable automation contract. It writes schema version 2 JSON with
+exact counts of unique Terraform, module, and provider blocks whose version values changed across
+the complete command. Keep human summaries and the report separate: existing summaries count
+source/file operations, while the report counts individual changed blocks. Dry-run reports contain
+zero counts because no file values changed.
 
 `-check` uses the existing dry-run update paths but has a separate automation exit contract. The
 mode runners return their update-operation total to `main`: a processing error exits 1, a successful

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help:
 	@echo "  clean          - Clean build artifacts and coverage files"
 	@echo "  build          - Build the binary"
 	@echo "  install        - Install the binary"
-	@echo "  docs-check     - Check documentation links, schema, and example configs"
+	@echo "  docs-check     - Check documentation, schema, configs, and runnable examples"
 	@echo "  branch-automation-test - Alias for test-github-actions"
 	@echo "  test-github-actions - Run GitHub Actions example checks (harness + actionlint)"
 	@echo "  actionlint     - Lint GitHub Actions workflows"
@@ -58,7 +58,7 @@ build:
 install:
 	go install -v .
 
-# Check user documentation, its local links, the config schema, and maintained YAML examples.
+# Check user documentation, its local links, the config schema, and maintained examples.
 docs-check:
 	go test -v -run 'Test(ConfigSchema|Documentation|ExampleConfigs)' ./...
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Only the named provider is changed; other providers and `required_version` are l
 Create `versions.yml`:
 
 ```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yesdevnull/tf-version-bump/main/schema/config-schema.json
+
 terraform_version: ">= 1.9"
 
 providers:
@@ -120,7 +122,8 @@ tf-version-bump -validate-config versions.yml
 
 Config mode is exclusive with `-module`, `-provider`, `-terraform-version`, `-to`, and the
 module-filter flags. It can still be combined with global behaviour flags such as `-dry-run`,
-`-force-add`, `-verbose`, `-output`, and `-report-file`.
+`-check`, `-force-add`, `-verbose`, `-output`, and `-report-file`, subject to the check-mode
+restrictions below.
 
 ## Preview and review
 
@@ -147,9 +150,14 @@ terraform validate
 with your Terraform configuration. Use your normal validation and planning workflow before
 deployment.
 
-Automation can pass `-report-file update-report.json` to receive exact updated module and
-provider block counts as JSON. See the [usage reference](docs/USAGE.md#machine-readable-update-report)
-for the report contract.
+For CI, use `-check` instead of `-dry-run`. It writes nothing and exits 0 when all selected values
+are current, 2 when updates are required, and 1 on an error. It cannot be combined with `-dry-run`
+or `-report-file`.
+
+Automation can pass `-report-file update-report.json` in write mode to receive exact updated
+Terraform, module, and provider block counts as JSON. See the
+[usage reference](docs/USAGE.md#machine-readable-update-report) for the report contract and the
+[examples cookbook](examples/README.md#automation-cookbook) for a complete workflow.
 
 ## Common controls
 

--- a/README.md
+++ b/README.md
@@ -150,9 +150,10 @@ terraform validate
 with your Terraform configuration. Use your normal validation and planning workflow before
 deployment.
 
-For CI, use `-check` instead of `-dry-run`. It writes nothing and exits 0 when all selected values
-are current, 2 when updates are required, and 1 on an error. It cannot be combined with `-dry-run`
-or `-report-file`.
+For CI, use `-check` instead of `-dry-run`. It writes nothing and exits 0 when no eligible version
+value would change, 2 when updates are required, and 1 on an error. Ignored modules, unmatched
+targets, and matching modules skipped for a missing `version` can still return 0. Check mode cannot
+be combined with `-dry-run` or `-report-file`.
 
 Automation can pass `-report-file update-report.json` in write mode to receive exact updated
 Terraform, module, and provider block counts as JSON. See the

--- a/command_test.go
+++ b/command_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"errors"
+	"flag"
 	"os"
 	"reflect"
 	"strings"
@@ -37,6 +39,28 @@ func TestParseFlagsRejectsInvalidOutput(t *testing.T) {
 	})
 	if got != "Error: Invalid output format 'invalid'. Must be 'text' or 'md'\n" {
 		t.Fatalf("diagnostic: %q", got)
+	}
+}
+
+func TestParseFlagsPreservesConfiguredUsageOutput(t *testing.T) {
+	originalArgs := os.Args
+	originalFlagSet := flag.CommandLine
+	t.Cleanup(func() {
+		os.Args = originalArgs
+		flag.CommandLine = originalFlagSet
+	})
+
+	var usage bytes.Buffer
+	configuredFlagSet := flag.NewFlagSet("tf-version-bump", flag.ContinueOnError)
+	configuredFlagSet.SetOutput(&usage)
+	flag.CommandLine = configuredFlagSet
+	os.Args = []string{"tf-version-bump", "-version"}
+
+	_ = parseFlags()
+	flag.PrintDefaults()
+
+	if !strings.Contains(usage.String(), "-check") {
+		t.Fatalf("usage output = %q, want registered flags on the configured writer", usage.String())
 	}
 }
 

--- a/command_test.go
+++ b/command_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 func TestParseFlagsContract(t *testing.T) {
-	args := []string{"tf-version-bump", "-pattern", "**/*.tf", "-module", "example/module", "-to", "2.0.0", "-from", "1.0.0", "-from", "1.5.0", "-ignore-version", "3.0.0", "-ignore-modules", "vpc, legacy-*", "-config", "config.yml", "-validate-config", "validate.yml", "-force-add", "-dry-run", "-verbose", "-version", "-output", "md", "-terraform-version", ">= 1.5", "-provider", "aws"}
+	args := []string{"tf-version-bump", "-pattern", "**/*.tf", "-module", "example/module", "-to", "2.0.0", "-from", "1.0.0", "-from", "1.5.0", "-ignore-version", "3.0.0", "-ignore-modules", "vpc, legacy-*", "-config", "config.yml", "-validate-config", "validate.yml", "-force-add", "-dry-run", "-check", "-verbose", "-version", "-output", "md", "-terraform-version", ">= 1.5", "-provider", "aws"}
 	withFlagArgs(t, args, func() {
 		got := parseFlags()
-		want := &cliFlags{pattern: "**/*.tf", moduleSource: "example/module", toVersion: "2.0.0", fromVersions: stringSliceFlag{"1.0.0", "1.5.0"}, ignoreVersions: stringSliceFlag{"3.0.0"}, ignoreModules: "vpc, legacy-*", configFile: "config.yml", validationConfigFile: "validate.yml", forceAdd: true, dryRun: true, verbose: true, showVersion: true, output: "md", terraformVersion: ">= 1.5", providerName: "aws"}
+		want := &cliFlags{pattern: "**/*.tf", moduleSource: "example/module", toVersion: "2.0.0", fromVersions: stringSliceFlag{"1.0.0", "1.5.0"}, ignoreVersions: stringSliceFlag{"3.0.0"}, ignoreModules: "vpc, legacy-*", configFile: "config.yml", validationConfigFile: "validate.yml", forceAdd: true, dryRun: true, check: true, verbose: true, showVersion: true, output: "md", terraformVersion: ">= 1.5", providerName: "aws"}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("flags = %#v, want %#v", got, want)
 		}
@@ -86,7 +86,7 @@ func TestLoadModuleUpdatesRequiresFlags(t *testing.T) {
 func TestRunCLIModeRequiresProviderVersion(t *testing.T) {
 	restore, _ := stubExit(t)
 	t.Cleanup(restore)
-	diag := captureLog(t, func() { requireExitCall(t, func() { _ = runCLIMode(nil, &cliFlags{providerName: "aws"}) }) })
+	diag := captureLog(t, func() { requireExitCall(t, func() { _, _ = runCLIMode(nil, &cliFlags{providerName: "aws"}) }) })
 	if diag != "Error: -to flag is required when using -provider\n" {
 		t.Fatalf("diagnostics: %q", diag)
 	}
@@ -165,6 +165,7 @@ func TestCommandConfigValidationRejectsUpdateAndReportFlags(t *testing.T) {
 		{name: "provider", args: []string{"-provider", "aws"}},
 		{name: "force add", args: []string{"-force-add"}},
 		{name: "dry run", args: []string{"-dry-run"}},
+		{name: "check", args: []string{"-check"}},
 		{name: "verbose", args: []string{"-verbose"}},
 		{name: "report", args: []string{"-report-file", "report.json"}},
 	}
@@ -182,8 +183,138 @@ func TestCommandConfigValidationRejectsUpdateAndReportFlags(t *testing.T) {
 	}
 }
 
+func TestCommandCheckProposesModuleUpdateWithoutWriting(t *testing.T) {
+	dir := t.TempDir()
+	input := "module \"example\" {\n  source  = \"example/module\"\n  version = \"1.0.0\"\n}\n"
+	file := writeTestFile(t, dir, "main.tf", input)
+
+	result := runMainCommand(t, []string{
+		"tf-version-bump", "-pattern", file, "-module", "example/module", "-to", "2.0.0", "-check",
+	})
+
+	wantStdout := "Found 1 file(s) matching pattern '" + file + "'\n" +
+		"Running in check mode - no files will be modified\n" +
+		"→ Would update module source 'example/module' to version '2.0.0' in " + file + "\n\n" +
+		"Dry run: would update 1 file(s)\n"
+	if result.stdout != wantStdout || result.diagnostics != "" || result.exitCode != 2 {
+		t.Fatalf("result = %#v, want stdout %q and exit 2", result, wantStdout)
+	}
+	if got := readTestFile(t, file); got != input {
+		t.Fatalf("check changed content to %q, want %q", got, input)
+	}
+}
+
+func TestCommandCheckConfigReportsAllUpdateModesWithoutWriting(t *testing.T) {
+	dir := t.TempDir()
+	input := `terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+module "example" {
+  source  = "example/module"
+  version = "1.0.0"
+}
+`
+	file := writeTestFile(t, dir, "main.tf", input)
+	config := writeTestFile(t, dir, "versions.yml", `terraform_version: ">= 1.5"
+providers:
+  - name: aws
+    version: "~> 5.0"
+modules:
+  - source: example/module
+    version: 2.0.0
+`)
+
+	result := runMainCommand(t, []string{
+		"tf-version-bump", "-pattern", file, "-config", config, "-check",
+	})
+
+	for _, fragment := range []string{
+		"Running in check mode - no files will be modified\n",
+		"→ Would update Terraform required_version to '>= 1.5'",
+		"→ Would update provider 'aws' to version '~> 5.0'",
+		"→ Would update module source 'example/module' to version '2.0.0'",
+	} {
+		if !strings.Contains(result.stdout, fragment) {
+			t.Errorf("stdout %q does not contain %q", result.stdout, fragment)
+		}
+	}
+	if result.diagnostics != "" || result.exitCode != 2 {
+		t.Fatalf("result = %#v, want no diagnostics and exit 2", result)
+	}
+	if got := readTestFile(t, file); got != input {
+		t.Fatalf("check changed content to %q, want %q", got, input)
+	}
+}
+
+func TestCommandCheckReturnsSuccessWhenCurrent(t *testing.T) {
+	dir := t.TempDir()
+	input := "module \"example\" {\n  source  = \"example/module\"\n  version = \"2.0.0\"\n}\n"
+	file := writeTestFile(t, dir, "main.tf", input)
+
+	result := runMainCommand(t, []string{
+		"tf-version-bump", "-pattern", file, "-module", "example/module", "-to", "2.0.0", "-check",
+	})
+
+	wantStdout := "Found 1 file(s) matching pattern '" + file + "'\n" +
+		"Running in check mode - no files will be modified\n\n" +
+		"Dry run: would update 0 file(s)\n"
+	if result.stdout != wantStdout || result.diagnostics != "" || result.exitCode != -1 {
+		t.Fatalf("result = %#v, want stdout %q and normal return", result, wantStdout)
+	}
+	if got := readTestFile(t, file); got != input {
+		t.Fatalf("check changed content to %q, want %q", got, input)
+	}
+}
+
+func TestCommandCheckProcessingErrorWinsOverUpdatesRequired(t *testing.T) {
+	dir := t.TempDir()
+	bad := writeTestFile(t, dir, "bad.tf", "module {")
+	goodInput := "module \"example\" {\n  source  = \"example/module\"\n  version = \"1.0.0\"\n}\n"
+	good := writeTestFile(t, dir, "good.tf", goodInput)
+
+	result := runMainCommand(t, []string{
+		"tf-version-bump", "-pattern", dir + "/*.tf", "-module", "example/module", "-to", "2.0.0", "-check",
+	})
+
+	if result.exitCode != 1 || !strings.Contains(result.diagnostics, "Error processing "+bad) || !strings.Contains(result.diagnostics, "1 module update error(s)") {
+		t.Fatalf("result = %#v, want processing diagnostics and exit 1", result)
+	}
+	if got := readTestFile(t, good); got != goodInput {
+		t.Fatalf("check changed valid content to %q, want %q", got, goodInput)
+	}
+}
+
+func TestCommandCheckRejectsConflictingFlags(t *testing.T) {
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "main.tf", "module \"example\" {\n  source = \"example/module\"\n}\n")
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "dry run", args: []string{"-dry-run"}, want: "Error: Cannot use -check with -dry-run\n"},
+		{name: "report", args: []string{"-report-file", dir + "/report.json"}, want: "Error: Cannot use -check with -report-file\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := []string{"tf-version-bump", "-pattern", file, "-module", "example/module", "-to", "2.0.0", "-check"}
+			result := runMainCommand(t, append(args, tt.args...))
+			if result.stdout != "" || result.diagnostics != tt.want || result.exitCode != 1 {
+				t.Fatalf("result = %#v, want diagnostic %q and exit 1", result, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunConfigFileModeReturnsLoadErrorContract(t *testing.T) {
-	err := runConfigFileMode(nil, &cliFlags{configFile: "does-not-exist"})
+	_, err := runConfigFileMode(nil, &cliFlags{configFile: "does-not-exist"})
 	if err == nil || !errors.Is(err, os.ErrNotExist) || !strings.HasPrefix(err.Error(), "Error loading config file:") {
 		t.Fatalf("error = %v", err)
 	}
@@ -544,9 +675,9 @@ func TestProviderModesSkipReportBookkeepingWhenDisabled(t *testing.T) {
 			var runErr error
 			captureStdout(t, func() {
 				if mode == "CLI" {
-					runErr = runCLIMode([]string{file}, flags)
+					_, runErr = runCLIMode([]string{file}, flags)
 				} else {
-					runErr = runConfigFileMode([]string{file}, flags)
+					_, runErr = runConfigFileMode([]string{file}, flags)
 				}
 			})
 

--- a/command_test.go
+++ b/command_test.go
@@ -313,6 +313,41 @@ func TestCommandCheckRejectsConflictingFlags(t *testing.T) {
 	}
 }
 
+func TestCommandCheckRejectsInvalidArgumentsWithErrorStatus(t *testing.T) {
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "main.tf", "module \"example\" {\n  source  = \"example/module\"\n  version = \"1.0.0\"\n}\n")
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "unknown flag",
+			args: []string{"-check", "-module", "example/module", "-to", "2.0.0", "-bogus"},
+			want: "Error: flag provided but not defined: -bogus\n",
+		},
+		{
+			name: "missing flag value",
+			args: []string{"-check", "-module", "example/module", "-to", "2.0.0", "-pattern"},
+			want: "Error: flag needs an argument: -pattern\n",
+		},
+		{
+			name: "positional argument",
+			args: []string{"-check", "-pattern", file, "-module", "example/module", "-to", "2.0.0", "trailing"},
+			want: "Error: unexpected positional argument(s): trailing\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := runMainCommand(t, append([]string{"tf-version-bump"}, tt.args...))
+			if result.stdout != "" || result.diagnostics != tt.want || result.exitCode != 1 {
+				t.Fatalf("result = %#v, want diagnostic %q and exit 1", result, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunConfigFileModeReturnsLoadErrorContract(t *testing.T) {
 	_, err := runConfigFileMode(nil, &cliFlags{configFile: "does-not-exist"})
 	if err == nil || !errors.Is(err, os.ErrNotExist) || !strings.HasPrefix(err.Error(), "Error loading config file:") {

--- a/command_test.go
+++ b/command_test.go
@@ -439,7 +439,7 @@ func TestCommandConfigDryRunOutputContract(t *testing.T) {
 	if got := readTestFile(t, file); got != input {
 		t.Errorf("config dry run content = %q, want %q", got, input)
 	}
-	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 0,\n  \"provider_blocks_updated\": 0\n}\n"
+	wantReport := "{\n  \"schema_version\": 2,\n  \"terraform_blocks_updated\": 0,\n  \"module_blocks_updated\": 0,\n  \"provider_blocks_updated\": 0\n}\n"
 	if got := readTestFile(t, report); got != wantReport {
 		t.Errorf("dry-run report = %q, want %q", got, wantReport)
 	}
@@ -448,7 +448,8 @@ func TestCommandConfigDryRunOutputContract(t *testing.T) {
 func TestCommandWritesExactUpdatedBlockCounts(t *testing.T) {
 	dir := t.TempDir()
 	file := writeTestFile(t, dir, "main.tf", `terraform {
-  required_providers {
+	  required_version = ">= 1.0"
+	  required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.0"
@@ -456,7 +457,8 @@ func TestCommandWritesExactUpdatedBlockCounts(t *testing.T) {
   }
 }
 terraform {
-  required_providers {
+	  required_version = ">= 1.5"
+	  required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.0"
@@ -464,7 +466,16 @@ terraform {
   }
 }
 terraform {
-  required_providers {
+	  required_providers {
+	    aws = {
+	      source  = "hashicorp/aws"
+	      version = "~> 5.0"
+	    }
+	  }
+	}
+	terraform {
+	  required_version = "${">= 2.0"}"
+	  required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 5.0"
@@ -490,6 +501,7 @@ module "current" {
 modules:
   - source: example/module
     version: 2.0.0
+terraform_version: ">= 2.0"
 `)
 	report := dir + "/report.json"
 
@@ -500,7 +512,57 @@ modules:
 	if result.exitCode != -1 || result.diagnostics != "" {
 		t.Fatalf("result = %#v", result)
 	}
-	want := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 2,\n  \"provider_blocks_updated\": 2\n}\n"
+	want := "{\n  \"schema_version\": 2,\n  \"terraform_blocks_updated\": 3,\n  \"module_blocks_updated\": 2,\n  \"provider_blocks_updated\": 2\n}\n"
+	if got := readTestFile(t, report); got != want {
+		t.Fatalf("report = %q, want %q", got, want)
+	}
+}
+
+func TestCommandReportCountsTerraformBlocksInDirectMode(t *testing.T) {
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "main.tf", `terraform {
+  required_version = ">= 1.0"
+}
+
+terraform {
+  required_version = "${">= 1.5"}"
+}
+
+terraform {
+}
+`)
+	report := dir + "/report.json"
+
+	result := runMainCommand(t, []string{
+		"tf-version-bump", "-pattern", file, "-terraform-version", ">= 1.5", "-report-file", report,
+	})
+
+	if result.exitCode != -1 || result.diagnostics != "" {
+		t.Fatalf("result = %#v", result)
+	}
+	want := "{\n  \"schema_version\": 2,\n  \"terraform_blocks_updated\": 2,\n  \"module_blocks_updated\": 0,\n  \"provider_blocks_updated\": 0\n}\n"
+	if got := readTestFile(t, report); got != want {
+		t.Fatalf("report = %q, want %q", got, want)
+	}
+}
+
+func TestCommandReportCountsHardLinkedTerraformBlocksOnce(t *testing.T) {
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "a.tf", "terraform {\n  required_version = \">= 1.0\"\n}\n")
+	linkedFile := dir + "/b.tf"
+	if err := os.Link(file, linkedFile); err != nil {
+		t.Skipf("cannot create hard link: %v", err)
+	}
+	report := dir + "/report.json"
+
+	result := runMainCommand(t, []string{
+		"tf-version-bump", "-pattern", dir + "/*.tf", "-terraform-version", ">= 1.5", "-report-file", report,
+	})
+
+	if result.exitCode != -1 || result.diagnostics != "" {
+		t.Fatalf("result = %#v", result)
+	}
+	want := "{\n  \"schema_version\": 2,\n  \"terraform_blocks_updated\": 1,\n  \"module_blocks_updated\": 0,\n  \"provider_blocks_updated\": 0\n}\n"
 	if got := readTestFile(t, report); got != want {
 		t.Fatalf("report = %q, want %q", got, want)
 	}
@@ -554,7 +616,7 @@ modules:
 	if result.exitCode != -1 || result.diagnostics != "" {
 		t.Fatalf("result = %#v", result)
 	}
-	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 3,\n  \"provider_blocks_updated\": 2\n}\n"
+	wantReport := "{\n  \"schema_version\": 2,\n  \"terraform_blocks_updated\": 0,\n  \"module_blocks_updated\": 3,\n  \"provider_blocks_updated\": 2\n}\n"
 	if got := readTestFile(t, report); got != wantReport {
 		t.Errorf("report = %q, want %q", got, wantReport)
 	}
@@ -602,7 +664,7 @@ terraform {
 	if result.exitCode != -1 || result.diagnostics != "" {
 		t.Fatalf("result = %#v", result)
 	}
-	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 0,\n  \"provider_blocks_updated\": 2\n}\n"
+	wantReport := "{\n  \"schema_version\": 2,\n  \"terraform_blocks_updated\": 0,\n  \"module_blocks_updated\": 0,\n  \"provider_blocks_updated\": 2\n}\n"
 	if got := readTestFile(t, report); got != wantReport {
 		t.Errorf("report = %q, want %q", got, wantReport)
 	}
@@ -625,7 +687,7 @@ func TestCommandReportCountsForceAddedModuleBlock(t *testing.T) {
 	if result.exitCode != -1 || result.diagnostics != "" {
 		t.Fatalf("result = %#v", result)
 	}
-	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 1,\n  \"provider_blocks_updated\": 0\n}\n"
+	wantReport := "{\n  \"schema_version\": 2,\n  \"terraform_blocks_updated\": 0,\n  \"module_blocks_updated\": 1,\n  \"provider_blocks_updated\": 0\n}\n"
 	if got := readTestFile(t, report); got != wantReport {
 		t.Errorf("report = %q, want %q", got, wantReport)
 	}
@@ -729,7 +791,7 @@ modules:
 	if result.exitCode != -1 || result.diagnostics != "" {
 		t.Fatalf("result = %#v", result)
 	}
-	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 1,\n  \"provider_blocks_updated\": 1\n}\n"
+	wantReport := "{\n  \"schema_version\": 2,\n  \"terraform_blocks_updated\": 0,\n  \"module_blocks_updated\": 1,\n  \"provider_blocks_updated\": 1\n}\n"
 	if got := readTestFile(t, report); got != wantReport {
 		t.Errorf("report = %q, want %q", got, wantReport)
 	}
@@ -778,7 +840,7 @@ modules:
 	if result.exitCode != -1 || result.diagnostics != "" {
 		t.Fatalf("result = %#v", result)
 	}
-	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 1,\n  \"provider_blocks_updated\": 1\n}\n"
+	wantReport := "{\n  \"schema_version\": 2,\n  \"terraform_blocks_updated\": 0,\n  \"module_blocks_updated\": 1,\n  \"provider_blocks_updated\": 1\n}\n"
 	if got := readTestFile(t, report); got != wantReport {
 		t.Errorf("report = %q, want %q", got, wantReport)
 	}
@@ -799,7 +861,7 @@ func TestCommandReplacesExistingReportAfterSuccessfulUpdate(t *testing.T) {
 	if result.exitCode != -1 || result.diagnostics != "" {
 		t.Fatalf("result = %#v", result)
 	}
-	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 1,\n  \"provider_blocks_updated\": 0\n}\n"
+	wantReport := "{\n  \"schema_version\": 2,\n  \"terraform_blocks_updated\": 0,\n  \"module_blocks_updated\": 1,\n  \"provider_blocks_updated\": 0\n}\n"
 	if got := readTestFile(t, report); got != wantReport {
 		t.Errorf("report = %q, want %q", got, wantReport)
 	}
@@ -1009,7 +1071,7 @@ terraform_version: ">= 1.5"
 	if result.exitCode != -1 || result.diagnostics != "" || result.stdout != wantStdout {
 		t.Fatalf("result = %#v, want stdout %q", result, wantStdout)
 	}
-	wantReport := "{\n  \"schema_version\": 1,\n  \"module_blocks_updated\": 0,\n  \"provider_blocks_updated\": 0\n}\n"
+	wantReport := "{\n  \"schema_version\": 2,\n  \"terraform_blocks_updated\": 0,\n  \"module_blocks_updated\": 0,\n  \"provider_blocks_updated\": 0\n}\n"
 	if got := readTestFile(t, report); got != wantReport {
 		t.Fatalf("report = %q, want %q", got, wantReport)
 	}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -42,7 +42,9 @@ sources, and version strings; empty items in module filter lists are discarded.
 
 The repository's [JSON Schema](../schema/config-schema.json) provides editor completion and
 validates Terraform-style version-constraint syntax. The CLI's YAML loader does not execute that
-JSON Schema, so use an editor or separate schema validator when you need schema enforcement.
+JSON Schema, so use an editor or separate schema validator when you need schema enforcement. The
+maintained configurations under [`examples/`](../examples/README.md#yaml-configurations) include
+the schema declaration shown above and can be copied as editor-enabled starting points.
 
 ## Validate without updating
 
@@ -55,8 +57,8 @@ tf-version-bump -validate-config versions.yml
 The command rejects malformed YAML, multiple YAML documents, unknown fields, missing required
 entry fields, and configs without any Terraform, provider, or module updates. It trims and
 validates values in the same way as update mode. It does not execute the JSON Schema or validate
-Terraform version-constraint syntax. Validation is standalone and cannot be combined with update
-or report flags.
+Terraform version-constraint syntax. Validation is standalone and cannot be combined with update,
+check, or report flags.
 
 ## Top-level fields
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -297,8 +297,9 @@ An invalid pattern or a pattern with no matching files is a fatal command error.
 - Local modules and matching modules without versions produce warnings on standard error.
 - `-verbose` adds explanations for name and version filter skips.
 - `-dry-run` parses every selected file and reports proposed updates without writing.
-- `-check` performs the same no-write preview, exits 0 when no updates are required, and exits 2
-  after a successful run that found updates. Errors exit 1 and take precedence over status 2.
+- `-check` performs the same no-write preview, exits 0 when no eligible version value would change,
+  and exits 2 after a successful run that found updates. Errors exit 1 and take precedence over
+  status 2.
 - Parse, stat, read, and write errors for an individual file are logged and processing continues
   with later files or updates.
 
@@ -308,6 +309,9 @@ any selected operation encountered a file-level error.
 
 `-check` cannot be combined with `-dry-run` because their exit contracts differ. It also rejects
 `-report-file` so the check promise covers every output file, not only Terraform inputs.
+Status 0 does not prove that every requested source or block exists: filters, ignored modules,
+unmatched targets, and missing module versions skipped without `-force-add` can leave no eligible
+update.
 
 ## File-writing behaviour
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -21,8 +21,8 @@ tf-version-bump -validate-config <file>
 with the three direct operation flags or their module filters. `-validate-config` checks only the
 YAML runtime contract and cannot be combined with update or report flags.
 
-An eligible module, provider, or Terraform version that already equals its requested literal value
-is a no-op: the command does not rewrite the file or count it as an update.
+An eligible module, provider, or Terraform version that already evaluates to its requested constant
+string is a no-op: the command does not rewrite the file or count it as an update.
 
 ## Flag reference
 
@@ -40,9 +40,10 @@ is a no-op: the command does not rewrite the file or count it as an update.
 | `-provider <name>` | Direct provider mode | Local provider name within `required_providers`. |
 | `-force-add` | Module updates | Add a missing module `version` attribute to registry modules. |
 | `-dry-run` | All update modes | Report changes without writing files. |
+| `-check` | All update modes | Report changes without writing files; exit 2 when updates are required. |
 | `-verbose` | Module updates | Report modules skipped by name or version filters. |
 | `-output <format>` | All update modes | `text` (default) uses single quotes; `md` uses backticks in messages. |
-| `-report-file <path>` | All update modes | Write exact updated module and provider block counts as JSON. |
+| `-report-file <path>` | All update modes | Write exact updated Terraform, module, and provider block counts as JSON. |
 | `-version` | Standalone | Print version, commit, and build date metadata, then exit. |
 
 `-output md` changes quoting in human-readable update messages; it does not emit a structured
@@ -65,19 +66,20 @@ The report has this stable shape:
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
+  "terraform_blocks_updated": 1,
   "module_blocks_updated": 4,
   "provider_blocks_updated": 2
 }
 ```
 
-Counts represent unique individual blocks whose version value changed across the complete command.
-Repeated config entries that update the same block count it once. Blocks already at the requested
-version are excluded. Dry runs write zero counts because they do not change files. The report is
-written only after the update operation completes without errors. Its destination is validated
-before Terraform files are modified and cannot be one of the selected Terraform or YAML config
-inputs. Terraform `required_version` changes and changed-file counts are outside this report;
-automation can derive file counts from its version-control diff.
+Counts represent unique individual Terraform, module, and provider blocks whose version value
+changed across the complete command. Repeated config entries that update the same block count it
+once. Blocks already at the requested version are excluded. Dry runs write zero counts because they
+do not change files. The report is written only after the update operation completes without
+errors. Its destination is validated before Terraform files are modified and cannot be one of the
+selected Terraform or YAML config inputs. Changed-file counts are outside this report; automation
+can derive them from its version-control diff.
 
 ## Module updates
 
@@ -104,8 +106,11 @@ module "test_vpc" {
 }
 ```
 
-The tool is designed for literal source and version strings. It does not evaluate HCL
-expressions, Terraform variables, semantic versions, or version constraints.
+Source and version-filter matching use literal strings; the tool does not interpret semantic
+versions or version constraints. For idempotency only, a version expression that HCL can evaluate
+as a wholly known constant string is compared with the requested value before rewriting. Variables,
+function calls, and other context-dependent expressions are not evaluated and are replaced with the
+requested literal string when their block is otherwise eligible.
 
 ### Version filters
 
@@ -250,8 +255,8 @@ Config mode applies updates in this order for each selected set of files:
 2. Providers, in YAML order
 3. Modules, in YAML order
 
-Use `-force-add`, `-dry-run`, `-verbose`, or `-output md` with config mode when required. See
-[Configuration](CONFIGURATION.md) for the complete YAML contract.
+Use `-force-add`, `-dry-run`, `-check`, `-verbose`, or `-output md` with config mode when required.
+See [Configuration](CONFIGURATION.md) for the complete YAML contract.
 
 Config summaries count module entry/file applications as `update(s)`, not distinct files. A file
 matched by two module entries therefore contributes two module updates.
@@ -292,12 +297,17 @@ An invalid pattern or a pattern with no matching files is a fatal command error.
 - Local modules and matching modules without versions produce warnings on standard error.
 - `-verbose` adds explanations for name and version filter skips.
 - `-dry-run` parses every selected file and reports proposed updates without writing.
+- `-check` performs the same no-write preview, exits 0 when no updates are required, and exits 2
+  after a successful run that found updates. Errors exit 1 and take precedence over status 2.
 - Parse, stat, read, and write errors for an individual file are logged and processing continues
   with later files or updates.
 
 File-level errors do not stop processing: the command writes every diagnostic and continues with
 later files or configured updates. After processing, and after any summary, it exits non-zero if
 any selected operation encountered a file-level error.
+
+`-check` cannot be combined with `-dry-run` because their exit contracts differ. It also rejects
+`-report-file` so the check promise covers every output file, not only Terraform inputs.
 
 ## File-writing behaviour
 

--- a/docs/superpowers/plans/2026-08-23-actions-rc10-migration.md
+++ b/docs/superpowers/plans/2026-08-23-actions-rc10-migration.md
@@ -1,0 +1,173 @@
+# GitHub Actions rc.10 migration implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the copyable GitHub Actions example to the verified rc.10 artefact and use standalone configuration validation.
+
+**Architecture:** Start a fresh feature branch from the rc.10 release commit. Change the immutable release pin, strict report reader, and config-validation workflow in one tested unit so the POC never combines rc.10 report output with an rc.9 parser.
+
+**Tech Stack:** Bash, GitHub Actions YAML, jq, yq, Docker-backed Terraform harness, actionlint.
+
+**Spec:** `docs/superpowers/specs/2026-08-23-day-to-day-quick-wins-design.md`
+
+## Global Constraints
+
+- Start only after `v1.0.0-rc.10` is published and independently accepted.
+- Use the exact verified rc.10 Linux x86-64 archive SHA-256.
+- Accept only update report schema version 2; do not preserve schema version 1 compatibility.
+- Keep the configuration-validation workflow read-only and independent of Terraform fixtures.
+- Do not propagate Terraform counts into the POC manifest or pull-request body.
+- Use TDD for harness-visible workflow and script behaviour.
+- All Codex commits must be SSH-signed with the dedicated GenAI key through `/Users/dan/.codex/bin/codex-git`.
+
+---
+
+### Task 1: Establish the rc.10 migration branch
+
+**Files:**
+- No source changes.
+
+**Interfaces:**
+- Consumes: merged `main`, published `v1.0.0-rc.10`, verified archive digest.
+- Produces: clean isolated topic branch for the POC migration.
+
+- [ ] **Step 1: Refresh and verify main**
+
+Pull `main` with rebase through the Codex wrapper, verify the release tag resolves to the current
+commit, and confirm the worktree is clean.
+
+- [ ] **Step 2: Create an isolated topic worktree**
+
+Create a descriptively named branch and worktree using the worktree skill. Run `go test ./...` as the
+baseline.
+
+### Task 2: Change strict harness expectations first
+
+**Files:**
+- Modify: `examples/github-actions/test.sh`
+- Modify: `examples/github-actions/reconcile-test.sh` only if fixture report payloads reach the strict released-report reader.
+
+**Interfaces:**
+- Consumes: rc.10 tag and digest; existing `accumulate_update_report` boundary.
+- Produces: tests requiring schema-v2 report validation, the Terraform count key, rc.10 pins, and direct config validation.
+
+- [ ] **Step 1: Update the release constants and valid report fixture**
+
+Change the harness release URL/version/digest to the independently verified rc.10 values. Change
+the controlled valid report to exact JSON keys `schema_version`, `terraform_blocks_updated`,
+`module_blocks_updated`, and `provider_blocks_updated`, with schema version 2.
+
+- [ ] **Step 2: Add report-contract failure rows**
+
+Require rejection of schema version 1, a missing Terraform count, a negative Terraform count, a
+fractional Terraform count, and an extra key. Retain the existing malformed/missing/module/provider
+contract rows.
+
+The production mutations caught are accepting the old schema, ignoring malformed new counts, or
+weakening the exact-key boundary.
+
+- [ ] **Step 3: Change the config-workflow structural assertion**
+
+Require the validation step to call `-validate-config` for both control files and contain no
+temporary Terraform fixture, `-pattern`, `-config`, or `-dry-run`. Retain the immutable archive,
+checksum-before-extraction, reported-version, read-only permission, and no-secret assertions.
+
+The production mutation caught is falling back to update-mode validation or gaining write-capable
+workflow behaviour.
+
+- [ ] **Step 4: Run the focused harness and verify RED**
+
+Run: `make test-github-actions`
+
+Expected: FAIL at the report and config-validation expectations because production still consumes
+rc.9/schema v1 and creates a fixture dry run.
+
+### Task 3: Migrate the POC atomically to rc.10
+
+**Files:**
+- Modify: `examples/github-actions/.github/scripts/process-state-branch.sh`
+- Modify: `examples/github-actions/.github/workflows/tf-version-bump-config-validation.yml`
+- Modify: `examples/github-actions/.github/workflows/tf-version-bump-nonproduction.yml`
+- Modify: `examples/github-actions/.github/workflows/tf-version-bump-production.yml`
+- Modify: `examples/github-actions/README.md`
+
+**Interfaces:**
+- Consumes: strict expectations from Task 2 and published rc.10.
+- Produces: a schema-v2 report reader that validates but does not propagate Terraform counts; direct standalone config validation; consistent rc.10 release pins.
+
+- [ ] **Step 1: Update the report reader minimally**
+
+Require exactly the four schema-v2 keys and validate all three counts as non-negative integers.
+Continue adding only module/provider counts to the existing preparation manifest.
+
+- [ ] **Step 2: Replace fixture dry runs with standalone validation**
+
+Remove temporary fixture creation and loop over both configs with
+`"$TF_VERSION_BUMP_BINARY" -validate-config "$config"`. Keep download cleanup under `always()` and
+update every filename/version occurrence to rc.10.
+
+- [ ] **Step 3: Update caller pins and operator documentation**
+
+Use rc.10 and its verified digest in both callers. Update the README release statement and explain
+that pull requests validate only the YAML runtime contract without selecting Terraform files.
+
+- [ ] **Step 4: Run focused and full harness verification**
+
+Run: `make test-github-actions`
+
+Expected: PASS, including real rc.10 download, checksum/version verification, strict schema-v2
+reports, direct config validation, Docker-backed Terraform processing, and actionlint.
+
+Run: `make docs-check`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the migration**
+
+Stage only the Actions example scripts, workflows, tests, and README. Commit with subject
+`chore: migrate Actions example to rc.10`.
+
+### Task 4: Clean up, review, verify, and merge the second pull request
+
+**Files:**
+- Modify only touched test scripts if the subtractive cleanup pass removes slop.
+
+**Interfaces:**
+- Consumes: complete PR B diff.
+- Produces: reviewed and merged Actions example migration.
+
+- [ ] **Step 1: Run mandatory test cleanup**
+
+Invoke the `test-cleanup` skill in a fresh subagent. Classify all test changes, run the Actions
+harness, and commit only subtractive test changes if warranted.
+
+- [ ] **Step 2: Request adversarial review and resolve findings**
+
+Review the complete diff, verify findings technically, and fix confirmed problems with failing tests
+first. Re-run cleanup only if review adds substantial tests.
+
+- [ ] **Step 3: Run fresh full verification**
+
+Run separately:
+
+```bash
+go mod verify
+go mod tidy -diff
+go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
+golangci-lint run --timeout=5m
+go build -o tf-version-bump .
+make docs-check
+make test-github-actions
+```
+
+Expected: every command exits 0 with pristine output and coverage remains at least 90%.
+
+- [ ] **Step 4: Verify signatures, push, and create the pull request**
+
+Confirm all branch commits are correctly signed, push through the Codex wrapper, open the PR, and
+wait for all required checks.
+
+- [ ] **Step 5: Rebase-merge and refresh local main**
+
+Rebase-merge after checks pass, pull local `main` with rebase, and verify the merged tree and clean
+status. No additional release is required.

--- a/docs/superpowers/plans/2026-08-23-cli-docs-examples-quick-wins.md
+++ b/docs/superpowers/plans/2026-08-23-cli-docs-examples-quick-wins.md
@@ -1,0 +1,332 @@
+# CLI, documentation, and examples quick wins implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add CI check semantics, schema-v2 Terraform reporting, and maintained day-to-day examples, then publish `v1.0.0-rc.10`.
+
+**Architecture:** Keep `-check` as a command-level policy layered over the existing dry-run update paths, while returning update totals to `main` so errors take precedence over exit status 2. Extend the existing physical-file/block identity report recorder to Terraform blocks. Exercise runnable examples through one shell harness invoked by documentation checks.
+
+**Tech Stack:** Go 1.26, HashiCorp HCL/hclwrite, Bash, YAML, JSON, jq, Make, GitHub Actions/GoReleaser.
+
+**Spec:** `docs/superpowers/specs/2026-08-23-day-to-day-quick-wins-design.md`
+
+## Global Constraints
+
+- `-check` exits 0 when current, 2 when updates are required, and 1 on errors.
+- `-check` performs no filesystem writes and is incompatible with `-dry-run` and `-report-file`.
+- Report schema version 2 has exact Terraform, module, and provider block counts.
+- Do not preserve report schema version 1 compatibility.
+- Use TDD for production behaviour and observable example-runner behaviour.
+- Use Australian/British English in prose and comments.
+- All Codex commits must be SSH-signed with the dedicated GenAI key through `/Users/dan/.codex/bin/codex-git`.
+
+---
+
+### Task 1: Commit the approved design and execution plans
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-08-23-day-to-day-quick-wins-design.md`
+- Create: `docs/superpowers/plans/2026-08-23-cli-docs-examples-quick-wins.md`
+- Create: `docs/superpowers/plans/2026-08-23-actions-rc10-migration.md`
+
+**Interfaces:**
+- Consumes: Dan's approved choices for the check flag, statuses, report schema, release, and worktree.
+- Produces: the reviewed requirements and ordered execution steps for both pull requests.
+
+- [ ] **Step 1: Review the plans against the design**
+
+Confirm every design section maps to a task and that the second pull request starts only after the
+rc.10 acceptance checks.
+
+- [ ] **Step 2: Scan for placeholders and inconsistent names**
+
+Run: `rg -n 'T[B]D|T[O]DO|i[m]plement later|a[p]propriate error|a[d]d validation|w[r]ite tests for|s[i]milar to Task' docs/superpowers/specs/2026-08-23-day-to-day-quick-wins-design.md docs/superpowers/plans/2026-08-23-*.md`
+
+Expected: no plan placeholders.
+
+- [ ] **Step 3: Verify local documentation links**
+
+Run: `make docs-check`
+
+Expected: PASS against the new cross-linked plan and specification files.
+
+- [ ] **Step 4: Commit the planning artefacts**
+
+Stage the three files explicitly and commit with subject `docs: design day-to-day quick wins`.
+
+### Task 2: Add the `-check` command contract
+
+**Files:**
+- Modify: `command_test.go`
+- Modify: `main.go`
+- Modify: `CLAUDE.md`
+
+**Interfaces:**
+- Consumes: existing `cliFlags.dryRun`, `runConfigFileMode([]string, *cliFlags)`, and `runCLIMode([]string, *cliFlags)`.
+- Produces: `cliFlags.check bool`; both mode runners return `(int, error)`, where the integer is the number of proposed/applied update operations; `main` requests exit status 2 only after successful check processing with a positive total.
+
+- [ ] **Step 1: Write focused failing command tests**
+
+Add command-level tests that execute real Terraform fixtures and prove:
+
+- direct module check mode proposes a change, preserves bytes, and exits 2;
+- config check mode with module/provider/Terraform changes preserves bytes and exits 2;
+- an already-current check exits normally with no writes;
+- a malformed selected file exits 1 rather than 2;
+- `-check -dry-run`, `-check -report-file`, and `-validate-config ... -check` are rejected with exact diagnostics;
+- parsing records `check: true` and existing dry-run parsing remains distinct.
+
+The production mutations caught are an accidental write, wrong status precedence, a missing
+conflict, and treating all successful checks as status 2.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `go test -run 'Test(ParseFlagsContract|CommandCheck|ValidateOperationModes)' ./...`
+
+Expected: FAIL because `-check`, its conflicts, and status 2 do not exist.
+
+- [ ] **Step 3: Implement the minimal command policy**
+
+Add the flag and validation. After mode validation, make check mode use the existing dry-run update
+path while retaining a distinct banner. Return update totals from both command-mode runners. In
+`main`, process all files, handle any error as status 1, publish only allowed reports, then call
+`exitFunc(2)` when check mode found one or more updates.
+
+- [ ] **Step 4: Run focused and complete Go tests**
+
+Run: `go test -run 'Test(ParseFlagsContract|CommandCheck|ValidateOperationModes)' ./...`
+
+Expected: PASS with pristine output.
+
+Run: `go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 5: Update the internal architecture contract**
+
+Update `CLAUDE.md` to describe check status precedence and the mode-runner update total. Do not add
+user-facing cookbook prose yet.
+
+- [ ] **Step 6: Commit check mode**
+
+Stage `main.go`, `command_test.go`, and `CLAUDE.md`; commit with subject
+`feat: add CI check mode`.
+
+### Task 3: Report exact Terraform block updates in schema version 2
+
+**Files:**
+- Modify: `command_test.go`
+- Modify: `terraform_version_test.go`
+- Modify: `test_helpers_test.go`
+- Modify: `main.go`
+- Modify: `CLAUDE.md`
+
+**Interfaces:**
+- Consumes: `updateReport.fileIdentity`, existing module/provider recorders, and top-level Terraform block iteration.
+- Produces: `updateReport.TerraformBlocksUpdated int`; `recordTerraformBlocks(string, []int)`; `updateTerraformVersionWithCount(string, string, bool) (bool, []int, error)`; `processTerraformVersion(..., *updateReport)`.
+
+- [ ] **Step 1: Write the failing Terraform report tests**
+
+Add command-level report assertions for multiple Terraform blocks, already-current blocks, a
+missing `required_version`, two hard-linked paths, config mode, direct mode, and dry-run zeros. Add a
+focused updater test proving changed block indexes identify only blocks that would be rewritten.
+Update no existing expected report strings yet.
+
+The production mutations caught are counting files instead of blocks, counting semantic no-ops,
+double-counting a hard link, and forgetting either direct or config mode.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run: `go test -run 'Test(CommandReport.*Terraform|UpdateTerraformVersion.*Count)' ./...`
+
+Expected: FAIL because the report has no Terraform field or recorder.
+
+- [ ] **Step 3: Implement Terraform block identity recording**
+
+Refactor the updater through `updateTerraformVersionWithCount`, retain the existing convenience
+adapter for tests, pass the report recorder through direct/config processing, and record changed
+block indexes only after actual writes. Set `SchemaVersion` to 2 before publishing.
+
+- [ ] **Step 4: Update all schema-v1 report expectations mechanically**
+
+Change existing expected JSON to schema version 2 and include
+`"terraform_blocks_updated": 0` or the independently derived non-zero value. Do not weaken exact
+JSON assertions.
+
+- [ ] **Step 5: Run focused and complete Go tests**
+
+Run: `go test -run 'Test(CommandReport|UpdateTerraformVersion)' ./...`
+
+Expected: PASS.
+
+Run: `go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 6: Update the internal report contract and commit**
+
+Update `CLAUDE.md` from report schema version 1 to version 2 and describe the unique Terraform block
+count. Stage only the task files and commit with subject `feat: report Terraform block updates`.
+
+### Task 4: Add the automation cookbook and maintained scenarios
+
+**Files:**
+- Create: `examples/scenarios/force-add/main.tf`
+- Create: `examples/scenarios/force-add/config.yml`
+- Create: `examples/scenarios/idempotency/main.tf`
+- Create: `examples/scenarios/idempotency/config.yml`
+- Create: `examples/run-scenarios.sh`
+- Modify: `examples/README.md`
+- Modify: `README.md`
+- Modify: `docs/USAGE.md`
+- Modify: `docs/CONFIGURATION.md`
+- Modify: `documentation_test.go`
+- Modify: `Makefile`
+- Modify: maintained `examples/config-*.yml`
+- Modify: maintained `examples/github-actions/.github/tf-version-bump/*.yml`
+
+**Interfaces:**
+- Consumes: released/public CLI syntax, local `go build`, scenario fixtures, `jq`, and the config JSON Schema URL.
+- Produces: `examples/run-scenarios.sh [--help]`; `make docs-check` executes the scenario acceptance harness.
+
+- [ ] **Step 1: Write the failing scenario-runner contract in Go**
+
+Add a documentation test that runs `examples/run-scenarios.sh` from the repository root, captures
+stdout/stderr, and requires a zero exit with a concise success line. Add config discovery for the two
+scenario YAML files so the runtime/schema constraint checks own them too.
+
+The production mutation caught is a copyable scenario whose command, fixture, or assertion has
+drifted from the real CLI.
+
+- [ ] **Step 2: Run documentation checks and verify RED**
+
+Run: `make docs-check`
+
+Expected: FAIL because `examples/run-scenarios.sh` and the scenario configs do not exist.
+
+- [ ] **Step 3: Add minimal fixtures and runner**
+
+Create the two scenario directories and an executable Bash runner with `--help`, dependency checks,
+one temporary workspace, cleanup trap, one repository binary build, precise failure messages, and
+observable assertions:
+
+- force-add first warns and preserves the fixture, then adds version `5.0.0` with `-force-add`;
+- idempotency applies the combined config, records bytes and modification time, applies it again,
+  and proves the second command reports no updates without changing either.
+
+- [ ] **Step 4: Run the runner and documentation checks**
+
+Run: `examples/run-scenarios.sh`
+
+Expected: PASS with one concise success line and no leaked expected warning/error output.
+
+Run: `make docs-check`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write the human-facing cookbook and corrections**
+
+Add schema declarations to every maintained update config. Expand `examples/README.md` with
+validation, preview, check-status handling, apply/report/jq, and copy-safe scenario commands. Update
+the README quick-start flag list, the usage flag/report/expression contracts, and the configuration
+guide's editor setup without duplicating the full reference.
+
+- [ ] **Step 6: Re-run documentation and complete Go tests**
+
+Run: `make docs-check`
+
+Expected: PASS.
+
+Run: `go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit documentation and examples**
+
+Stage the listed documentation, Makefile, runner, configs, scenarios, and documentation test. Commit
+with subject `docs: add automation cookbook and scenarios`.
+
+### Task 5: Clean up tests and review the first pull request
+
+**Files:**
+- Modify only branch-touched `*_test.go` files if cleanup removes slop.
+- Create: reviewer findings artefact only if the selected review skill requires it.
+
+**Interfaces:**
+- Consumes: all PR A commits versus `origin/main`.
+- Produces: a subtractive test-cleanup commit if warranted and resolved adversarial-review findings.
+
+- [ ] **Step 1: Run the mandatory test-cleanup subagent**
+
+Commit all implementation work, invoke the `test-cleanup` skill in a fresh subagent on this branch,
+classify every touched test, run the relevant suite and coverage, and commit only subtractive test
+changes. If nothing is removed, record that result without an empty commit.
+
+- [ ] **Step 2: Request adversarial review**
+
+Use the repository's peer/adversarial review workflow on the complete diff. Verify every finding
+against code and tests before accepting it. Apply confirmed fixes with TDD and signed commits; reply
+to rejected findings with technical evidence.
+
+- [ ] **Step 3: Re-run cleanup if review fixes changed tests materially**
+
+Invoke a fresh cleanup pass only if review fixes added or substantially rewrote tests.
+
+### Task 6: Verify, merge, and publish rc.10
+
+**Files:**
+- No source changes expected.
+
+**Interfaces:**
+- Consumes: reviewed PR A branch with signed commits.
+- Produces: merged `main`, annotated tag `v1.0.0-rc.10`, published release artefacts, and the verified Linux x86-64 archive SHA-256 needed by PR B.
+
+- [ ] **Step 1: Run fresh pre-PR verification**
+
+Run each command separately and inspect its complete output:
+
+```bash
+go mod download
+go mod verify
+go mod tidy -diff
+go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
+go tool cover -func=coverage.out
+golangci-lint run --timeout=5m
+go build -o tf-version-bump .
+make docs-check
+make test-github-actions
+```
+
+Expected: every command exits 0, output is pristine, and total coverage remains at least 90%.
+
+- [ ] **Step 2: Verify branch state and signatures**
+
+Inspect `origin/main...HEAD`, confirm only intended files changed, and verify every PR commit reports a
+good signature from Dan's GenAI key. Stop on any signing failure.
+
+- [ ] **Step 3: Push, open the pull request, and verify CI**
+
+Push through the Codex wrapper, create a PR with a body covering behaviour, report migration, docs,
+tests, and the planned rc.10 dependency. Wait for every required check and resolve failures rather
+than bypassing them.
+
+- [ ] **Step 4: Rebase-merge and refresh local main**
+
+Rebase-merge only after all branch commits are signed and checks pass. Pull `main` with rebase and
+verify the merged tree matches the reviewed PR result.
+
+- [ ] **Step 5: Re-run release-gate verification on merged main**
+
+Repeat the full commands from Step 1 on the exact merged commit. Confirm a clean worktree.
+
+- [ ] **Step 6: Create and push the annotated release tag**
+
+Create annotated tag `v1.0.0-rc.10` with message `Release v1.0.0-rc.10` through the Codex Git wrapper
+and push that exact tag. Do not move or recreate the tag after publication.
+
+- [ ] **Step 7: Verify the published release**
+
+Wait for the release and provenance workflows. Confirm six platform archives, four Linux packages,
+the checksum manifest, and the in-toto provenance file. Download the Linux x86-64 archive and
+checksum manifest, verify the archive checksum, verify provenance using the documented command, run
+the extracted binary's `-version`, and record its SHA-256 for the Actions migration.

--- a/docs/superpowers/specs/2026-08-23-day-to-day-quick-wins-design.md
+++ b/docs/superpowers/specs/2026-08-23-day-to-day-quick-wins-design.md
@@ -1,0 +1,146 @@
+# Day-to-day quick wins design
+
+## Goal
+
+Improve routine local and CI use of `tf-version-bump` with a machine-friendly check mode, complete
+Terraform update reporting, copyable automation guidance, maintained scenario examples, and a
+simpler pull-request configuration-validation workflow.
+
+## Delivery sequence
+
+The work is split across two pull requests because the copyable GitHub Actions example deliberately
+executes an independently downloaded release artefact rather than a binary built from its checkout.
+
+1. Add the CLI, report, documentation, and scenario changes; merge them to `main`; publish
+   `v1.0.0-rc.10`.
+2. Verify the published Linux x86-64 archive and use its digest to migrate the Actions example from
+   `v1.0.0-rc.9` to `v1.0.0-rc.10`.
+
+The first pull request must remain compatible with the currently pinned rc.9 example harness. The
+second pull request changes the strict report reader and release pin together, so the example never
+expects one report schema while executing a release that emits another.
+
+## CLI check mode
+
+Add `-check` to every update mode. It performs the same selection, parsing, filtering, diagnostics,
+and human-readable preview as `-dry-run`, but its process status is designed for automation:
+
+- `0` when no eligible version value would change;
+- `2` when one or more eligible version values would change;
+- `1` for invalid arguments, invalid input, or processing failures.
+
+`-check` never modifies Terraform files. It is mutually exclusive with `-dry-run` because the two
+flags have different exit contracts, and with `-report-file` because creating a report would violate
+the no-write promise. It remains compatible with `-config`, the three direct update modes,
+`-force-add`, filters, `-verbose`, and `-output`.
+
+The check status is decided only after all selected files have been processed. A processing error
+always wins over status 2. A normal return represents status 0; the existing injected exit hook is
+used only to request status 2 or report a fatal status 1.
+
+The existing `-dry-run` output and status contract stay unchanged. Check mode reuses its preview
+wording and adds a distinct mode banner so humans can tell which exit contract is active.
+
+## Update report schema version 2
+
+The JSON update report gains an exact `terraform_blocks_updated` integer and advances from schema
+version 1 to schema version 2:
+
+```json
+{
+  "schema_version": 2,
+  "terraform_blocks_updated": 1,
+  "module_blocks_updated": 4,
+  "provider_blocks_updated": 2
+}
+```
+
+The Terraform count represents unique top-level `terraform` blocks whose `required_version` value
+changed. Missing `required_version` attributes count when added. Blocks already semantically equal
+to the requested constant string do not count. Hard-linked paths to the same physical file and
+repeated processing of the same block count once, matching the existing module and provider report
+identity rules.
+
+Dry-run reports continue to contain zero counts because they describe applied changes, not proposed
+changes. Check mode rejects reports entirely.
+
+The internal Terraform updater returns changed top-level block indexes alongside its existing
+updated/error result. `processTerraformVersion` records those identities only in write mode and
+only when a report was requested.
+
+## Documentation and maintained examples
+
+Expand `examples/README.md` into a compact automation cookbook that shows:
+
+1. standalone configuration validation;
+2. previewing updates;
+3. using `-check` in CI while handling status 2 explicitly;
+4. applying updates with a report;
+5. inspecting schema version 2 counts with `jq`.
+
+Every maintained `tf-version-bump` YAML configuration begins with the published
+`yaml-language-server` schema declaration so editors can provide completion and diagnostics.
+
+Correct the usage reference's expression wording. Source and filter matching remain literal, and
+Terraform variables and functions are not evaluated. For idempotency only, a version expression
+that HCL can evaluate as a wholly known constant string is compared with the requested value before
+rewriting.
+
+Add two focused, copy-safe scenario directories:
+
+- `examples/scenarios/force-add` contains a registry module without `version` and demonstrates the
+  default warning followed by `-force-add`.
+- `examples/scenarios/idempotency` contains Terraform, provider, and module targets and demonstrates
+  that applying the same config a second time produces no filesystem change.
+
+The checked-in fixtures are never modified by documentation commands. A maintained scenario runner
+copies each fixture into a temporary directory, builds the repository binary once, executes the real
+commands, and verifies output and file effects. It has help text, precise failures, and automatic
+temporary-directory cleanup. `make docs-check` runs the scenario runner so copyable examples cannot
+silently rot.
+
+## GitHub Actions example migration
+
+After rc.10 is published, update every Actions example release pin and verified archive digest to
+that release. Its strict update-report reader accepts exactly schema version 2 with the four report
+keys, validates `terraform_blocks_updated` as a non-negative integer, and continues aggregating the
+module/provider counts used by its existing manifest. Propagating the Terraform count into the POC
+manifest or pull-request body is deliberately out of scope; the CLI report itself owns that new
+contract.
+
+Replace the configuration-validation workflow's generated Terraform fixture and config-mode dry
+runs with direct calls of:
+
+```bash
+tf-version-bump -validate-config <config>
+```
+
+The workflow retains read-only permissions, an immutable action pin, archive checksum verification,
+binary version verification, and validation of both control configurations. The harness exercises
+the published rc.10 binary and asserts that invalid configuration is rejected without selecting or
+modifying Terraform files.
+
+## Release and acceptance
+
+All commits created or rewritten by Codex are SSH-signed with the dedicated GenAI key. Pull-request
+commits are verified as signed before rebase merge.
+
+Before tagging rc.10, the first pull request must pass the complete Go test suite with race detection
+and coverage, lint, build, module verification, documentation checks, and the current rc.9 Actions
+example harness. Publish an annotated `v1.0.0-rc.10` tag only from the verified merged `main` commit.
+Wait for the release workflow, then verify the expected artefacts, checksum, provenance, and Linux
+x86-64 binary version before recording the archive digest.
+
+The second pull request must pass the same repository verification plus the Actions harness using
+the published rc.10 artefact. No second release is required because that pull request changes only
+the copyable example and its documentation/tests.
+
+## Non-goals
+
+- Change `-dry-run` exit behaviour.
+- Emit proposed counts in dry-run reports.
+- Preserve report schema version 1 or accept both report schemas in one consumer.
+- Add stale pull-request cleanup, hostile Terraform isolation, GitHub App authentication, commit
+  signing in Actions, or publication-race recovery.
+- Add provider-only or Terraform-only YAML files that duplicate the existing combined config.
+- Propagate Terraform counts into the Actions POC manifest or generated pull-request body.

--- a/documentation_test.go
+++ b/documentation_test.go
@@ -41,7 +41,11 @@ func TestExampleConfigsMatchDocumentedContract(t *testing.T) {
 }
 
 func TestDocumentationExampleScenariosRunSuccessfully(t *testing.T) {
-	command := exec.Command("examples/run-scenarios.sh")
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash is required to run the maintained example scenarios")
+	}
+	command := exec.Command(bash, "examples/run-scenarios.sh")
 	output, err := command.CombinedOutput()
 	if err != nil {
 		t.Fatalf("run example scenarios: %v\n%s", err, output)

--- a/documentation_test.go
+++ b/documentation_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -13,6 +14,7 @@ import (
 
 func TestExampleConfigsMatchDocumentedContract(t *testing.T) {
 	configFiles := append(globTestFiles(t, "examples/config-*.yml"), globTestFiles(t, "examples/github-actions/.github/tf-version-bump/*.yml")...)
+	configFiles = append(configFiles, globTestFiles(t, "examples/scenarios/*/config.yml")...)
 	constraintPatterns := compileConstraintRegexps(t, loadConfigSchema(t).Definitions.VersionConstraint)
 
 	for _, filename := range configFiles {
@@ -35,6 +37,17 @@ func TestExampleConfigsMatchDocumentedContract(t *testing.T) {
 		for _, provider := range config.Providers {
 			assertDocumentedVersionConstraint(t, filename, "provider version", provider.Version, constraintPatterns)
 		}
+	}
+}
+
+func TestDocumentationExampleScenariosRunSuccessfully(t *testing.T) {
+	command := exec.Command("examples/run-scenarios.sh")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run example scenarios: %v\n%s", err, output)
+	}
+	if got, want := string(output), "Example scenarios passed\n"; got != want {
+		t.Fatalf("scenario output = %q, want %q", got, want)
 	}
 }
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,12 +43,12 @@ Preview the human-readable changes without writing:
 tf-version-bump -pattern "**/*.tf" -config versions.yml -dry-run
 ```
 
-For a CI or pre-commit gate, use `-check`. Status 0 means the selected values are current, status 2
-means updates are required, and status 1 means validation or processing failed:
+For a CI or pre-commit gate, use `-check`. Status 0 means no eligible version value would change,
+status 2 means updates are required, and status 1 means validation or processing failed:
 
 ```bash
 if tf-version-bump -pattern "**/*.tf" -config versions.yml -check; then
-  echo "Terraform versions are current"
+  echo "No eligible Terraform version updates found"
 else
   check_status=$?
   if [ "$check_status" -eq 2 ]; then
@@ -58,6 +58,9 @@ else
   fi
 fi
 ```
+
+Status 0 does not prove that every configured target exists or was eligible. Ignored or unmatched
+modules and matching modules skipped for a missing `version` can also produce no eligible update.
 
 Apply the updates and write exact block counts independently of the human-readable summary:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 # Examples
 
-This directory contains sample YAML configurations, Terraform fixtures, and a maintained script
-for automating updates across Git branches.
+This directory contains sample YAML configurations, Terraform fixtures, runnable behaviour
+scenarios, and maintained automation scripts.
 
 Version numbers in these files demonstrate syntax only. They are not recommendations and may not
 be current releases of the referenced modules or providers.
@@ -28,6 +28,68 @@ legitimately report fewer updates than the config contains.
 
 For the YAML contract and filter precedence, see the
 [configuration reference](../docs/CONFIGURATION.md).
+
+## Automation cookbook
+
+Validate the runtime YAML contract before selecting any Terraform files:
+
+```bash
+tf-version-bump -validate-config versions.yml
+```
+
+Preview the human-readable changes without writing:
+
+```bash
+tf-version-bump -pattern "**/*.tf" -config versions.yml -dry-run
+```
+
+For a CI or pre-commit gate, use `-check`. Status 0 means the selected values are current, status 2
+means updates are required, and status 1 means validation or processing failed:
+
+```bash
+if tf-version-bump -pattern "**/*.tf" -config versions.yml -check; then
+  echo "Terraform versions are current"
+else
+  check_status=$?
+  if [ "$check_status" -eq 2 ]; then
+    echo "Terraform version updates are required"
+  else
+    exit "$check_status"
+  fi
+fi
+```
+
+Apply the updates and write exact block counts independently of the human-readable summary:
+
+```bash
+tf-version-bump \
+  -pattern "**/*.tf" \
+  -config versions.yml \
+  -report-file update-report.json
+
+jq '{terraform_blocks_updated, module_blocks_updated, provider_blocks_updated}' \
+  update-report.json
+```
+
+The report is schema version 2. It counts changed Terraform, module, and provider blocks, not files.
+Dry-run reports contain zero counts because no updates were applied. Check mode rejects
+`-report-file` so it remains entirely write-free.
+
+## Runnable scenarios
+
+[`scenarios/force-add`](scenarios/force-add) demonstrates the default warning for a registry module
+without `version`, followed by the same config with `-force-add`.
+[`scenarios/idempotency`](scenarios/idempotency) updates Terraform, provider, and module versions,
+then proves that applying the same config again leaves both bytes and modification time unchanged.
+
+Run both scenarios against a temporary copy of their fixtures:
+
+```bash
+examples/run-scenarios.sh
+```
+
+The runner builds the current source once, never changes the checked-in fixtures, and removes its
+temporary workspace when it exits.
 
 ## Terraform files
 

--- a/examples/config-advanced.yml
+++ b/examples/config-advanced.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yesdevnull/tf-version-bump/main/schema/config-schema.json
+
 # Advanced configuration example
 # Demonstrates public and private registry modules and subpaths
 

--- a/examples/config-basic.yml
+++ b/examples/config-basic.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yesdevnull/tf-version-bump/main/schema/config-schema.json
+
 # Basic configuration example
 # Updates multiple Terraform modules to specific versions
 

--- a/examples/config-multiple-from.yml
+++ b/examples/config-multiple-from.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yesdevnull/tf-version-bump/main/schema/config-schema.json
+
 # Example configuration demonstrating multiple from versions
 # This allows selective updates based on exact version-attribute strings
 

--- a/examples/config-production.yml
+++ b/examples/config-production.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yesdevnull/tf-version-bump/main/schema/config-schema.json
+
 # Larger configuration example organised by infrastructure concern
 # Version values demonstrate syntax and are not current-version recommendations
 

--- a/examples/config-terraform-providers.yml
+++ b/examples/config-terraform-providers.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yesdevnull/tf-version-bump/main/schema/config-schema.json
+
 # Configuration example with Terraform version and provider updates
 # This config updates the Terraform required version and multiple provider versions
 

--- a/examples/config-with-ignore.yml
+++ b/examples/config-with-ignore.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yesdevnull/tf-version-bump/main/schema/config-schema.json
+
 # Example configuration file demonstrating the ignore_modules feature
 # This shows how to selectively ignore specific modules by name or pattern
 

--- a/examples/github-actions/.github/tf-version-bump/production.yml
+++ b/examples/github-actions/.github/tf-version-bump/production.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yesdevnull/tf-version-bump/main/schema/config-schema.json
+
 # Syntax example: replace these targets with versions approved by your organisation.
 providers:
   - name: aws

--- a/examples/run-scenarios.sh
+++ b/examples/run-scenarios.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage: examples/run-scenarios.sh
+
+Build tf-version-bump and verify the maintained force-add and idempotency
+examples in an isolated temporary directory.
+USAGE
+}
+
+fail() {
+    printf 'Example scenario failure: %s\n' "$*" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+file_modification_time() {
+    if stat -f '%m' "$1" >/dev/null 2>&1; then
+        stat -f '%m' "$1"
+    else
+        stat -c '%Y' "$1"
+    fi
+}
+
+if [[ ${1:-} == "--help" ]]; then
+    usage
+    exit 0
+fi
+if (($# != 0)); then
+    usage >&2
+    exit 2
+fi
+
+for dependency in go grep cmp cp mktemp sed stat touch; do
+    require_command "$dependency"
+done
+
+script_directory=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+repository_root=$(cd -- "$script_directory/.." && pwd -P)
+workspace=$(mktemp -d "${TMPDIR:-/tmp}/tf-version-bump-scenarios.XXXXXX")
+cleanup() {
+    rm -rf -- "$workspace"
+}
+trap cleanup EXIT
+
+binary="$workspace/tf-version-bump"
+if ! (
+    cd -- "$repository_root"
+    GOCACHE="$workspace/go-cache" go build -o "$binary" .
+) >"$workspace/build.stdout" 2>"$workspace/build.stderr"; then
+    sed -n '1,40p' "$workspace/build.stderr" >&2
+    fail "could not build tf-version-bump"
+fi
+
+force_add_directory="$workspace/force-add"
+mkdir -p -- "$force_add_directory"
+cp -- "$repository_root/examples/scenarios/force-add/main.tf" "$force_add_directory/main.tf"
+cp -- "$repository_root/examples/scenarios/force-add/config.yml" "$force_add_directory/config.yml"
+
+"$binary" -pattern "$force_add_directory/main.tf" -config "$force_add_directory/config.yml" \
+    >"$workspace/force-add-skip.stdout" 2>"$workspace/force-add-skip.stderr"
+cmp -s "$force_add_directory/main.tf" "$repository_root/examples/scenarios/force-add/main.tf" \
+    || fail "force-add scenario changed the module without -force-add"
+grep -F "has no version attribute, skipping" \
+    "$workspace/force-add-skip.stderr" >/dev/null \
+    || fail "force-add scenario did not report the default missing-version warning"
+
+"$binary" -pattern "$force_add_directory/main.tf" -config "$force_add_directory/config.yml" \
+    -force-add >"$workspace/force-add.stdout" 2>"$workspace/force-add.stderr"
+grep -F 'version = "5.0.0"' "$force_add_directory/main.tf" >/dev/null \
+    || fail "force-add scenario did not add the configured module version"
+
+idempotency_directory="$workspace/idempotency"
+mkdir -p -- "$idempotency_directory"
+cp -- "$repository_root/examples/scenarios/idempotency/main.tf" "$idempotency_directory/main.tf"
+cp -- "$repository_root/examples/scenarios/idempotency/config.yml" "$idempotency_directory/config.yml"
+
+"$binary" -pattern "$idempotency_directory/main.tf" -config "$idempotency_directory/config.yml" \
+    >"$workspace/idempotency-first.stdout" 2>"$workspace/idempotency-first.stderr"
+grep -F 'required_version = ">= 1.5"' "$idempotency_directory/main.tf" >/dev/null \
+    || fail "idempotency scenario did not update Terraform required_version"
+grep -F 'version = "~> 5.0"' "$idempotency_directory/main.tf" >/dev/null \
+    || fail "idempotency scenario did not update the provider version"
+grep -F 'version = "2.0.0"' "$idempotency_directory/main.tf" >/dev/null \
+    || fail "idempotency scenario did not update the module version"
+
+cp -- "$idempotency_directory/main.tf" "$workspace/idempotency-first.tf"
+touch -t 200001010000 "$idempotency_directory/main.tf"
+first_modification_time=$(file_modification_time "$idempotency_directory/main.tf")
+"$binary" -pattern "$idempotency_directory/main.tf" -config "$idempotency_directory/config.yml" \
+    >"$workspace/idempotency-second.stdout" 2>"$workspace/idempotency-second.stderr"
+second_modification_time=$(file_modification_time "$idempotency_directory/main.tf")
+cmp -s "$idempotency_directory/main.tf" "$workspace/idempotency-first.tf" \
+    || fail "second idempotency run changed Terraform bytes"
+[[ $second_modification_time == "$first_modification_time" ]] \
+    || fail "second idempotency run changed the Terraform modification time"
+grep -F 'No updates were performed.' "$workspace/idempotency-second.stdout" >/dev/null \
+    || fail "second idempotency run did not report an already-current configuration"
+
+printf 'Example scenarios passed\n'

--- a/examples/scenarios/force-add/config.yml
+++ b/examples/scenarios/force-add/config.yml
@@ -1,10 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/yesdevnull/tf-version-bump/main/schema/config-schema.json
 
-# Syntax example: replace these targets with versions approved by your organisation.
-providers:
-  - name: aws
-    version: "~> 6.0"
-
 modules:
   - source: terraform-aws-modules/vpc/aws
-    version: "5.0.0"
+    version: 5.0.0

--- a/examples/scenarios/force-add/main.tf
+++ b/examples/scenarios/force-add/main.tf
@@ -1,0 +1,3 @@
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+}

--- a/examples/scenarios/idempotency/config.yml
+++ b/examples/scenarios/idempotency/config.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yesdevnull/tf-version-bump/main/schema/config-schema.json
+
+terraform_version: ">= 1.5"
+
+providers:
+  - name: aws
+    version: "~> 5.0"
+
+modules:
+  - source: example/module
+    version: 2.0.0

--- a/examples/scenarios/idempotency/main.tf
+++ b/examples/scenarios/idempotency/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+module "example" {
+  source  = "example/module"
+  version = "1.0.0"
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -22,7 +22,10 @@ func TestRunCLIModeContinuesAfterFileFailure(t *testing.T) {
 				flags.providerName = "aws"
 				flags.toVersion = "~> 5.0"
 			}
-			stdout, diag, err := captureRunnerOutput(t, func() error { return runCLIMode([]string{bad, good}, flags) })
+			stdout, diag, err := captureRunnerOutput(t, func() error {
+				_, err := runCLIMode([]string{bad, good}, flags)
+				return err
+			})
 			parser := "failed to parse HCL: " + bad + ":1,11-12: Unclosed configuration block; There is no closing brace for this block before the end of the file. This may be caused by incorrect brace nesting elsewhere in this file."
 			wantDiag := "Error processing " + bad + ": " + parser + "\n"
 			wantOut := tt.output + good + "\n\nSuccessfully updated 1 file(s)\n"
@@ -66,7 +69,8 @@ modules:
     version: 2.0.0
 `)
 	stdout, diag, err := captureRunnerOutput(t, func() error {
-		return runConfigFileMode([]string{first, second}, &cliFlags{configFile: cfg, output: "text"})
+		_, err := runConfigFileMode([]string{first, second}, &cliFlags{configFile: cfg, output: "text"})
+		return err
 	})
 	wantStdout := "✓ Updated Terraform required_version to '>= 1.5' in " + first + "\n" +
 		"✓ Updated Terraform required_version to '>= 1.5' in " + second + "\n" +
@@ -143,7 +147,8 @@ modules:
     version: 6.0.0
 `)
 	stdout, diag, err := captureRunnerOutput(t, func() error {
-		return runConfigFileMode([]string{bad1, bad2, good}, &cliFlags{configFile: cfg, output: "text"})
+		_, err := runConfigFileMode([]string{bad1, bad2, good}, &cliFlags{configFile: cfg, output: "text"})
+		return err
 	})
 	wantPrefix := "✓ Updated Terraform required_version to '>= 1.6' in " + good + "\n✓ Updated provider 'aws' to version '~> 5.0' in " + good + "\n✓ Updated provider 'azurerm' to version '~> 4.0' in " + good + "\n✓ Updated module source 'terraform-aws-modules/vpc/aws' to version '5.0.0' in " + good + "\n✓ Updated module source 'terraform-aws-modules/ec2-instance/aws' to version '6.0.0' in " + good + "\n\n==================================================\nConfig File Update Summary\n==================================================\nTerraform version: 1 file(s) updated\nProviders: 2 update(s) applied\nModules: 2 update(s) applied\n"
 	if err == nil || err.Error() != "10 update error(s)" || stdout != wantPrefix {

--- a/main.go
+++ b/main.go
@@ -216,6 +216,7 @@ func canonicalFileIdentity(filename string) string {
 // parseFlags parses and validates command-line flags
 func parseFlags() *cliFlags {
 	flags := &cliFlags{}
+	usageOutput := flag.CommandLine.Output()
 	flagSet := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	flagSet.SetOutput(io.Discard)
 	flag.CommandLine = flagSet
@@ -239,8 +240,8 @@ func parseFlags() *cliFlags {
 	flagSet.StringVar(&flags.reportFile, "report-file", "", "Write exact updated Terraform, module, and provider block counts as JSON")
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
-			flagSet.SetOutput(os.Stderr)
-			fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+			flagSet.SetOutput(usageOutput)
+			fmt.Fprintf(usageOutput, "Usage of %s:\n", os.Args[0])
 			flagSet.PrintDefaults()
 			exitFunc(0)
 			return flags
@@ -248,7 +249,7 @@ func parseFlags() *cliFlags {
 		fatalf("Error: %v", err)
 		return flags
 	}
-	flagSet.SetOutput(os.Stderr)
+	flagSet.SetOutput(usageOutput)
 	if flagSet.NArg() > 0 {
 		fatalf("Error: unexpected positional argument(s): %s", strings.Join(flagSet.Args(), " "))
 		return flags

--- a/main.go
+++ b/main.go
@@ -14,8 +14,10 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/fs"
 	"log"
 	"os"
@@ -214,25 +216,43 @@ func canonicalFileIdentity(filename string) string {
 // parseFlags parses and validates command-line flags
 func parseFlags() *cliFlags {
 	flags := &cliFlags{}
+	flagSet := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	flagSet.SetOutput(io.Discard)
+	flag.CommandLine = flagSet
 
-	flag.StringVar(&flags.pattern, "pattern", "", "Glob pattern for Terraform files; '**' matches any depth (e.g., '*.tf' or 'modules/**/*.tf')")
-	flag.StringVar(&flags.moduleSource, "module", "", "Source of the module to update (e.g., 'terraform-aws-modules/vpc/aws')")
-	flag.StringVar(&flags.toVersion, "to", "", "Desired version number")
-	flag.Var(&flags.fromVersions, "from", "Optional: version to update from (can be specified multiple times, e.g., -from 3.0.0 -from '~> 3.0')")
-	flag.Var(&flags.ignoreVersions, "ignore-version", "Optional: version(s) to skip (can be specified multiple times, e.g., -ignore-version 3.0.0 -ignore-version '~> 3.0')")
-	flag.StringVar(&flags.ignoreModules, "ignore-modules", "", "Optional: comma-separated list of module names or patterns to ignore (e.g., 'vpc,legacy-*')")
-	flag.StringVar(&flags.configFile, "config", "", "Path to YAML config file with multiple module updates")
-	flag.StringVar(&flags.validationConfigFile, "validate-config", "", "Validate a YAML config file without updating Terraform files")
-	flag.BoolVar(&flags.forceAdd, "force-add", false, "Add a missing version attribute to registry modules (default: skip with warning)")
-	flag.BoolVar(&flags.dryRun, "dry-run", false, "Show what changes would be made without actually modifying files")
-	flag.BoolVar(&flags.check, "check", false, "Exit 2 when updates are required without modifying files")
-	flag.BoolVar(&flags.verbose, "verbose", false, "Show verbose output including skipped modules")
-	flag.BoolVar(&flags.showVersion, "version", false, "Print version information and exit")
-	flag.StringVar(&flags.output, "output", "text", "Output format: 'text' (default) or 'md' (Markdown)")
-	flag.StringVar(&flags.terraformVersion, "terraform-version", "", "Update Terraform required_version in terraform blocks")
-	flag.StringVar(&flags.providerName, "provider", "", "Provider name to update (e.g., 'aws', 'azurerm')")
-	flag.StringVar(&flags.reportFile, "report-file", "", "Write exact updated Terraform, module, and provider block counts as JSON")
-	flag.Parse()
+	flagSet.StringVar(&flags.pattern, "pattern", "", "Glob pattern for Terraform files; '**' matches any depth (e.g., '*.tf' or 'modules/**/*.tf')")
+	flagSet.StringVar(&flags.moduleSource, "module", "", "Source of the module to update (e.g., 'terraform-aws-modules/vpc/aws')")
+	flagSet.StringVar(&flags.toVersion, "to", "", "Desired version number")
+	flagSet.Var(&flags.fromVersions, "from", "Optional: version to update from (can be specified multiple times, e.g., -from 3.0.0 -from '~> 3.0')")
+	flagSet.Var(&flags.ignoreVersions, "ignore-version", "Optional: version(s) to skip (can be specified multiple times, e.g., -ignore-version 3.0.0 -ignore-version '~> 3.0')")
+	flagSet.StringVar(&flags.ignoreModules, "ignore-modules", "", "Optional: comma-separated list of module names or patterns to ignore (e.g., 'vpc,legacy-*')")
+	flagSet.StringVar(&flags.configFile, "config", "", "Path to YAML config file with multiple module updates")
+	flagSet.StringVar(&flags.validationConfigFile, "validate-config", "", "Validate a YAML config file without updating Terraform files")
+	flagSet.BoolVar(&flags.forceAdd, "force-add", false, "Add a missing version attribute to registry modules (default: skip with warning)")
+	flagSet.BoolVar(&flags.dryRun, "dry-run", false, "Show what changes would be made without actually modifying files")
+	flagSet.BoolVar(&flags.check, "check", false, "Exit 2 when updates are required without modifying files")
+	flagSet.BoolVar(&flags.verbose, "verbose", false, "Show verbose output including skipped modules")
+	flagSet.BoolVar(&flags.showVersion, "version", false, "Print version information and exit")
+	flagSet.StringVar(&flags.output, "output", "text", "Output format: 'text' (default) or 'md' (Markdown)")
+	flagSet.StringVar(&flags.terraformVersion, "terraform-version", "", "Update Terraform required_version in terraform blocks")
+	flagSet.StringVar(&flags.providerName, "provider", "", "Provider name to update (e.g., 'aws', 'azurerm')")
+	flagSet.StringVar(&flags.reportFile, "report-file", "", "Write exact updated Terraform, module, and provider block counts as JSON")
+	if err := flagSet.Parse(os.Args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			flagSet.SetOutput(os.Stderr)
+			fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+			flagSet.PrintDefaults()
+			exitFunc(0)
+			return flags
+		}
+		fatalf("Error: %v", err)
+		return flags
+	}
+	flagSet.SetOutput(os.Stderr)
+	if flagSet.NArg() > 0 {
+		fatalf("Error: unexpected positional argument(s): %s", strings.Join(flagSet.Args(), " "))
+		return flags
+	}
 
 	// Validate output format
 	if flags.output != "text" && flags.output != "md" {

--- a/main.go
+++ b/main.go
@@ -114,6 +114,7 @@ type cliFlags struct {
 	validationConfigFile string
 	forceAdd             bool
 	dryRun               bool
+	check                bool
 	verbose              bool
 	showVersion          bool
 	output               string
@@ -214,6 +215,7 @@ func parseFlags() *cliFlags {
 	flag.StringVar(&flags.validationConfigFile, "validate-config", "", "Validate a YAML config file without updating Terraform files")
 	flag.BoolVar(&flags.forceAdd, "force-add", false, "Add a missing version attribute to registry modules (default: skip with warning)")
 	flag.BoolVar(&flags.dryRun, "dry-run", false, "Show what changes would be made without actually modifying files")
+	flag.BoolVar(&flags.check, "check", false, "Exit 2 when updates are required without modifying files")
 	flag.BoolVar(&flags.verbose, "verbose", false, "Show verbose output including skipped modules")
 	flag.BoolVar(&flags.showVersion, "version", false, "Print version information and exit")
 	flag.StringVar(&flags.output, "output", "text", "Output format: 'text' (default) or 'md' (Markdown)")
@@ -325,6 +327,9 @@ func main() {
 		fmt.Printf("Config '%s' is valid\n", flags.validationConfigFile)
 		exitFunc(0)
 	}
+	if flags.check {
+		flags.dryRun = true
+	}
 
 	// Find and validate matching files
 	files := findMatchingFiles(flags)
@@ -339,10 +344,11 @@ func main() {
 	}
 
 	// Run the appropriate operation mode
+	var totalUpdates int
 	if flags.configFile != "" {
-		err = runConfigFileMode(files, flags)
+		totalUpdates, err = runConfigFileMode(files, flags)
 	} else {
-		err = runCLIMode(files, flags)
+		totalUpdates, err = runCLIMode(files, flags)
 	}
 	if err != nil {
 		if preparedReport != nil {
@@ -357,6 +363,9 @@ func main() {
 		if publishErr := preparedReport.publish(flags.report); publishErr != nil {
 			fatalf("Error writing update report: %v", publishErr)
 		}
+	}
+	if flags.check && totalUpdates > 0 {
+		exitFunc(2)
 	}
 }
 
@@ -474,6 +483,12 @@ func validateOperationModes(flags *cliFlags) {
 		}
 		return
 	}
+	if flags.check && flags.dryRun {
+		fatalf("Error: Cannot use -check with -dry-run")
+	}
+	if flags.check && flags.reportFile != "" {
+		fatalf("Error: Cannot use -check with -report-file")
+	}
 
 	// Config file mode is exclusive with all other CLI flags
 	if flags.configFile != "" {
@@ -520,7 +535,7 @@ func configValidationHasConflicts(flags *cliFlags) bool {
 	return flags.pattern != "" || flags.configFile != "" || flags.moduleSource != "" || flags.toVersion != "" ||
 		len(flags.fromVersions) > 0 || len(flags.ignoreVersions) > 0 || flags.ignoreModules != "" ||
 		flags.terraformVersion != "" || flags.providerName != "" || flags.forceAdd || flags.dryRun ||
-		flags.verbose || flags.reportFile != ""
+		flags.check || flags.verbose || flags.reportFile != ""
 }
 
 // findMatchingFiles finds all files matching the pattern
@@ -580,7 +595,9 @@ func findMatchingFiles(flags *cliFlags) []string {
 
 	fmt.Printf("Found %d file(s) matching pattern %s\n", len(files), quote(flags.pattern, flags.output))
 
-	if flags.dryRun {
+	if flags.check {
+		fmt.Println("Running in check mode - no files will be modified")
+	} else if flags.dryRun {
 		fmt.Println("Running in dry-run mode - no files will be modified")
 	}
 
@@ -588,11 +605,11 @@ func findMatchingFiles(flags *cliFlags) []string {
 }
 
 // runConfigFileMode handles config file mode operations.
-func runConfigFileMode(files []string, flags *cliFlags) error {
+func runConfigFileMode(files []string, flags *cliFlags) (int, error) {
 	config, err := loadConfig(flags.configFile)
 	if err != nil {
 		//nolint:staticcheck // The capitalised prefix is user-facing CLI output.
-		return fmt.Errorf("Error loading config file: %w", err)
+		return 0, fmt.Errorf("Error loading config file: %w", err)
 	}
 
 	var terraformUpdates, terraformErrors, providerUpdates, providerErrors, moduleUpdates, moduleErrors int
@@ -616,17 +633,18 @@ func runConfigFileMode(files []string, flags *cliFlags) error {
 
 	// Print summary
 	printConfigSummary(terraformUpdates, providerUpdates, moduleUpdates, flags.dryRun)
+	totalUpdates := terraformUpdates + providerUpdates + moduleUpdates
 	if terraformErrors == 0 && providerErrors == 0 && moduleErrors > 0 {
-		return fmt.Errorf("%d module update error(s)", moduleErrors)
+		return totalUpdates, fmt.Errorf("%d module update error(s)", moduleErrors)
 	}
 	if totalErrors := terraformErrors + providerErrors + moduleErrors; totalErrors > 0 {
-		return fmt.Errorf("%d update error(s)", totalErrors)
+		return totalUpdates, fmt.Errorf("%d update error(s)", totalErrors)
 	}
-	return nil
+	return totalUpdates, nil
 }
 
 // runCLIMode handles CLI mode operations
-func runCLIMode(files []string, flags *cliFlags) error {
+func runCLIMode(files []string, flags *cliFlags) (int, error) {
 	var totalUpdates int
 	var updates []ModuleUpdate
 
@@ -636,9 +654,9 @@ func runCLIMode(files []string, flags *cliFlags) error {
 		totalUpdates, totalErrors = processTerraformVersion(files, flags.terraformVersion, flags.dryRun, flags.output)
 		printTerraformSummary(totalUpdates, flags.dryRun)
 		if totalErrors > 0 {
-			return fmt.Errorf("%d Terraform version update error(s)", totalErrors)
+			return totalUpdates, fmt.Errorf("%d Terraform version update error(s)", totalErrors)
 		}
-		return nil
+		return totalUpdates, nil
 	case flags.providerName != "":
 		if flags.toVersion == "" {
 			fatalf("Error: -to flag is required when using -provider")
@@ -647,18 +665,18 @@ func runCLIMode(files []string, flags *cliFlags) error {
 		totalUpdates, totalErrors = processProviderVersion(files, flags.providerName, flags.toVersion, flags.dryRun, flags.output, flags.reportRecorder())
 		printProviderSummary(flags.providerName, totalUpdates, flags.dryRun, flags.output)
 		if totalErrors > 0 {
-			return fmt.Errorf("%d provider update error(s)", totalErrors)
+			return totalUpdates, fmt.Errorf("%d provider update error(s)", totalErrors)
 		}
-		return nil
+		return totalUpdates, nil
 	default:
 		updates = loadModuleUpdates(flags)
 		var totalErrors int
 		totalUpdates, totalErrors = processFiles(files, updates, flags)
 		printSummary(totalUpdates, len(updates), flags.dryRun)
 		if totalErrors > 0 {
-			return fmt.Errorf("%d module update error(s)", totalErrors)
+			return totalUpdates, fmt.Errorf("%d module update error(s)", totalErrors)
 		}
-		return nil
+		return totalUpdates, nil
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -231,7 +231,7 @@ func parseFlags() *cliFlags {
 	flag.StringVar(&flags.output, "output", "text", "Output format: 'text' (default) or 'md' (Markdown)")
 	flag.StringVar(&flags.terraformVersion, "terraform-version", "", "Update Terraform required_version in terraform blocks")
 	flag.StringVar(&flags.providerName, "provider", "", "Provider name to update (e.g., 'aws', 'azurerm')")
-	flag.StringVar(&flags.reportFile, "report-file", "", "Write exact updated module and provider block counts as JSON")
+	flag.StringVar(&flags.reportFile, "report-file", "", "Write exact updated Terraform, module, and provider block counts as JSON")
 	flag.Parse()
 
 	// Validate output format

--- a/main.go
+++ b/main.go
@@ -125,12 +125,14 @@ type cliFlags struct {
 }
 
 type updateReport struct {
-	SchemaVersion         int `json:"schema_version"`
-	ModuleBlocksUpdated   int `json:"module_blocks_updated"`
-	ProviderBlocksUpdated int `json:"provider_blocks_updated"`
-	moduleBlockIDs        map[string]struct{}
-	providerBlockIDs      map[string]struct{}
-	fileIdentities        []fs.FileInfo
+	SchemaVersion          int `json:"schema_version"`
+	TerraformBlocksUpdated int `json:"terraform_blocks_updated"`
+	ModuleBlocksUpdated    int `json:"module_blocks_updated"`
+	ProviderBlocksUpdated  int `json:"provider_blocks_updated"`
+	terraformBlockIDs      map[string]struct{}
+	moduleBlockIDs         map[string]struct{}
+	providerBlockIDs       map[string]struct{}
+	fileIdentities         []fs.FileInfo
 }
 
 type preparedReportFile struct {
@@ -145,18 +147,26 @@ func (flags *cliFlags) reportRecorder() *updateReport {
 	return &flags.report
 }
 
+func (report *updateReport) recordTerraformBlocks(filename string, blockIndexes []int) {
+	report.recordTopLevelBlocks(filename, blockIndexes, &report.terraformBlockIDs, &report.TerraformBlocksUpdated)
+}
+
 func (report *updateReport) recordModuleBlocks(filename string, blockIndexes []int) {
+	report.recordTopLevelBlocks(filename, blockIndexes, &report.moduleBlockIDs, &report.ModuleBlocksUpdated)
+}
+
+func (report *updateReport) recordTopLevelBlocks(filename string, blockIndexes []int, blockIDs *map[string]struct{}, count *int) {
 	fileID := report.fileIdentity(filename)
-	if report.moduleBlockIDs == nil {
-		report.moduleBlockIDs = make(map[string]struct{})
+	if *blockIDs == nil {
+		*blockIDs = make(map[string]struct{})
 	}
 	for _, blockIndex := range blockIndexes {
 		blockID := fmt.Sprintf("%s\x00%d", fileID, blockIndex)
-		if _, recorded := report.moduleBlockIDs[blockID]; recorded {
+		if _, recorded := (*blockIDs)[blockID]; recorded {
 			continue
 		}
-		report.moduleBlockIDs[blockID] = struct{}{}
-		report.ModuleBlocksUpdated++
+		(*blockIDs)[blockID] = struct{}{}
+		*count++
 	}
 }
 
@@ -359,7 +369,7 @@ func main() {
 		fatalf("%v", err)
 	}
 	if preparedReport != nil {
-		flags.report.SchemaVersion = 1
+		flags.report.SchemaVersion = 2
 		if publishErr := preparedReport.publish(flags.report); publishErr != nil {
 			fatalf("Error writing update report: %v", publishErr)
 		}
@@ -616,7 +626,7 @@ func runConfigFileMode(files []string, flags *cliFlags) (int, error) {
 
 	// Process terraform version if specified
 	if config.TerraformVersion != "" {
-		terraformUpdates, terraformErrors = processTerraformVersion(files, config.TerraformVersion, flags.dryRun, flags.output)
+		terraformUpdates, terraformErrors = processTerraformVersion(files, config.TerraformVersion, flags.dryRun, flags.output, flags.reportRecorder())
 	}
 
 	// Process provider updates if specified
@@ -651,7 +661,7 @@ func runCLIMode(files []string, flags *cliFlags) (int, error) {
 	switch {
 	case flags.terraformVersion != "":
 		var totalErrors int
-		totalUpdates, totalErrors = processTerraformVersion(files, flags.terraformVersion, flags.dryRun, flags.output)
+		totalUpdates, totalErrors = processTerraformVersion(files, flags.terraformVersion, flags.dryRun, flags.output, flags.reportRecorder())
 		printTerraformSummary(totalUpdates, flags.dryRun)
 		if totalErrors > 0 {
 			return totalUpdates, fmt.Errorf("%d Terraform version update error(s)", totalErrors)
@@ -759,15 +769,18 @@ func containsVersion(versions []string, version string) bool {
 // Returns:
 //   - totalUpdates: Number of files that were updated (or would be updated in dry-run mode)
 //   - totalErrors: Number of files that could not be processed
-func processTerraformVersion(files []string, version string, dryRun bool, outputFormat string) (totalUpdates, totalErrors int) {
+func processTerraformVersion(files []string, version string, dryRun bool, outputFormat string, report *updateReport) (totalUpdates, totalErrors int) {
 	for _, file := range files {
-		updated, err := updateTerraformVersion(file, version, dryRun)
+		updated, changedBlocks, err := updateTerraformVersionWithCount(file, version, dryRun)
 		if err != nil {
 			log.Printf("Error processing %s: %v", file, err)
 			totalErrors++
 			continue
 		}
 		if updated {
+			if report != nil && !dryRun && len(changedBlocks) > 0 {
+				report.recordTerraformBlocks(file, changedBlocks)
+			}
 			prefix := "✓"
 			action := "Updated"
 			if dryRun {
@@ -829,29 +842,36 @@ func processProviderVersion(files []string, providerName, version string, dryRun
 //   - bool: true if a terraform block was updated (or would be updated in dry-run mode)
 //   - error: Any error encountered during file reading, parsing, or writing
 func updateTerraformVersion(filename, version string, dryRun bool) (bool, error) {
+	updated, _, err := updateTerraformVersionWithCount(filename, version, dryRun)
+	return updated, err
+}
+
+// updateTerraformVersionWithCount updates required_version and identifies changed terraform blocks.
+func updateTerraformVersionWithCount(filename, version string, dryRun bool) (updated bool, changedBlocks []int, err error) {
 	// Get original file permissions to preserve them when writing
 	fileInfo, err := os.Stat(filename)
 	if err != nil {
-		return false, fmt.Errorf("failed to stat file: %w", err)
+		return false, nil, fmt.Errorf("failed to stat file: %w", err)
 	}
 	originalMode := fileInfo.Mode()
 
 	// Read the file
 	src, err := os.ReadFile(filename)
 	if err != nil {
-		return false, fmt.Errorf("failed to read file: %w", err)
+		return false, nil, fmt.Errorf("failed to read file: %w", err)
 	}
 
 	// Parse the file with hclwrite
 	file, diags := hclwrite.ParseConfig(src, filename, hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
-		return false, fmt.Errorf("failed to parse HCL: %s", diags.Error())
+		return false, nil, fmt.Errorf("failed to parse HCL: %s", diags.Error())
 	}
 
 	// Track if we made any changes
-	updated := false
+	updated = false
+	changedBlocks = nil
 	// Iterate through all blocks in the file
-	for _, block := range file.Body().Blocks() {
+	for blockIndex, block := range file.Body().Blocks() {
 		// Look for terraform blocks
 		if block.Type() == "terraform" {
 			currentVersion := block.Body().GetAttribute("required_version")
@@ -861,6 +881,7 @@ func updateTerraformVersion(filename, version string, dryRun bool) (bool, error)
 			// Update or add the required_version attribute
 			block.Body().SetAttributeValue("required_version", cty.StringVal(version))
 			updated = true
+			changedBlocks = append(changedBlocks, blockIndex)
 		}
 	}
 
@@ -869,11 +890,11 @@ func updateTerraformVersion(filename, version string, dryRun bool) (bool, error)
 		output := hclwrite.Format(file.Bytes())
 		// Preserve original file permissions
 		if err := os.WriteFile(filename, output, originalMode.Perm()); err != nil {
-			return false, fmt.Errorf("failed to write file: %w", err)
+			return false, nil, fmt.Errorf("failed to write file: %w", err)
 		}
 	}
 
-	return updated, nil
+	return updated, changedBlocks, nil
 }
 
 // updateProviderVersionWithCount updates a provider version and counts blocks whose values changed.

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
+	stderrors "errors"
 	"flag"
 	"fmt"
 	"io"
@@ -150,26 +150,32 @@ func (flags *cliFlags) reportRecorder() *updateReport {
 }
 
 func (report *updateReport) recordTerraformBlocks(filename string, blockIndexes []int) {
-	report.recordTopLevelBlocks(filename, blockIndexes, &report.terraformBlockIDs, &report.TerraformBlocksUpdated)
+	var recorded int
+	report.terraformBlockIDs, recorded = report.recordTopLevelBlocks(filename, blockIndexes, report.terraformBlockIDs)
+	report.TerraformBlocksUpdated += recorded
 }
 
 func (report *updateReport) recordModuleBlocks(filename string, blockIndexes []int) {
-	report.recordTopLevelBlocks(filename, blockIndexes, &report.moduleBlockIDs, &report.ModuleBlocksUpdated)
+	var recorded int
+	report.moduleBlockIDs, recorded = report.recordTopLevelBlocks(filename, blockIndexes, report.moduleBlockIDs)
+	report.ModuleBlocksUpdated += recorded
 }
 
-func (report *updateReport) recordTopLevelBlocks(filename string, blockIndexes []int, blockIDs *map[string]struct{}, count *int) {
+func (report *updateReport) recordTopLevelBlocks(filename string, blockIndexes []int, existingBlockIDs map[string]struct{}) (blockIDs map[string]struct{}, recordedBlocks int) {
 	fileID := report.fileIdentity(filename)
-	if *blockIDs == nil {
-		*blockIDs = make(map[string]struct{})
+	blockIDs = existingBlockIDs
+	if blockIDs == nil {
+		blockIDs = make(map[string]struct{})
 	}
 	for _, blockIndex := range blockIndexes {
 		blockID := fmt.Sprintf("%s\x00%d", fileID, blockIndex)
-		if _, recorded := (*blockIDs)[blockID]; recorded {
+		if _, recorded := blockIDs[blockID]; recorded {
 			continue
 		}
-		(*blockIDs)[blockID] = struct{}{}
-		*count++
+		blockIDs[blockID] = struct{}{}
+		recordedBlocks++
 	}
+	return blockIDs, recordedBlocks
 }
 
 func (report *updateReport) recordProviderBlocks(filename string, blockLocations []string) {
@@ -239,9 +245,12 @@ func parseFlags() *cliFlags {
 	flagSet.StringVar(&flags.providerName, "provider", "", "Provider name to update (e.g., 'aws', 'azurerm')")
 	flagSet.StringVar(&flags.reportFile, "report-file", "", "Write exact updated Terraform, module, and provider block counts as JSON")
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if stderrors.Is(err, flag.ErrHelp) {
 			flagSet.SetOutput(usageOutput)
-			fmt.Fprintf(usageOutput, "Usage of %s:\n", os.Args[0])
+			if _, writeErr := fmt.Fprintf(usageOutput, "Usage of %s:\n", os.Args[0]); writeErr != nil {
+				fatalf("Error writing help: %v", writeErr)
+				return flags
+			}
 			flagSet.PrintDefaults()
 			exitFunc(0)
 			return flags
@@ -391,7 +400,7 @@ func main() {
 	}
 	if preparedReport != nil {
 		flags.report.SchemaVersion = 2
-		if publishErr := preparedReport.publish(flags.report); publishErr != nil {
+		if publishErr := preparedReport.publish(&flags.report); publishErr != nil {
 			fatalf("Error writing update report: %v", publishErr)
 		}
 	}
@@ -424,7 +433,7 @@ func prepareUpdateReport(reportFile string, inputFiles []string) (*preparedRepor
 	return &preparedReportFile{destination: reportFile, file: file}, nil
 }
 
-func (prepared *preparedReportFile) publish(report updateReport) error {
+func (prepared *preparedReportFile) publish(report *updateReport) error {
 	data, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
 		_ = prepared.discard()
@@ -652,9 +661,9 @@ func runConfigFileMode(files []string, flags *cliFlags) (int, error) {
 
 	// Process provider updates if specified
 	for _, provider := range config.Providers {
-		count, errors := processProviderVersion(files, provider.Name, provider.Version, flags.dryRun, flags.output, flags.reportRecorder())
+		count, updateErrors := processProviderVersion(files, provider.Name, provider.Version, flags.dryRun, flags.output, flags.reportRecorder())
 		providerUpdates += count
-		providerErrors += errors
+		providerErrors += updateErrors
 	}
 
 	// Process module updates if specified
@@ -893,17 +902,17 @@ func updateTerraformVersionWithCount(filename, version string, dryRun bool) (upd
 	changedBlocks = nil
 	// Iterate through all blocks in the file
 	for blockIndex, block := range file.Body().Blocks() {
-		// Look for terraform blocks
-		if block.Type() == "terraform" {
-			currentVersion := block.Body().GetAttribute("required_version")
-			if currentVersion != nil && attributeHasStringValue(currentVersion, version) {
-				continue
-			}
-			// Update or add the required_version attribute
-			block.Body().SetAttributeValue("required_version", cty.StringVal(version))
-			updated = true
-			changedBlocks = append(changedBlocks, blockIndex)
+		if block.Type() != "terraform" {
+			continue
 		}
+		currentVersion := block.Body().GetAttribute("required_version")
+		if currentVersion != nil && attributeHasStringValue(currentVersion, version) {
+			continue
+		}
+		// Update or add the required_version attribute
+		block.Body().SetAttributeValue("required_version", cty.StringVal(version))
+		updated = true
+		changedBlocks = append(changedBlocks, blockIndex)
 	}
 
 	// If we made changes, write the file back (unless in dry-run mode)

--- a/terraform_version_test.go
+++ b/terraform_version_test.go
@@ -3,10 +3,40 @@ package main
 import (
 	"errors"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestUpdateTerraformVersionWithCountIdentifiesChangedBlocks(t *testing.T) {
+	input := `terraform {
+  required_version = ">= 1.0"
+}
+
+terraform {
+  required_version = "${">= 1.5"}"
+}
+
+terraform {
+}
+`
+	filename := writeTestFile(t, t.TempDir(), "main.tf", input)
+
+	updated, changedBlocks, err := updateTerraformVersionWithCount(filename, ">= 1.5", true)
+	if err != nil {
+		t.Fatalf("updateTerraformVersionWithCount returned error: %v", err)
+	}
+	if !updated {
+		t.Fatal("updated = false, want true")
+	}
+	if want := []int{0, 2}; !reflect.DeepEqual(changedBlocks, want) {
+		t.Fatalf("changed blocks = %v, want %v", changedBlocks, want)
+	}
+	if got := readTestFile(t, filename); got != input {
+		t.Fatalf("dry run content = %q, want unchanged %q", got, input)
+	}
+}
 
 func TestUpdateTerraformVersionContract(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- add a non-writing `-check` mode with CI-friendly exit statuses
- publish report schema v2 with exact Terraform, module, and provider block counts
- add an automation cookbook plus executable force-add and idempotency scenarios
- document schema-aware configuration examples and the planned rc.10 Actions migration

## Behaviour

`-check` exits 0 when no eligible changes are required, 2 when eligible changes are found, and 1 for command or processing errors. It rejects combinations with `-dry-run`, `-report-file`, and standalone config validation.

Report files now use schema version 2 and include `terraform_blocks_updated` alongside the existing exact module and provider counts.

## Verification

- `go mod download`
- `go mod verify`
- `go mod tidy -diff`
- `go test -v -race -coverprofile=coverage.out -covermode=atomic ./...` (93.1% statement coverage)
- `golangci-lint run --timeout=5m`
- `make build`
- `make docs-check`
- `make test-github-actions`

Peer review found three issues in the first pass: malformed `-check` arguments could collide with status 2, status-0 documentation was too broad, and one documentation test assumed Bash existed. All three are fixed and independently verified.
