### PR TITLE
chore: migrate Actions example to rc.10

### DIFF
--- a/docs/ADVANCED-USAGE.md
+++ b/docs/ADVANCED-USAGE.md
@@ -34,8 +34,8 @@ helpers; publication does not receive the registry token in its environment.
 `terraform_fmt` defaults to `false`; both callers opt in with `terraform_fmt: true`. For every
 configured root, preparation runs the updater and `terraform init -upgrade` before formatting is
 eligible, then an eligible changed candidate runs `terraform fmt -recursive` in every configured
-root. The callers pin `tf-version-bump` to `v1.0.0-rc.9` and archive SHA-256
-`38428a229a77671fd192fd6a18f5d1f9c404b5557124883f04e6a8bec154b1d2`.
+root. The callers pin `tf-version-bump` to `v1.0.0-rc.10` and archive SHA-256
+`532783cd3c6834a37616ed81ed76ef99ec343cc64d9664dd67c7eb325420c830`.
 
 The reusable workflow installs the pinned Terraform CLI with `hashicorp/setup-terraform` in both
 Terraform jobs and invokes it directly. Docker is neither a production workflow requirement nor a

--- a/examples/github-actions/.github/scripts/process-state-branch.sh
+++ b/examples/github-actions/.github/scripts/process-state-branch.sh
@@ -276,8 +276,9 @@ accumulate_update_report() {
     local report=$1 relative_root=$2
     jq -e '
         type == "object" and
-        (keys == ["module_blocks_updated", "provider_blocks_updated", "schema_version"]) and
-        .schema_version == 1 and
+        (keys == ["module_blocks_updated", "provider_blocks_updated", "schema_version", "terraform_blocks_updated"]) and
+        .schema_version == 2 and
+        (.terraform_blocks_updated | type == "number" and . >= 0 and floor == .) and
         (.module_blocks_updated | type == "number" and . >= 0 and floor == .) and
         (.provider_blocks_updated | type == "number" and . >= 0 and floor == .)
     ' "$report" >/dev/null || return 1

--- a/examples/github-actions/.github/workflows/tf-version-bump-config-validation.yml
+++ b/examples/github-actions/.github/workflows/tf-version-bump-config-validation.yml
@@ -18,45 +18,27 @@ jobs:
           persist-credentials: false
       - name: Download and verify tf-version-bump
         run: |
-          archive_path="$RUNNER_TEMP/tf-version-bump_1.0.0-rc.9_linux_x86_64.tar.gz"
+          archive_path="$RUNNER_TEMP/tf-version-bump_1.0.0-rc.10_linux_x86_64.tar.gz"
           tool_directory="$RUNNER_TEMP/tf-version-bump-config-validation"
           rm -rf -- "$archive_path" "$tool_directory"
           mkdir -p -- "$tool_directory"
           curl --fail --silent --show-error --location \
             --output "$archive_path" \
-            https://github.com/yesdevnull/tf-version-bump/releases/download/v1.0.0-rc.9/tf-version-bump_1.0.0-rc.9_linux_x86_64.tar.gz
+            https://github.com/yesdevnull/tf-version-bump/releases/download/v1.0.0-rc.10/tf-version-bump_1.0.0-rc.10_linux_x86_64.tar.gz
           printf '%s  %s\n' \
-            38428a229a77671fd192fd6a18f5d1f9c404b5557124883f04e6a8bec154b1d2 \
+            532783cd3c6834a37616ed81ed76ef99ec343cc64d9664dd67c7eb325420c830 \
             "$archive_path" | sha256sum --check --status
           tar -xzf "$archive_path" -C "$tool_directory"
           version_output=$("$tool_directory/tf-version-bump" -version)
-          [[ "${version_output%%$'\n'*}" == "tf-version-bump 1.0.0-rc.9" ]]
+          [[ "${version_output%%$'\n'*}" == "tf-version-bump 1.0.0-rc.10" ]]
           printf 'TF_VERSION_BUMP_BINARY=%s\n' "$tool_directory/tf-version-bump" >> "$GITHUB_ENV"
-      - name: Validate configuration dry runs
+      - name: Validate configuration
         run: |
-          fixture_directory=$(mktemp -d "$RUNNER_TEMP/tf-version-bump-config-validation-fixture.XXXXXX")
-          trap 'rm -rf -- "$fixture_directory"' EXIT
-          cat > "$fixture_directory/main.tf" <<'EOF'
-          terraform {
-            required_providers {
-              aws = {
-                source  = "hashicorp/aws"
-                version = "~> 5.0"
-              }
-            }
-          }
-
-          module "vpc" {
-            source  = "terraform-aws-modules/vpc/aws"
-            version = "4.0.0"
-          }
-          EOF
-
           for config in \
             .github/tf-version-bump/nonproduction.yml \
             .github/tf-version-bump/production.yml; do
-            "$TF_VERSION_BUMP_BINARY" -pattern "$fixture_directory/main.tf" -config "$config" -dry-run
+            "$TF_VERSION_BUMP_BINARY" -validate-config "$config"
           done
       - name: Remove downloaded tf-version-bump
         if: ${{ always() }}
-        run: rm -rf -- "$RUNNER_TEMP/tf-version-bump_1.0.0-rc.9_linux_x86_64.tar.gz" "$RUNNER_TEMP/tf-version-bump-config-validation"
+        run: rm -rf -- "$RUNNER_TEMP/tf-version-bump_1.0.0-rc.10_linux_x86_64.tar.gz" "$RUNNER_TEMP/tf-version-bump-config-validation"

--- a/examples/github-actions/.github/workflows/tf-version-bump-nonproduction.yml
+++ b/examples/github-actions/.github/workflows/tf-version-bump-nonproduction.yml
@@ -46,8 +46,8 @@ jobs:
       terraform_directories: .
       terraform_fmt: true
       terraform_version: 1.15.5
-      tf_version_bump_version: v1.0.0-rc.9
-      tf_version_bump_archive_sha256: 38428a229a77671fd192fd6a18f5d1f9c404b5557124883f04e6a8bec154b1d2
+      tf_version_bump_version: v1.0.0-rc.10
+      tf_version_bump_archive_sha256: 532783cd3c6834a37616ed81ed76ef99ec343cc64d9664dd67c7eb325420c830
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
       max_parallel: 4
       commit_author_name: github-actions[bot]

--- a/examples/github-actions/.github/workflows/tf-version-bump-production.yml
+++ b/examples/github-actions/.github/workflows/tf-version-bump-production.yml
@@ -44,8 +44,8 @@ jobs:
       terraform_directories: .
       terraform_fmt: true
       terraform_version: 1.15.5
-      tf_version_bump_version: v1.0.0-rc.9
-      tf_version_bump_archive_sha256: 38428a229a77671fd192fd6a18f5d1f9c404b5557124883f04e6a8bec154b1d2
+      tf_version_bump_version: v1.0.0-rc.10
+      tf_version_bump_archive_sha256: 532783cd3c6834a37616ed81ed76ef99ec343cc64d9664dd67c7eb325420c830
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
       max_parallel: 2
       commit_author_name: github-actions[bot]

--- a/examples/github-actions/README.md
+++ b/examples/github-actions/README.md
@@ -37,7 +37,8 @@ Review and commit the copied files. The example supplies two callers:
 Both callers run only when the workflow revision is on the default branch. Their schedules are Monday 04:17 and Sunday 04:43 respectively in `Australia/Melbourne`.
 Changing `.github/tf-version-bump/nonproduction.yml` or `production.yml` on that branch also starts
 the matching caller. The separate configuration-validation workflow runs for pull requests that
-change either file.
+change either file. Pull requests validate only the YAML runtime contract without selecting
+Terraform files.
 
 Configure Actions to permit the workflow's `contents`, `pull-requests`, and `issues` write permissions. Before live publication, enable **Settings → Actions → General → Workflow permissions → Allow GitHub Actions to create and approve pull requests** for the repository or organisation.
 
@@ -79,7 +80,7 @@ Each configured root is processed independently. Keep the config path repository
 When a root has provider selections, its resulting `.terraform.lock.hcl` change is included in the
 update branch for reproducible runs. A provider-free root can legitimately have no lock file.
 
-The callers pin `tf-version-bump` to `v1.0.0-rc.9` and verify the archive SHA-256 `38428a229a77671fd192fd6a18f5d1f9c404b5557124883f04e6a8bec154b1d2` before execution.
+The callers pin `tf-version-bump` to `v1.0.0-rc.10` and verify the archive SHA-256 `532783cd3c6834a37616ed81ed76ef99ec343cc64d9664dd67c7eb325420c830` before execution.
 
 ## Results, failures, and pull requests
 

--- a/examples/github-actions/test.sh
+++ b/examples/github-actions/test.sh
@@ -560,7 +560,7 @@ prepopulate_verified_processing_release_cache() {
     local actual_sha256
     actual_sha256=$(sha256_file "$verified_archive")
     [[ "$actual_sha256" == "$TF_VERSION_BUMP_ARCHIVE_SHA256" ]] \
-        || fail "independently downloaded rc.10 fixture archive failed checksum verification"
+        || fail "independently downloaded $TF_VERSION_BUMP_VERSION fixture archive failed checksum verification"
 
     local cache_directory="$PROCESS_RUNNER_TEMP/tf-version-bump-release-cache"
     local cached_archive="$cache_directory/$TF_VERSION_BUMP_ARCHIVE_SHA256.tar.gz"
@@ -988,7 +988,7 @@ test_operator_documentation_describes_stage_two_contract() {
     grep -F 'both supplied callers set `terraform_fmt: true`' "$readme" >/dev/null \
         || fail "example README omits caller formatting opt-in"
     grep -F "$TF_VERSION_BUMP_VERSION" "$readme" >/dev/null \
-        || fail "example README omits the rc.10 pin"
+        || fail "example README omits the $TF_VERSION_BUMP_VERSION pin"
     grep -F "$TF_VERSION_BUMP_ARCHIVE_SHA256" "$readme" >/dev/null \
         || fail "example README omits the pinned archive SHA-256"
     local normalised_readme
@@ -1021,7 +1021,7 @@ test_operator_documentation_describes_stage_two_contract() {
     grep -F 'both callers opt in with `terraform_fmt: true`' "$advanced_usage" >/dev/null \
         || fail "advanced usage omits caller formatting opt-in"
     grep -F "$TF_VERSION_BUMP_VERSION" "$advanced_usage" >/dev/null \
-        || fail "advanced usage omits the rc.10 pin"
+        || fail "advanced usage omits the $TF_VERSION_BUMP_VERSION pin"
     grep -F "$TF_VERSION_BUMP_ARCHIVE_SHA256" "$advanced_usage" >/dev/null \
         || fail "advanced usage omits the pinned archive SHA-256"
     grep -F 'Validation and verification use one target checkout in `validate`' "$advanced_usage" >/dev/null \
@@ -1030,6 +1030,65 @@ test_operator_documentation_describes_stage_two_contract() {
         || fail "advanced usage omits the dynamic dependency commit"
     grep -F 'no separate validation artefact' "$advanced_usage" >/dev/null \
         || fail "advanced usage does not remove the validation artefact"
+}
+
+test_fixture_version_diagnostics_follow_current_expected_version() {
+    # Production break caught: release fixture diagnostics retain a previous release pin after the
+    # expected version changes, misleading an operator investigating a checksum or documentation
+    # failure.
+    local expected_version="v9.9.9-rc.11"
+    local archive_url="https://example.invalid/tf-version-bump_9.9.9-rc.11_linux_x86_64.tar.gz"
+    local archive_path="$TEST_TMP_ROOT/${archive_url##*/}"
+    local checksum_stdout="$TEST_TMP_ROOT/version-diagnostic-checksum.stdout"
+    local checksum_stderr="$TEST_TMP_ROOT/version-diagnostic-checksum.stderr"
+
+    printf '%s\n' 'deliberately invalid release archive' >"$archive_path"
+    if (
+        TF_VERSION_BUMP_VERSION="$expected_version"
+        TF_VERSION_BUMP_ARCHIVE_SHA256="0000000000000000000000000000000000000000000000000000000000000000"
+        TF_VERSION_BUMP_ARCHIVE_URL="$archive_url"
+        prepopulate_verified_processing_release_cache
+    ) >"$checksum_stdout" 2>"$checksum_stderr"; then
+        fail "checksum fixture mismatch unexpectedly succeeded"
+    fi
+    [[ ! -s "$checksum_stdout" ]] || fail "checksum fixture mismatch emitted stdout"
+    [[ "$(<"$checksum_stderr")" == "FAIL: independently downloaded $expected_version fixture archive failed checksum verification" ]] \
+        || fail "checksum fixture mismatch did not report the current expected version: $(<"$checksum_stderr")"
+
+    local documentation_fixture="$TEST_TMP_ROOT/version-diagnostic-docs"
+    local fixture_script_dir="$documentation_fixture/examples/github-actions"
+    mkdir -p "$fixture_script_dir" "$documentation_fixture/docs"
+    cp "$SCRIPT_DIR/README.md" "$fixture_script_dir/README.md"
+    cp "$REPOSITORY_ROOT/docs/ADVANCED-USAGE.md" "$documentation_fixture/docs/ADVANCED-USAGE.md"
+
+    local readme_stdout="$TEST_TMP_ROOT/version-diagnostic-readme.stdout"
+    local readme_stderr="$TEST_TMP_ROOT/version-diagnostic-readme.stderr"
+    if (
+        SCRIPT_DIR="$fixture_script_dir"
+        REPOSITORY_ROOT="$documentation_fixture"
+        TF_VERSION_BUMP_VERSION="$expected_version"
+        test_operator_documentation_describes_stage_two_contract
+    ) >"$readme_stdout" 2>"$readme_stderr"; then
+        fail "README pin mismatch unexpectedly succeeded"
+    fi
+    [[ ! -s "$readme_stdout" ]] || fail "README pin mismatch emitted stdout"
+    [[ "$(<"$readme_stderr")" == "FAIL: example README omits the $expected_version pin" ]] \
+        || fail "README pin mismatch did not report the current expected version: $(<"$readme_stderr")"
+
+    printf '%s\n' "$expected_version" >>"$fixture_script_dir/README.md"
+    local advanced_usage_stdout="$TEST_TMP_ROOT/version-diagnostic-advanced-usage.stdout"
+    local advanced_usage_stderr="$TEST_TMP_ROOT/version-diagnostic-advanced-usage.stderr"
+    if (
+        SCRIPT_DIR="$fixture_script_dir"
+        REPOSITORY_ROOT="$documentation_fixture"
+        TF_VERSION_BUMP_VERSION="$expected_version"
+        test_operator_documentation_describes_stage_two_contract
+    ) >"$advanced_usage_stdout" 2>"$advanced_usage_stderr"; then
+        fail "advanced usage pin mismatch unexpectedly succeeded"
+    fi
+    [[ ! -s "$advanced_usage_stdout" ]] || fail "advanced usage pin mismatch emitted stdout"
+    [[ "$(<"$advanced_usage_stderr")" == "FAIL: advanced usage omits the $expected_version pin" ]] \
+        || fail "advanced usage pin mismatch did not report the current expected version: $(<"$advanced_usage_stderr")"
 }
 
 test_reusable_workflow_declares_lean_interface() {
@@ -3713,6 +3772,7 @@ if [[ $# -eq 0 ]]; then
     test_modules_require_supported_go_version
     test_copyable_workflow_layout
     test_operator_documentation_describes_stage_two_contract
+    test_fixture_version_diagnostics_follow_current_expected_version
     test_reusable_workflow_declares_lean_interface
     test_reusable_workflow_wires_current_attempt_pipeline
     test_callers_define_weekly_policies_and_tool_pins

--- a/examples/github-actions/test.sh
+++ b/examples/github-actions/test.sh
@@ -1020,6 +1020,10 @@ test_operator_documentation_describes_stage_two_contract() {
 
     grep -F 'both callers opt in with `terraform_fmt: true`' "$advanced_usage" >/dev/null \
         || fail "advanced usage omits caller formatting opt-in"
+    grep -F "$TF_VERSION_BUMP_VERSION" "$advanced_usage" >/dev/null \
+        || fail "advanced usage omits the rc.10 pin"
+    grep -F "$TF_VERSION_BUMP_ARCHIVE_SHA256" "$advanced_usage" >/dev/null \
+        || fail "advanced usage omits the pinned archive SHA-256"
     grep -F 'Validation and verification use one target checkout in `validate`' "$advanced_usage" >/dev/null \
         || fail "advanced usage claims a separate verification checkout"
     grep -F 'one dynamic dependency commit' "$advanced_usage" >/dev/null \

--- a/examples/github-actions/test.sh
+++ b/examples/github-actions/test.sh
@@ -37,9 +37,9 @@ SUCCESSFUL_PREPARATION_READY=false
 TEST_TMP_ROOT=$(mktemp -d)
 TEST_TMP_ROOT=$(realpath "$TEST_TMP_ROOT")
 
-TF_VERSION_BUMP_VERSION="v1.0.0-rc.9"
-TF_VERSION_BUMP_ARCHIVE_SHA256="38428a229a77671fd192fd6a18f5d1f9c404b5557124883f04e6a8bec154b1d2"
-TF_VERSION_BUMP_ARCHIVE_URL="https://github.com/yesdevnull/tf-version-bump/releases/download/v1.0.0-rc.9/tf-version-bump_1.0.0-rc.9_linux_x86_64.tar.gz"
+TF_VERSION_BUMP_VERSION="v1.0.0-rc.10"
+TF_VERSION_BUMP_ARCHIVE_SHA256="532783cd3c6834a37616ed81ed76ef99ec343cc64d9664dd67c7eb325420c830"
+TF_VERSION_BUMP_ARCHIVE_URL="https://github.com/yesdevnull/tf-version-bump/releases/download/v1.0.0-rc.10/tf-version-bump_1.0.0-rc.10_linux_x86_64.tar.gz"
 TF_VERSION_BUMP_PREFETCH_CONNECT_TIMEOUT_SECONDS=10
 TF_VERSION_BUMP_PREFETCH_MAX_TIME_SECONDS=120
 TERRAFORM_VERSION="1.15.5"
@@ -560,7 +560,7 @@ prepopulate_verified_processing_release_cache() {
     local actual_sha256
     actual_sha256=$(sha256_file "$verified_archive")
     [[ "$actual_sha256" == "$TF_VERSION_BUMP_ARCHIVE_SHA256" ]] \
-        || fail "independently downloaded rc.9 fixture archive failed checksum verification"
+        || fail "independently downloaded rc.10 fixture archive failed checksum verification"
 
     local cache_directory="$PROCESS_RUNNER_TEMP/tf-version-bump-release-cache"
     local cached_archive="$cache_directory/$TF_VERSION_BUMP_ARCHIVE_SHA256.tar.gz"
@@ -959,11 +959,6 @@ test_operator_documentation_describes_stage_two_contract() {
             || fail "operator documentation omits the terraform_fmt default: $document"
         grep -F '`discover`, `prepare`, `validate`, and `publish`' "$document" >/dev/null \
             || fail "operator documentation omits the four-job topology: $document"
-        grep -F 'v1.0.0-rc.9' "$document" >/dev/null \
-            || fail "operator documentation omits the rc.9 pin: $document"
-        grep -F '38428a229a77671fd192fd6a18f5d1f9c404b5557124883f04e6a8bec154b1d2' \
-            "$document" >/dev/null \
-            || fail "operator documentation omits the pinned archive SHA-256: $document"
         [[ "$normalised_document" == *"private and first-party providers are trusted code"* ]] \
             || fail "operator documentation omits the trusted-provider limitation: $document"
         [[ "$normalised_document" == *"private and first-party module sources are trusted code"* ]] \
@@ -992,6 +987,14 @@ test_operator_documentation_describes_stage_two_contract() {
 
     grep -F 'both supplied callers set `terraform_fmt: true`' "$readme" >/dev/null \
         || fail "example README omits caller formatting opt-in"
+    grep -F "$TF_VERSION_BUMP_VERSION" "$readme" >/dev/null \
+        || fail "example README omits the rc.10 pin"
+    grep -F "$TF_VERSION_BUMP_ARCHIVE_SHA256" "$readme" >/dev/null \
+        || fail "example README omits the pinned archive SHA-256"
+    local normalised_readme
+    normalised_readme=$(tr '\n' ' ' < "$readme")
+    [[ "$normalised_readme" == *"validate only the YAML runtime contract without selecting Terraform files"* ]] \
+        || fail "example README does not describe standalone configuration validation"
     grep -F 'updater and `terraform init -upgrade` before formatting is eligible' "$readme" >/dev/null \
         || fail "example README omits per-root update and initialisation ordering"
     grep -F '`terraform fmt -recursive` in every configured root' "$readme" >/dev/null \
@@ -1254,12 +1257,16 @@ test_config_validation_workflow_is_read_only() {
             (.run | contains("tar -xzf")) and
             ((.run | index("sha256sum --check --status")) < (.run | index("tar -xzf"))) and
             (.run | contains("tf-version-bump " + $release_version))) and
-        any(.[]; .name == "Validate configuration dry runs" and
-            (.run | contains("mktemp -d")) and
+        any(.[]; .name == "Validate configuration" and
             (.run | contains(".github/tf-version-bump/nonproduction.yml")) and
             (.run | contains(".github/tf-version-bump/production.yml")) and
-            (.run | contains("-pattern \"$fixture_directory/main.tf\" -config \"$config\" -dry-run")))
-    ' >/dev/null || fail "config validation workflow does not verify and dry-run both example configs"
+            (.run | contains("\"$TF_VERSION_BUMP_BINARY\" -validate-config \"$config\"")) and
+            (.run | contains("mktemp -d") | not) and
+            (.run | contains("fixture") | not) and
+            (.run | contains("-pattern") | not) and
+            (.run | test("(^|[[:space:]])-config([[:space:]]|$)") | not) and
+            (.run | contains("-dry-run") | not))
+    ' >/dev/null || fail "config validation workflow does not directly validate both example configs"
 }
 
 test_workflows_keep_representative_execution_boundaries() {
@@ -2321,7 +2328,7 @@ EOF
 }
 
 test_processing_rejects_invalid_update_reports_as_automation() {
-    # Production break caught: preparation accepts absent, malformed, non-v1, non-integral, or
+    # Production break caught: preparation accepts absent, malformed, non-v2, non-integral, or
     # extended updater reports and exposes their partial working-tree changes for publication.
     local row report_payload
     while IFS=$'\t' read -r row report_payload; do
@@ -2346,10 +2353,13 @@ test_processing_rejects_invalid_update_reports_as_automation() {
     done <<'EOF'
 missing	__MISSING__
 malformed	not json
-schema-2	{"schema_version":2,"module_blocks_updated":0,"provider_blocks_updated":0}
-negative-count	{"schema_version":1,"module_blocks_updated":-1,"provider_blocks_updated":0}
-fractional-count	{"schema_version":1,"module_blocks_updated":0,"provider_blocks_updated":1.5}
-extra-key	{"schema_version":1,"module_blocks_updated":0,"provider_blocks_updated":0,"extra":true}
+schema-1	{"schema_version":1,"terraform_blocks_updated":0,"module_blocks_updated":0,"provider_blocks_updated":0}
+missing-terraform-count	{"schema_version":2,"module_blocks_updated":0,"provider_blocks_updated":0}
+negative-terraform-count	{"schema_version":2,"terraform_blocks_updated":-1,"module_blocks_updated":0,"provider_blocks_updated":0}
+fractional-terraform-count	{"schema_version":2,"terraform_blocks_updated":1.5,"module_blocks_updated":0,"provider_blocks_updated":0}
+negative-module-count	{"schema_version":2,"terraform_blocks_updated":0,"module_blocks_updated":-1,"provider_blocks_updated":0}
+fractional-provider-count	{"schema_version":2,"terraform_blocks_updated":0,"module_blocks_updated":0,"provider_blocks_updated":1.5}
+extra-key	{"schema_version":2,"terraform_blocks_updated":0,"module_blocks_updated":0,"provider_blocks_updated":0,"extra":true}
 EOF
 }
 


### PR DESCRIPTION
## Summary

- migrate the copyable GitHub Actions example to the verified v1.0.0-rc.10 release artefact
- require exact report schema v2 payloads while keeping Terraform counts out of the existing POC manifest
- replace Terraform-fixture dry runs with standalone, read-only configuration validation
- update both operator guides and protect their release pins in the executable harness

## Trust boundary

The workflows pin the published Linux x86-64 archive to SHA-256 `532783cd3c6834a37616ed81ed76ef99ec343cc64d9664dd67c7eb325420c830`. The release checksum manifest, SLSA provenance, and binary version were independently verified before this branch was created.

## Verification

- `go mod verify`
- `go mod tidy -diff`
- `go test -v -race -coverprofile=coverage.out -covermode=atomic ./...` (93.1% statement coverage)
- `golangci-lint run --timeout=5m`
- `go build -o tf-version-bump .`
- `make docs-check`
- `make test-github-actions`

The implementation followed a recorded RED/GREEN cycle. A final adversarial review found one stale rc.9 pin in the active Advanced Usage guide; that was fixed with a failing harness assertion first and passed a scoped re-review. Two independent subtractive cleanup passes removed no tests.
